### PR TITLE
SPL validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ variables.
   - `GOVUK_NOTIFY_SPL_MATCH_EMAIL_TEMPLATE_ID` **\[required\]**: This is the email template id for the GOV.UK 
   Notify api for when a user is matched via the SPL call.
    
-  - `GOVUK_NOTIFY_SPL_MATCH_SMS_TEMPLATE_ID` **\[required\]**: This is the the SMS template id for the GOV.UK 
+  - `GOVUK_NOTIFY_SPL_MATCH_SMS_TEMPLATE_ID` **\[required\]**: This is the SMS template id for the GOV.UK 
   Notify api for when a user is matched via the SPL call.
    
   - `GOVUK_NOTIFY_SPL_MATCH_LETTER_TEMPLATE_ID` **\[required\]**: This is the letter template id for the GOV.UK 
@@ -258,7 +258,7 @@ variables.
   - `GOVUK_NOTIFY_NO_SPL_MATCH_EMAIL_TEMPLATE_ID` **\[required\]**: This is the email template id for the GOV.UK 
   Notify api for when a user is not matched via the SPL call.
    
-  - `GOVUK_NOTIFY_NO_SPL_MATCH_SMS_TEMPLATE_ID` **\[required\]**: This is the the SMS template id for the GOV.UK 
+  - `GOVUK_NOTIFY_NO_SPL_MATCH_SMS_TEMPLATE_ID` **\[required\]**: This is the SMS template id for the GOV.UK 
   Notify api for when a user is not matched via the SPL call.
    
   - `GOVUK_NOTIFY_NO_SPL_MATCH_LETTER_TEMPLATE_ID` **\[required\]**: This is the letter template id for the GOV.UK 

--- a/vulnerable_people_form/form_pages/check_your_answers.py
+++ b/vulnerable_people_form/form_pages/check_your_answers.py
@@ -1,34 +1,13 @@
-from flask import redirect, session
+from flask import session
 
-from ..integrations import govuk_notify_client
 from .blueprint import form
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page, dynamic_back_url
 from .shared.session import (
-    form_answers,
     persist_answers_from_session,
     get_answer_from_form,
-    get_summary_rows_from_form_answers,
-    request_form,
-    should_contact_gp,
-)
-
-
-def send_sms_and_email_notifications_if_applicable(reference_number):
-    first_name = get_answer_from_form(["name", "first_name"])
-    last_name = get_answer_from_form(["name", "last_name"])
-    phone_number = get_answer_from_form(["contact_details", "phone_number_texts"])
-    email = get_answer_from_form(["contact_details", "email"])
-    contact_gp = should_contact_gp()
-
-    if phone_number:
-        govuk_notify_client.try_send_confirmation_sms(
-            phone_number, first_name, last_name, contact_gp
-        )
-    if email:
-        govuk_notify_client.try_send_confirmation_email(
-            phone_number, first_name, last_name, reference_number, contact_gp
-        )
+    get_summary_rows_from_form_answers)
+from ..integrations import govuk_notify_client, spl_check
 
 
 @form.route("/check-your-answers", methods=["GET"])
@@ -45,6 +24,12 @@ def get_check_your_answers():
 def post_check_your_answers():
     registration_number = persist_answers_from_session()
     session["registration_number"] = registration_number
-    send_sms_and_email_notifications_if_applicable(registration_number)
+
+    is_spl_match = spl_check.check_spl(
+        get_answer_from_form("nhs_number"),
+        get_answer_from_form("date_of_birth")
+    )
+
+    govuk_notify_client.send_notification(registration_number, is_spl_match)
 
     return route_to_next_form_page()

