### PR TITLE
Fix nhs registration callback error

### DIFF
--- a/vulnerable_people_form/form_pages/nhs_login_callback.py
+++ b/vulnerable_people_form/form_pages/nhs_login_callback.py
@@ -1,24 +1,8 @@
 from flask import abort, current_app, redirect, request, session
 
 from .blueprint import form
-from .shared.constants import NHS_USER_INFO_TO_FORM_ANSWERS
 from .shared.routing import get_redirect_to_terminal_page
-from .shared.session import load_answers_into_session_if_available
-
-
-def set_form_answers_from_nhs_userinfo(nhs_user_info):
-    for answers_key, maybe_key in NHS_USER_INFO_TO_FORM_ANSWERS.items():
-        nhs_answer = maybe_key(nhs_user_info) if callable(maybe_key) else nhs_user_info.get(maybe_key)
-        if nhs_answer is None:
-            continue
-        set_form_answer(answers_key, nhs_answer)
-
-
-def set_form_answer(answers_key_list, answer):
-    answers = session["form_answers"]
-    for key in answers_key_list[:-1]:
-        answers = answers.setdefault(key, {})
-    answers[answers_key_list[-1]] = answer
+from .shared.session import load_answers_into_session_if_available, set_form_answers_from_nhs_user_info
 
 
 @form.route("/nhs-login-callback", methods=["GET"])
@@ -33,7 +17,7 @@ def get_nhs_login_callback():
     if load_answers_into_session_if_available():
         return get_redirect_to_terminal_page()
 
-    set_form_answers_from_nhs_userinfo(nhs_user_info)
+    set_form_answers_from_nhs_user_info(nhs_user_info)
 
     return redirect("postcode-eligibility")
 

--- a/vulnerable_people_form/form_pages/nhs_registration.py
+++ b/vulnerable_people_form/form_pages/nhs_registration.py
@@ -1,5 +1,6 @@
 from flask import current_app
 
+from vulnerable_people_form.form_pages.shared.constants import JourneyProgress
 from .shared.answers_enums import YesNoAnswers, get_radio_options_from_enum
 from .blueprint import form
 from .shared.render import render_template_with_title
@@ -11,7 +12,7 @@ def get_nhs_registration():
     return render_template_with_title(
         "nhs-registration.html",
         radio_items=get_radio_options_from_enum(YesNoAnswers, form_answers().get("nhs_registration")),
-        nhs_registration_href=current_app.nhs_oidc_client.get_registration_url(),
+        nhs_registration_href=current_app.nhs_oidc_client.get_registration_url(JourneyProgress.NHS_REGISTRATION),
         previous_path="/basic-care-needs",
         **get_errors_from_session("nhs_registration"),
     )

--- a/vulnerable_people_form/form_pages/nhs_registration_callback.py
+++ b/vulnerable_people_form/form_pages/nhs_registration_callback.py
@@ -1,9 +1,10 @@
 from flask import abort, current_app, redirect, request, session
 
+from vulnerable_people_form.form_pages.shared.routing import get_next_form_url_after_nhs_number
 from ..integrations import google_analytics
 from .blueprint import form
-from .shared.constants import NHS_USER_INFO_TO_FORM_ANSWERS
-from .shared.session import get_answer_from_form, persist_answers_from_session
+from .shared.constants import NHS_USER_INFO_TO_FORM_ANSWERS, JourneyProgress
+from .shared.session import get_answer_from_form, persist_answers_from_session, set_form_answers_from_nhs_user_info
 
 
 def log_form_and_nhs_answers_differences(nhs_user_info):
@@ -32,9 +33,25 @@ def log_form_and_nhs_answers_differences(nhs_user_info):
 def get_nhs_registration_callback():
     if "error" in request.args:
         abort(500)
+    state_from_query_string = request.args.get('state')
+    if state_from_query_string:
+        last_char_of_state = state_from_query_string[len(state_from_query_string)-1]
+        journey_progress = JourneyProgress(int(last_char_of_state))
+    else:
+        abort(500)
+
     nhs_user_info = current_app.nhs_oidc_client.get_nhs_user_info_from_registration_callback(request.args)
     log_form_and_nhs_answers_differences(nhs_user_info)
     session["nhs_sub"] = nhs_user_info["sub"]
     session["form_answers"]["nhs_number"] = nhs_user_info["nhs_number"]
-    persist_answers_from_session()
-    return redirect("/confirmation")
+
+    if journey_progress is JourneyProgress.NHS_NUMBER:
+        set_form_answers_from_nhs_user_info(nhs_user_info)
+        redirect_url = get_next_form_url_after_nhs_number()
+    elif journey_progress is JourneyProgress.NHS_REGISTRATION:
+        persist_answers_from_session()
+        redirect_url = "/confirmation"
+    else:
+        raise ValueError("Unexpected JourneyProgress value extracted from state: " + last_char_of_state)
+
+    return redirect(redirect_url)

