### PR TITLE
Made town_city mandatory in support address form

### DIFF
--- a/vulnerable_people_form/form_pages/shared/validation.py
+++ b/vulnerable_people_form/form_pages/shared/validation.py
@@ -247,6 +247,11 @@ def validate_support_address():
                 75,
                 length_fstring.format("Address line 2", 75),
             ),
+            validate_mandatory_form_field(
+                "support_address",
+                "town_city",
+                "Enter a town or city",
+            ),
             validate_length(
                 ("support_address", "town_city"), 50, length_fstring.format("Town or city", 50)
             ),


### PR DESCRIPTION
This field cannot be null in the database schema / stored procedure and causes the form submission to fail if it's not provided.