### PR TITLE
Fixed support address form error when no address selected

### DIFF
--- a/vulnerable_people_form/form_pages/support_address.py
+++ b/vulnerable_people_form/form_pages/support_address.py
@@ -9,8 +9,9 @@ from .shared.validation import validate_support_address
 
 @form.route("/support-address", methods=["POST"])
 def post_support_address():
+    support_address = form_answers().get("support_address", {}).items()
     original_address = {
-        k: v for k, v in form_answers()["support_address"].items() if k != "uprn"
+        k: v for k, v in support_address if k != "uprn"
     }
     session["postcode"] = request_form().get("postcode")
     if original_address != request_form():


### PR DESCRIPTION
A user can bypass support address selection using the "my address isn't listed or wrong" link. This caused an error because post_support_address compares the selected address with the newly entered one so as to populate the UPRN if the addresses are the same.