### PR TITLE
Remove route from URL the smoke tests use

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -95,7 +95,7 @@ jobs:
       - task: smoke-test
         file: git-master/concourse/tasks/smoke-test.yml
         params:
-          URL: 'https://gds-shielded-vulnerable-people-service-staging.london.cloudapps.digital/applying-on-own-behalf'
+          WEB_APP_BASE_URL: 'https://gds-shielded-vulnerable-people-service-staging.london.cloudapps.digital'
           MESSAGE: "Checks that the application deployed to staging is not serving HTTP error codes"
         on_failure: *slack_alert_on_failure
 
@@ -155,7 +155,7 @@ jobs:
       - task: smoke-test
         file: git-master/concourse/tasks/smoke-test.yml
         params:
-          URL: 'https://coronavirus-shielding-support.service.gov.uk/applying-on-own-behalf'
+          WEB_APP_BASE_URL: 'https://coronavirus-shielding-support.service.gov.uk'
           MESSAGE: "Checks that the application deployed to production is not serving HTTP error codes"
         on_failure: *slack_alert_on_failure
         on_success: *slack_alert_on_success

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -168,7 +168,7 @@ jobs:
       - task: smoke-test
         file: git-master/concourse/tasks/smoke-test.yml
         params:
-          WEB_APP_BASE_URL: 'https://gds-shielded-vulnerable-people-service-staging.london.cloudapps.digital/applying-on-own-behalf'
+          WEB_APP_BASE_URL: 'https://gds-shielded-vulnerable-people-service-staging.london.cloudapps.digital'
           MESSAGE: "Checks that the application deployed to staging is not serving HTTP error codes"
         on_failure: *slack_alert_on_failure
       - task: cronitor-heartbeat
@@ -185,7 +185,7 @@ jobs:
       - task: smoke-test
         file: git-master/concourse/tasks/smoke-test.yml
         params:
-          WEB_APP_BASE_URL: 'https://coronavirus-shielding-support.service.gov.uk/applying-on-own-behalf'
+          WEB_APP_BASE_URL: 'https://coronavirus-shielding-support.service.gov.uk'
           MESSAGE: "Checks that the application deployed to production is not serving HTTP error codes"
         on_failure: *slack_alert_on_failure
       - task: cronitor-heartbeat


### PR DESCRIPTION
This is not required and when specified breaks the tests.