### PR TITLE
Continuously run a smoke test against the form

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ concourse_e2e:
 	@echo "Executing e2e automated tests against the staging environment..."
 	behave behave/features/ --tags='@e2e_happy_path_no_nhs_login' --stop
 
+smoke_test:
+	@echo "Executing smoke tests..."
+	behave behave/features/ --tags='@e2e_happy_path_no_nhs_login' --stop
+
 test_e2e_local:
 	@echo "Executing e2e automated tests against the local environment..."
 	docker-compose run --service-ports --rm chrome-driver bash -c "behave features/ --stop"

--- a/behave/features/1.e2e_journey_no_nhs_login.feature
+++ b/behave/features/1.e2e_journey_no_nhs_login.feature
@@ -36,6 +36,7 @@ Feature: COVID-19 Shielded vulnerable people service - basic e2e user journey - 
 
     Scenario: Should be re-directed to name entry when valid nhs number entered
         Given I am on the "nhs-number" page
+        # This is passes the NHS number checksum but will never be assigned to a real person
         When I give the "#nhs_number" field the value "1116432455"
         And I submit the form
         Then wait "2" seconds

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -19,10 +19,10 @@ resources:
       url: ((slack_hook_automate))
       channel: covid-engineering-team
 
-  - name: every-1m
+  - name: every-10m
     type: time
     source:
-      interval: 1m
+      interval: 10m
 
 # Anchors for later
 slack_alert_on_failure: &slack_alert_on_failure
@@ -162,7 +162,7 @@ jobs:
 
   - name: continuous-smoke-test-staging
     plan:
-      - get: every-1m
+      - get: every-10m
         trigger: true
       - get: git-master
       - task: smoke-test
@@ -179,7 +179,7 @@ jobs:
 
   - name: continuous-smoke-test-prod
     plan:
-      - get: every-1m
+      - get: every-10m
         trigger: true
       - get: git-master
       - task: smoke-test

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -168,7 +168,7 @@ jobs:
       - task: smoke-test
         file: git-master/concourse/tasks/smoke-test.yml
         params:
-          URL: 'https://gds-shielded-vulnerable-people-service-staging.london.cloudapps.digital/applying-on-own-behalf'
+          WEB_APP_BASE_URL: 'https://gds-shielded-vulnerable-people-service-staging.london.cloudapps.digital/applying-on-own-behalf'
           MESSAGE: "Checks that the application deployed to staging is not serving HTTP error codes"
         on_failure: *slack_alert_on_failure
       - task: cronitor-heartbeat
@@ -185,7 +185,7 @@ jobs:
       - task: smoke-test
         file: git-master/concourse/tasks/smoke-test.yml
         params:
-          URL: 'https://coronavirus-shielding-support.service.gov.uk/applying-on-own-behalf'
+          WEB_APP_BASE_URL: 'https://coronavirus-shielding-support.service.gov.uk/applying-on-own-behalf'
           MESSAGE: "Checks that the application deployed to production is not serving HTTP error codes"
         on_failure: *slack_alert_on_failure
       - task: cronitor-heartbeat

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -19,6 +19,11 @@ resources:
       url: ((slack_hook_automate))
       channel: covid-engineering-team
 
+  - name: every-1m
+    type: time
+    source:
+      interval: 1m
+
 # Anchors for later
 slack_alert_on_failure: &slack_alert_on_failure
   put: slack
@@ -151,6 +156,40 @@ jobs:
         file: git-master/concourse/tasks/smoke-test.yml
         params:
           URL: 'https://coronavirus-shielding-support.service.gov.uk/applying-on-own-behalf'
-          MESSAGE: "Checks that the application deployed to staging is not serving HTTP error codes"
+          MESSAGE: "Checks that the application deployed to production is not serving HTTP error codes"
         on_failure: *slack_alert_on_failure
         on_success: *slack_alert_on_success
+
+  - name: continuous-smoke-test-staging
+    plan:
+      - get: every-1m
+        trigger: true
+      - get: git-master
+      - task: smoke-test
+        file: git-master/concourse/tasks/smoke-test.yml
+        params:
+          URL: 'https://gds-shielded-vulnerable-people-service-staging.london.cloudapps.digital/applying-on-own-behalf'
+          MESSAGE: "Checks that the application deployed to staging is not serving HTTP error codes"
+        on_failure: *slack_alert_on_failure
+      - task: cronitor-heartbeat
+        timeout: 1m
+        params:
+          CRONITOR_URL: ((svp-form/cronitor-heartbeat-stg))
+        file: git-master/concourse/tasks/cronitor.yml
+
+  - name: continuous-smoke-test-prod
+    plan:
+      - get: every-1m
+        trigger: true
+      - get: git-master
+      - task: smoke-test
+        file: git-master/concourse/tasks/smoke-test.yml
+        params:
+          URL: 'https://coronavirus-shielding-support.service.gov.uk/applying-on-own-behalf'
+          MESSAGE: "Checks that the application deployed to production is not serving HTTP error codes"
+        on_failure: *slack_alert_on_failure
+      - task: cronitor-heartbeat
+        timeout: 1m
+        params:
+          CRONITOR_URL: ((svp-form/cronitor-heartbeat-prod))
+        file: git-master/concourse/tasks/cronitor.yml

--- a/concourse/tasks/cronitor.yml
+++ b/concourse/tasks/cronitor.yml
@@ -1,0 +1,14 @@
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: governmentpaas/curl-ssl
+run:
+  path: sh
+  args:
+    - -c
+    - |
+      set -ue
+      echo 'Curling cronitor'
+      curl --fail "$CRONITOR_URL"
+      echo 'Curled cronitor successfully'

--- a/concourse/tasks/smoke-test.yml
+++ b/concourse/tasks/smoke-test.yml
@@ -20,5 +20,5 @@ run:
     - -c
     - |
       echo "running smoke tests against \"${WEB_APP_BASE_URL}\""
-      behave behave/features/ --tags='@e2e_happy_path_no_nhs_login' --stop
+      make smoke_test
   dir: git-master

--- a/concourse/tasks/smoke-test.yml
+++ b/concourse/tasks/smoke-test.yml
@@ -2,18 +2,23 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: governmentpaas/curl-ssl
+    repository: gdscyber/concourse-chrome-driver
+    tag: latest
 params:
-  URL:
-  MESSAGE:
+  CGO_ENABLE: "0"
+  DEBIAN_FRONTEND: "noninteractive"
+  PYTHONIOENCODING: "UTF-8"
+inputs:
+- name: git-master
+outputs:
+- name: builds
 run:
-  path: sh
+  path: /bin/bash
   args:
-    - '-c'
+    - -euo
+    - pipefail
+    - -c
     - |
-      set -eu
-
-      echo "$MESSAGE"
-
-      # TODO we can come up with a more thorough test than this
-      curl --fail --silent --verbose "$URL"
+      echo "running smoke tests against \"${WEB_APP_BASE_URL}\""
+      behave behave/features/ --tags='@e2e_happy_path_no_nhs_login' --stop
+  dir: git-master


### PR DESCRIPTION
At the moment this is a very simple smoke test. We should be do
something smarter but this is a start.

If the smoke test is successful then we curl Cronitor which is
configured as a heartbeat to expect a request every _n_ minutes.

PagerDuty can then be triggered off this.