--- a/vulnerable_people_form/integrations/notification_content.py
+++ b/vulnerable_people_form/integrations/notification_content.py
@@ -1,0 +1,69 @@
+from flask import render_template
+
+from vulnerable_people_form.form_pages.shared.session import form_answers, is_nhs_login_user
+
+
+def create_spl_no_match_email_content(reference_number):
+    return render_template(
+        "_spl_no_match_email_template.md",
+        first_name=form_answers()["name"]["first_name"],
+        last_name=form_answers()["name"]["last_name"],
+        reference_number=reference_number,
+        has_someone_to_shop=form_answers()["do_you_have_someone_to_go_shopping_for_you"],
+        told_to_shield=form_answers()["nhs_letter"])
+
+
+def create_spl_no_match_sms_content(reference_number):
+    return render_template(
+        "_spl_no_match_sms_template.txt",
+        first_name=form_answers()["name"]["first_name"],
+        last_name=form_answers()["name"]["last_name"],
+        reference_number=reference_number,
+        has_someone_to_shop=form_answers()["do_you_have_someone_to_go_shopping_for_you"],
+        told_to_shield=form_answers()["nhs_letter"]).replace('\n', '')
+
+
+def create_spl_no_match_letter_content(reference_number):
+    return render_template(
+        "_spl_no_match_letter_template.md",
+        first_name=form_answers()["name"]["first_name"],
+        last_name=form_answers()["name"]["last_name"],
+        reference_number=reference_number,
+        has_someone_to_shop=form_answers()["do_you_have_someone_to_go_shopping_for_you"],
+        told_to_shield=form_answers()["nhs_letter"])
+
+
+def create_spl_match_email_content(reference_number):
+    return render_template(
+        "_spl_match_email_template.md",
+        first_name=form_answers()["name"]["first_name"],
+        last_name=form_answers()["name"]["last_name"],
+        reference_number=reference_number,
+        has_someone_to_shop=form_answers()["do_you_have_someone_to_go_shopping_for_you"],
+        wants_supermarket_deliveries=form_answers()["priority_supermarket_deliveries"],
+        wants_social_care=form_answers()["basic_care_needs"],
+        has_set_up_account=is_nhs_login_user())
+
+
+def create_spl_match_sms_content(reference_number):
+    return render_template(
+        "_spl_match_sms_template.txt",
+        first_name=form_answers()["name"]["first_name"],
+        last_name=form_answers()["name"]["last_name"],
+        reference_number=reference_number,
+        has_someone_to_shop=form_answers()["do_you_have_someone_to_go_shopping_for_you"],
+        wants_supermarket_deliveries=form_answers()["priority_supermarket_deliveries"],
+        wants_social_care=form_answers()["basic_care_needs"],
+        has_set_up_account=is_nhs_login_user()).replace('\n', '')
+
+
+def create_spl_match_letter_content(reference_number):
+    return render_template(
+        "_spl_match_letter_template.md",
+        first_name=form_answers()["name"]["first_name"],
+        last_name=form_answers()["name"]["last_name"],
+        reference_number=reference_number,
+        has_someone_to_shop=form_answers()["do_you_have_someone_to_go_shopping_for_you"],
+        wants_supermarket_deliveries=form_answers()["priority_supermarket_deliveries"],
+        wants_social_care=form_answers()["basic_care_needs"],
+        has_set_up_account=is_nhs_login_user())

--- a/vulnerable_people_form/integrations/spl_check.py
+++ b/vulnerable_people_form/integrations/spl_check.py
@@ -1,6 +1,4 @@
-import os
-
-from .persistence import get_rds_data_client, generate_string_parameter, generate_date_parameter, execute_sql
+from .persistence import generate_string_parameter, generate_date_parameter, execute_sql
 
 
 def check_spl(nhs_number, date_of_birth):

--- a/vulnerable_people_form/integrations/spl_check.py
+++ b/vulnerable_people_form/integrations/spl_check.py
@@ -1,0 +1,18 @@
+import os
+
+from .persistence import get_rds_data_client, generate_string_parameter, generate_date_parameter, execute_sql
+
+
+def check_spl(nhs_number, date_of_birth):
+    records = execute_sql(
+        "CALL cv_base.is_person_on_the_spl(:nhs_number, :date_of_birth)",
+        (
+            generate_string_parameter("nhs_number", nhs_number),
+            generate_date_parameter("date_of_birth", date_of_birth),
+        ),
+    )["records"]
+
+    if records[0][0]["stringValue"] not in ("YES", "NO"):
+        raise ValueError(f"RDS procedure returned unrecognised value {records}")
+
+    return records[0][0]["stringValue"] == "YES"

