### PR TITLE
Update matching messages

### DIFF
--- a/vulnerable_people_form/templates/_spl_match_email_template.md
+++ b/vulnerable_people_form/templates/_spl_match_email_template.md
@@ -6,7 +6,7 @@ Your registration number is {{reference_number}}.
 
 #If you need urgent help
 
-Contact your local authority if you need urgent help: https://www.gov.uk/coronavirus-local-help.
+Contact your local authority if you need urgent help: https://www.gov.uk/coronavirus-local-help
 
 {% endif %}
 
@@ -21,6 +21,7 @@ If you do not already have an account with a supermarket delivery service, set o
 Someone from your local authority will contact you about your care needs within the next week.
 
 {% endif %}
+
 {% if wants_supermarket_deliveries and not wants_social_care %}
 
 You should be able to start booking priority supermarket deliveries in the next 1 to 7 days, depending on the supermarket.
@@ -37,7 +38,7 @@ Someone from your local authority will contact you about your care needs within 
 
 {% if not wants_supermarket_deliveries and not wants_social_care %}
 
-You said that you do not want priority supermarket deliveries or help with your care needs.
+Based on what you told us, at the moment you do not help getting supplies or meeting your basic care needs.
 
 {% endif %}
 
@@ -45,23 +46,23 @@ You said that you do not want priority supermarket deliveries or help with your 
 
 {% if has_set_up_account %}
 
-Use your NHS login to update your personal details or support needs: https://www.gov.uk/coronavirus-shielding-support.
+Use your NHS login to update your personal details or support needs: https://www.gov.uk/coronavirus-shielding-support
 
 {% endif %}
 
 {% if not has_set_up_account %}
 
-Go through the questions in the service again to update your personal details or support needs: https://www.gov.uk/coronavirus-extremely-vulnerable.
+Go through the questions in the service again to update your personal details or support needs: https://www.gov.uk/coronavirus-shielding-support
 
 {% endif %}
 
 {% if has_someone_to_shop %}
 
-Contact your local authority if you need support urgently and cannot rely on family, friends or neighbours: https://www.gov.uk/coronavirus-local-help.
+Contact your local authority if you need support urgently and cannot rely on family, friends or neighbours: https://www.gov.uk/coronavirus-local-help
 
 {% endif %}
 
-There’s guidance on what you should do if you’re extremely vulnerable to coronavirus: https://www.gov.uk/coronavirus-extremely-vulnerable-guidance.
+There’s guidance on what you should do if you’re extremely vulnerable to coronavirus: https://www.gov.uk/coronavirus-extremely-vulnerable-guidance
 
 Thanks,
 

--- a/vulnerable_people_form/templates/_spl_match_letter_template.md
+++ b/vulnerable_people_form/templates/_spl_match_letter_template.md
@@ -38,21 +38,21 @@ Someone from your local authority will contact you about your care needs within 
 
 {% if not wants_supermarket_deliveries and not wants_social_care %}
 
-You said that you do not want priority supermarket deliveries or help with your care needs.
+Based on what you told us, at the moment you do not help getting supplies or meeting your basic care needs.
 
 {% endif %}
 
 #If your personal details or support needs change
 
-Use the service again to update your personal details or support needs: www.gov.uk/coronavirus-extremely-vulnerable
+Use the service again to update your personal details or support needs: www.gov.uk/coronavirus-shielding-support.
 
 {% if has_someone_to_shop %}
 
-Contact your local authority if you need support urgently and cannot rely on family, friends or neighbours: www.gov.uk/coronavirus-local-help
+Contact your local authority if you need support urgently and cannot rely on family, friends or neighbours: www.gov.uk/coronavirus-local-help.
 
 {% endif %}
 
-There’s guidance on what you should do if you’re extremely vulnerable to coronavirus: www.gov.uk/coronavirus-extremely-vulnerable-guidance
+There’s guidance on what you should do if you’re extremely vulnerable to coronavirus: www.gov.uk/coronavirus-extremely-vulnerable-guidance.
 
 Regards,
 

--- a/vulnerable_people_form/templates/_spl_match_sms_template.txt
+++ b/vulnerable_people_form/templates/_spl_match_sms_template.txt
@@ -19,15 +19,15 @@ Someone from your local authority will contact you about your care needs within 
 {% endif %}
 
 {% if not wants_supermarket_deliveries and not wants_social_care %}
