### PR TITLE
Clear session on completion (pen test feedback)

### DIFF
--- a/vulnerable_people_form/form_pages/confirmation.py
+++ b/vulnerable_people_form/form_pages/confirmation.py
@@ -5,4 +5,8 @@ from .shared.render import render_template_with_title
 
 @form.route("/confirmation", methods=["GET"])
 def get_confirmation():
-    return render_template_with_title("confirmation.html", registration_number=session["registration_number"])
+    rendered_template = render_template_with_title(
+        "confirmation.html",
+        registration_number=session["registration_number"])
+    session.clear()
+    return rendered_template


### PR DESCRIPTION
The penetration test report indicated that the session should
be cleared when the user has completed their registration.

The session is now cleared prior to returning the rendered
template for the /confirmation page.