--- a/vulnerable_people_form/templates/_spl_match_email_template.md
+++ b/vulnerable_people_form/templates/_spl_match_email_template.md
@@ -1,0 +1,72 @@
+Dear {{first_name}} {{last_name}},
+
+Your registration number is {{reference_number}}.
+
+{% if not has_someone_to_shop %}
+
+#If you need urgent help
+
+Contact your local authority if you need urgent help: https://www.gov.uk/coronavirus-local-help.
+
+{% endif %}
+
+#What happens next
+
+{% if wants_supermarket_deliveries and wants_social_care %}
+
+You should be able to start booking priority supermarket deliveries in the next 1 to 7 days, depending on the supermarket.
+
+If you do not already have an account with a supermarket delivery service, set one up now. You can set up accounts with more than one supermarket if you're worried about not getting a delivery slot.
+
+Someone from your local authority will contact you about your care needs within the next week.
+
+{% endif %}
+{% if wants_supermarket_deliveries and not wants_social_care %}
+
+You should be able to start booking priority supermarket deliveries in the next 1 to 7 days, depending on the supermarket.
+
+If you do not already have an account with a supermarket delivery service, set one up now. You can set up accounts with more than one supermarket if you're worried about not getting a delivery slot.
+
+{% endif %}
+
+{% if not wants_supermarket_deliveries and wants_social_care %}
+
+Someone from your local authority will contact you about your care needs within the next week.
+
+{% endif %}
+
+{% if not wants_supermarket_deliveries and not wants_social_care %}
+
+You said that you do not want priority supermarket deliveries or help with your care needs.
+
+{% endif %}
+
+#If your personal details or support needs change
+
+{% if has_set_up_account %}
+
+Use your NHS login to update your personal details or support needs: https://www.gov.uk/coronavirus-shielding-support.
+
+{% endif %}
+
+{% if not has_set_up_account %}
+
+Go through the questions in the service again to update your personal details or support needs: https://www.gov.uk/coronavirus-extremely-vulnerable.
+
+{% endif %}
+
+{% if has_someone_to_shop %}
+
+Contact your local authority if you need support urgently and cannot rely on family, friends or neighbours: https://www.gov.uk/coronavirus-local-help.
+
+{% endif %}
+
+There’s guidance on what you should do if you’re extremely vulnerable to coronavirus: https://www.gov.uk/coronavirus-extremely-vulnerable-guidance.
+
+Thanks,
+
+National Shielding Service
+
+-----
+
+Do not reply to this email - it’s an automatic message from an unmonitored account.

--- a/vulnerable_people_form/templates/_spl_match_letter_template.md
+++ b/vulnerable_people_form/templates/_spl_match_letter_template.md
@@ -1,0 +1,59 @@
+Dear {{first_name}} {{last_name}},
+
+Your registration number is {{reference_number}}.
+
+{% if not has_someone_to_shop %}
+
+#If you need urgent help
+
+Contact your local authority if you need urgent help: www.gov.uk/coronavirus-local-help.
+
+{% endif %}
+
+#What happens next
+
+{% if wants_supermarket_deliveries and wants_social_care %}
+
+You should now be able to start booking priority deliveries with supermarkets.
+
+If you do not already have an account with a supermarket delivery service, set one up now. You can set up accounts with more than one supermarket if you're worried about not getting a delivery slot.
+
+Someone from your local authority will contact you about your care needs within the next week.
+
+{% endif %}
+
+{% if wants_supermarket_deliveries and not wants_social_care %}
+
+You should now be able to get priority access to supermarket deliveries.
+
+If you do not already have an account with a supermarket delivery service, set one up now. You can set up accounts with more than one supermarket if you're worried about not getting a delivery slot.
+
+{% endif %}
+
+{% if not wants_supermarket_deliveries and wants_social_care %}
+
+Someone from your local authority will contact you about your care needs within the next week.
+
+{% endif %}
+
+{% if not wants_supermarket_deliveries and not wants_social_care %}
+
+You said that you do not want priority supermarket deliveries or help with your care needs.
+
+{% endif %}
+
+#If your personal details or support needs change
+
+Use the service again to update your personal details or support needs: www.gov.uk/coronavirus-extremely-vulnerable
+
+{% if has_someone_to_shop %}
+
+Contact your local authority if you need support urgently and cannot rely on family, friends or neighbours: www.gov.uk/coronavirus-local-help
+
+{% endif %}
+
+There’s guidance on what you should do if you’re extremely vulnerable to coronavirus: www.gov.uk/coronavirus-extremely-vulnerable-guidance
+
+Regards,
+
+National Shielding Service