--- a/vulnerable_people_form/form_pages/nhs_registration_link.py
+++ b/vulnerable_people_form/form_pages/nhs_registration_link.py
@@ -1,5 +1,6 @@
 from flask import current_app, render_template
 
+from vulnerable_people_form.form_pages.shared.constants import JourneyProgress
 from .blueprint import form
 
 
@@ -8,5 +9,5 @@ def get_nhs_registration_link():
     return render_template(
         "nhs-registration-link.html",
         previous_path="/nhs-number",
-        nhs_registration_href=current_app.nhs_oidc_client.get_registration_url(),
+        nhs_registration_href=current_app.nhs_oidc_client.get_registration_url(JourneyProgress.NHS_NUMBER),
     )

--- a/vulnerable_people_form/form_pages/shared/constants.py
+++ b/vulnerable_people_form/form_pages/shared/constants.py
@@ -1,3 +1,4 @@
+import enum
 from functools import partial
 
 
@@ -60,3 +61,9 @@ NHS_USER_INFO_TO_FORM_ANSWERS = {
 }
 
 SESSION_KEY_ADDRESS_SELECTED = "auto_populated_address_selected"
+
+
+@enum.unique
+class JourneyProgress(enum.Enum):
+    NHS_NUMBER = 0
+    NHS_REGISTRATION = 1

--- a/vulnerable_people_form/form_pages/shared/routing.py
+++ b/vulnerable_people_form/form_pages/shared/routing.py
@@ -154,7 +154,6 @@ def route_to_next_form_page():
             return redirect("/confirmation")
         else:
             return redirect("/nhs-registration")
-        return redirect_to_next_form_page("/basic-care-needs")
     elif current_form == "check-contact-details":
         return get_redirect_to_terminal_page()
     elif current_form == "contact-details":

--- a/vulnerable_people_form/form_pages/shared/session.py
+++ b/vulnerable_people_form/form_pages/shared/session.py
@@ -7,7 +7,7 @@ from .answers_enums import (
     PrioritySuperMarketDeliveriesAnswers,
     YesNoAnswers,
 )
-from .constants import PAGE_TITLES
+from .constants import PAGE_TITLES, NHS_USER_INFO_TO_FORM_ANSWERS
 
 from ...integrations import persistence
 
@@ -272,3 +272,18 @@ def load_answers_into_session_if_available():
         session["accessing_saved_answers"] = True
         return True
     return False
+
+
+def set_form_answers_from_nhs_user_info(nhs_user_info):
+    for answers_key, maybe_key in NHS_USER_INFO_TO_FORM_ANSWERS.items():
+        nhs_answer = maybe_key(nhs_user_info) if callable(maybe_key) else nhs_user_info.get(maybe_key)
+        if nhs_answer is None:
+            continue
+        _set_form_answer(answers_key, nhs_answer)
+
+
+def _set_form_answer(answers_key_list, answer):
+    answers = session["form_answers"]
+    for key in answers_key_list[:-1]:
+        answers = answers.setdefault(key, {})
+    answers[answers_key_list[-1]] = answer

--- a/vulnerable_people_form/integrations/nhs_openconnect_id.py
+++ b/vulnerable_people_form/integrations/nhs_openconnect_id.py
@@ -36,10 +36,10 @@ class NHSOIDCDetails:
     def get_authorization_url(self):
         return self._get_authorization_url(self.authorization_callback_url, False)
 
-    def get_registration_url(self):
-        return self._get_authorization_url(self.registration_callback_url, True)
+    def get_registration_url(self, journey_progress):
+        return self._get_authorization_url(self.registration_callback_url, True, journey_progress)
 
-    def _get_authorization_url(self, callback_url, allow_registration):
+    def _get_authorization_url(self, callback_url, allow_registration, journey_progress=None):
         self.client.provider_config(self.authority_url)  # update
         return self.client.construct_AuthorizationRequest(
             request_args={
@@ -48,7 +48,7 @@ class NHSOIDCDetails:
                 "scope": self.scopes,
                 "nonce": rndstr(),
                 "redirect_uri": callback_url,
-                "state": rndstr(),
+                "state": rndstr() + (str(journey_progress.value) if journey_progress else ""),
                 "vtr": self.vtr,
                 "allow_registration": allow_registration,
             },
@@ -83,7 +83,7 @@ class NHSOIDCDetails:
         )
         if "access_token" not in access_token_result:
             raise RuntimeError(
-                f"Could not retrieve access token from NHS oidc endpoint. Recieved {access_token_result}"
+                f"Could not retrieve access token from NHS oidc endpoint. Received {access_token_result}"
             )
 
         return self.client.do_user_info_request(


### PR DESCRIPTION
When a user attempts to register at the nhs-number
stage in the journey an error occurs because the
app is attempting to access data that does not exist
when persisting the form answers.
The retrieved nhs user info is now updated in the session
and form answers. The data persistence is deferred
until later in the journey.