- You said that you do not want priority supermarket deliveries or help with your care needs.
+Based on what you told us, at the moment you do not help getting supplies or meeting your basic care needs.
 {% endif %}
 
 {% if has_set_up_account %}
- Use your NHS login to update your personal details or support needs: https://www.gov.uk/coronavirus-shielding-support.
+ Use your NHS login to update your personal details or support needs: www.gov.uk/coronavirus-shielding-support.
 {% endif %}
 
 {% if not has_set_up_account %}
- Go through the questions in the service again to update your personal details or support needs: www.gov.uk/coronavirus-extremely-vulnerable.
+ Go through the questions in the service again to update your personal details or support needs: www.gov.uk/coronavirus-shielding-support
 {% endif %}
 
 {% if has_someone_to_shop %}

--- a/vulnerable_people_form/templates/_spl_no_match_email_template.md
+++ b/vulnerable_people_form/templates/_spl_no_match_email_template.md
@@ -2,15 +2,13 @@ Dear {{first_name}} {{last_name}},
 
 Your registration number is {{reference_number}}.
 
-{% if not has_someone_to_shop %}
-
-#If you need urgent help
-
-Contact your local authority if you need urgent help: https://www.gov.uk/coronavirus-local-help.
-
-{% endif %}
-
 {% if told_to_shield == 1 %}
+
+#Make sure you've given us the correct personal details
+
+You'll only be able to get the support you need if you've given us the correct personal details. If you think you might have made a mistake, go through the questions again: https://www.gov.uk/coronavirus-shielding-support
+
+Contact your local authority if you need help using the service: https://www.gov.uk/coronavirus-local-help
 
 #What happens next
 
@@ -26,19 +24,23 @@ We’ll check your details, then contact you to confirm whether you’re eligibl
 
 Contact your GP or hospital clinician as soon as possible so they can put you on the NHS list of people who should be shielding. You may not get the support you need if you do not contact them.
 
+#Make sure you've given us the correct personal details
+
+You'll only be able to get the support you need if you've given us the correct personal details. If you think you might have made a mistake, go through the questions again: https://www.gov.uk/coronavirus-shielding-support
+
+Contact your local authority if you need help using the service: https://www.gov.uk/coronavirus-local-help
+
 #What happens next
 
 We’ll check your details, then contact you to confirm whether you’re eligible for support. This can take up to 2 weeks from when your GP or hospital clinician puts you on the NHS list of people who should be shielding.
 
 {% endif %}
 
-{% if has_someone_to_shop %}
+#If you need urgent help
 
-Contact your local authority if you need support urgently and cannot rely on family, friends or neighbours: https://www.gov.uk/coronavirus-local-help.
+Contact your local authority if you need support urgently and cannot rely on family, friends or neighbours: https://www.gov.uk/coronavirus-local-help
 
-{% endif %}
-
-There’s guidance on what you should do if you’re extremely vulnerable to coronavirus: https://www.gov.uk/coronavirus-extremely-vulnerable-guidance.
+There’s guidance on what you should do if you’re extremely vulnerable to coronavirus: https://www.gov.uk/coronavirus-extremely-vulnerable-guidance
 
 Thanks,
 

--- a/vulnerable_people_form/templates/_spl_no_match_letter_template.md
+++ b/vulnerable_people_form/templates/_spl_no_match_letter_template.md
@@ -2,17 +2,13 @@ Dear {{first_name}} {{last_name}}
 
 Your registration number is {{reference_number}}
 
-{% if not has_someone_to_shop %}
-
-#If you need urgent help
-
-Contact your local authority if you need urgent help: www.gov.uk/coronavirus-local-help.
-
-{% endif %}
-
 {% if told_to_shield == 1 %}
 
-What happens next
+#Make sure you've given us the correct personal details
+
+You'll only be able to get the support you need if you've given us the correct personal details. If you think you might have made a mistake, go through the questions again: www.gov.uk/coronavirus-shielding-support. Contact your local authority if you need help using the service: www.gov.uk/coronavirus-local-help.
+
+#What happens next
 
 You do not need to do anything else if you've been told to shield by the NHS or your doctor and they've put you on the NHS list of people who should be shielding.
 