--- a/vulnerable_people_form/templates/_spl_match_sms_template.txt
+++ b/vulnerable_people_form/templates/_spl_match_sms_template.txt
@@ -1,0 +1,35 @@
+Hello {{first_name}} {{last_name}} - your registration for the shielding service is {{reference_number}}.
+
+{% if not has_someone_to_shop %}
+Contact your local authority if you need urgent help: www.gov.uk/coronavirus-local-help
+{% endif %}
+
+{% if wants_supermarket_deliveries and wants_social_care %}
+ You should be able to start booking priority supermarket deliveries in the next 1 to 7 days, depending on the supermarket. If you do not already have an account with a supermarket, set one up now. You can set up accounts with more than one supermarket.
+
+Someone from your local authority will contact you about your care needs within the next week.
+{% endif %}
+
+{% if wants_supermarket_deliveries and not wants_social_care %}
+ You should be able to start booking priority supermarket deliveries in the next 1 to 7 days, depending on the supermarket. If you do not already have an account with a supermarket, set one up now. You can set up accounts with more than one supermarket.
+{% endif %}
+
+{% if not wants_supermarket_deliveries and wants_social_care %}
+ Someone from your local authority will contact you about your care needs within the next week.
+{% endif %}
+
+{% if not wants_supermarket_deliveries and not wants_social_care %}
+ You said that you do not want priority supermarket deliveries or help with your care needs.
+{% endif %}
+
+{% if has_set_up_account %}
+ Use your NHS login to update your personal details or support needs: https://www.gov.uk/coronavirus-shielding-support.
+{% endif %}
+
+{% if not has_set_up_account %}
+ Go through the questions in the service again to update your personal details or support needs: www.gov.uk/coronavirus-extremely-vulnerable.
+{% endif %}
+
+{% if has_someone_to_shop %}
+ Contact your local authority if you need support urgently and cannot rely on family, friends or neighbours: www.gov.uk/coronavirus-local-help
+{% endif %}

--- a/vulnerable_people_form/templates/_spl_no_match_email_template.md
+++ b/vulnerable_people_form/templates/_spl_no_match_email_template.md
@@ -1,0 +1,49 @@
+Dear {{first_name}} {{last_name}},
+
+Your registration number is {{reference_number}}.
+
+{% if not has_someone_to_shop %}
+
+#If you need urgent help
+
+Contact your local authority if you need urgent help: https://www.gov.uk/coronavirus-local-help.
+
+{% endif %}
+
+{% if told_to_shield == 1 %}
+
+#What happens next
+
+You do not need to do anything else if you've been told to shield by the NHS or your doctor and they've put you on the NHS list of people who should be shielding.
+
+We’ll check your details, then contact you to confirm whether you’re eligible for support. You will not start getting support until we’ve confirmed that you’re eligible. This can take up to 2 weeks.
+
+{% endif %}
+
+{% if told_to_shield == 2 or told_to_shield ==  3 %}
+
+#Contact your GP
+
+Contact your GP or hospital clinician as soon as possible so they can put you on the NHS list of people who should be shielding. You may not get the support you need if you do not contact them.
+
+#What happens next
+
+We’ll check your details, then contact you to confirm whether you’re eligible for support. This can take up to 2 weeks from when your GP or hospital clinician puts you on the NHS list of people who should be shielding.
+
+{% endif %}
+
+{% if has_someone_to_shop %}
+
+Contact your local authority if you need support urgently and cannot rely on family, friends or neighbours: https://www.gov.uk/coronavirus-local-help.
+
+{% endif %}
+
+There’s guidance on what you should do if you’re extremely vulnerable to coronavirus: https://www.gov.uk/coronavirus-extremely-vulnerable-guidance.
+
+Thanks,
+
+National Shielding Service
+
+-----
+
+Do not reply to this email - it’s an automatic message from an unmonitored account.

--- a/vulnerable_people_form/templates/_spl_no_match_letter_template.md
+++ b/vulnerable_people_form/templates/_spl_no_match_letter_template.md
@@ -1,0 +1,49 @@
+Dear {{first_name}} {{last_name}}
+
+Your registration number is {{reference_number}}
+
+{% if not has_someone_to_shop %}
+
+#If you need urgent help
+
+Contact your local authority if you need urgent help: www.gov.uk/coronavirus-local-help.
+
+{% endif %}
+
+{% if told_to_shield == 1 %}
+
+What happens next
+
+You do not need to do anything else if you've been told to shield by the NHS or your doctor and they've put you on the NHS list of people who should be shielding.
+
+We’ll check your details, then contact you to confirm whether you’re eligible for support. You will not start getting support until we’ve confirmed that you’re eligible. This can take up to 2 weeks.
+
+{% endif %}
+
+{% if told_to_shield == 2 or told_to_shield == 3 %}
+
+#Contact your GP
+
+Contact your GP or hospital clinician as soon as possible so they can put you on the NHS list of people who should be shielding. You may not get the support you need if you do not contact them.
+
+#What happens next
+
+We’ll check your details, then contact you to confirm whether you’re eligible for support. This can take up to 2 weeks from when your GP or hospital clinician puts you on the NHS list of people who should be shielding.
+
+#If your personal details or support needs change
+
+{% endif %}
+
+Use the service again to update your personal details or support needs: www.gov.uk/coronavirus-extremely-vulnerable
+
+{% if has_someone_to_shop %}
+
+Contact your local authority if you need support urgently and cannot rely on family, friends or neighbours: www.gov.uk/coronavirus-local-help
+
+{% endif %}
+
+There’s guidance on what you should do if you’re extremely vulnerable to coronavirus: www.gov.uk/coronavirus-extremely-vulnerable-guidance
+
+Regards,
+
+National Shielding Service

--- a/vulnerable_people_form/templates/_spl_no_match_sms_template.txt
+++ b/vulnerable_people_form/templates/_spl_no_match_sms_template.txt
@@ -1,0 +1,21 @@
+Hello {{first_name}} {{last_name}} - your registration for the shielding service is {{reference_number}}.
+
+{% if not has_someone_to_shop %}
+ Contact your local authority if you need urgent help: www.gov.uk/coronavirus-local-help
+{% endif %}
+
+{% if told_to_shield == 1 %}
+ You do not need to do anything else if you've been told to shield by the NHS or your doctor and they've put you on the NHS list of people who should be shielding.
+
+We’ll check your details, then contact you to confirm whether you’re eligible for support. You will not start getting support until we’ve confirmed that you’re eligible. This can take up to 2 weeks.
+{% endif %}
+
+{% if told_to_shield == 2 or told_to_shield == 3 %}
+ Contact your GP or hospital clinician as soon as possible so they can put you on the NHS list of people who should be shielding. You may not get the support you need if you do not contact them.
+
+We’ll check your details, then contact you to confirm whether you’re eligible for support. This can take up to 2 weeks from when your GP or hospital clinician puts you on the NHS list of people who should be shielding.
+{% endif %}
+
+{% if has_someone_to_shop %}
+ Contact your local authority if you need support urgently and cannot rely on family, friends or neighbours: www.gov.uk/coronavirus-local-help
+{% endif %}


### PR DESCRIPTION
**What**
Added the logic to carry out an SPL check and then send a notification to the user based on the data entered in the form.

**Why**
Users need to know if they are on the SPL and what the next steps are once they have submitted the form.

**How**

Added in all templates for match and no match from SPL
Updated GOV.UK Notify python client to send emails, SMS and letters
Added SPL sproc call to determine whether use is on SPL or not
Updated readme to fix typos