@@ -26,6 +22,10 @@ We’ll check your details, then contact you to confirm whether you’re eligibl
 
 Contact your GP or hospital clinician as soon as possible so they can put you on the NHS list of people who should be shielding. You may not get the support you need if you do not contact them.
 
+#Make sure you've given us the correct personal details
+
+You'll only be able to get the support you need if you've given us the correct personal details. If you think you might have made a mistake, go through the questions again: www.gov.uk/coronavirus-shielding-support. Contact your local authority if you need help using the service: www.gov.uk/coronavirus-local-help.
+
 #What happens next
 
 We’ll check your details, then contact you to confirm whether you’re eligible for support. This can take up to 2 weeks from when your GP or hospital clinician puts you on the NHS list of people who should be shielding.
@@ -34,15 +34,13 @@ We’ll check your details, then contact you to confirm whether you’re eligibl
 
 {% endif %}
 
-Use the service again to update your personal details or support needs: www.gov.uk/coronavirus-extremely-vulnerable
+Use the service again to update your personal details or support needs: www.gov.uk/coronavirus-shielding-support.
 
-{% if has_someone_to_shop %}
+#If you need urgent help
 
-Contact your local authority if you need support urgently and cannot rely on family, friends or neighbours: www.gov.uk/coronavirus-local-help
+Contact your local authority if you need support urgently and cannot rely on family, friends or neighbours: www.gov.uk/coronavirus-local-help.
 
-{% endif %}
-
-There’s guidance on what you should do if you’re extremely vulnerable to coronavirus: www.gov.uk/coronavirus-extremely-vulnerable-guidance
+There’s guidance on what you should do if you’re extremely vulnerable to coronavirus: www.gov.uk/coronavirus-extremely-vulnerable-guidance.
 
 Regards,
 

--- a/vulnerable_people_form/templates/_spl_no_match_sms_template.txt
+++ b/vulnerable_people_form/templates/_spl_no_match_sms_template.txt
@@ -1,21 +1,24 @@
 Hello {{first_name}} {{last_name}} - your registration for the shielding service is {{reference_number}}.
 
-{% if not has_someone_to_shop %}
- Contact your local authority if you need urgent help: www.gov.uk/coronavirus-local-help
-{% endif %}
-
 {% if told_to_shield == 1 %}
- You do not need to do anything else if you've been told to shield by the NHS or your doctor and they've put you on the NHS list of people who should be shielding.
+  You'll only be able to get the support you need if you've given us the correct personal details. If you think you might have made a mistake, go through the questions again: www.gov.uk/coronavirus-shielding-support
 
-We’ll check your details, then contact you to confirm whether you’re eligible for support. You will not start getting support until we’ve confirmed that you’re eligible. This can take up to 2 weeks.
+  Contact your local authority if you need help using the service: www.gov.uk/coronavirus-local-help
+
+  You do not need to do anything else if you've been told to shield by the NHS or your doctor and they've put you on the NHS list of people who should be shielding.
+
+  We’ll check your details, then contact you to confirm whether you’re eligible for support. You will not start getting support until we’ve confirmed that you’re eligible. This can take up to 2 weeks.
+
 {% endif %}
 
 {% if told_to_shield == 2 or told_to_shield == 3 %}
  Contact your GP or hospital clinician as soon as possible so they can put you on the NHS list of people who should be shielding. You may not get the support you need if you do not contact them.
 
+ You'll only be able to get the support you need if you've given us the correct personal details. If you think you might have made a mistake, go through the questions again: www.gov.uk/coronavirus-shielding-support
+
+ Contact your local authority if you need help using the service: www.gov.uk/coronavirus-local-help
+
 We’ll check your details, then contact you to confirm whether you’re eligible for support. This can take up to 2 weeks from when your GP or hospital clinician puts you on the NHS list of people who should be shielding.
 {% endif %}
 
-{% if has_someone_to_shop %}
  Contact your local authority if you need support urgently and cannot rely on family, friends or neighbours: www.gov.uk/coronavirus-local-help
-{% endif %}


### PR DESCRIPTION
This PR:

- updates content and if statements so that message about contacting your GP appears first where appropriate
- adds sentence covering use case where user fails to match on date of birth
- updates links to point to correct url - gov.uk/coronavirus-shielding-support
- corrects minor inconsistencies with formatting

Trello card: https://trello.com/c/bIvyvj2v/335-update-notify-content-to-reflect-matching-behaviour