### PR TITLE
Enable Prometheus scraping

### DIFF
--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -93,5 +93,7 @@ run:
 
       cf push govuk-coronavirus-shielded-vulnerable-people-form --strategy rolling -i "$INSTANCES"
       cf map-route govuk-coronavirus-shielded-vulnerable-people-form london.cloudapps.digital --hostname "$HOSTNAME"
+      cf map-route govuk-coronavirus-shielded-vulnerable-people-form london.cloudapps.digital  --hostname "$HOSTNAME" --path metrics
 
       cf bind-service govuk-coronavirus-shielded-vulnerable-people-form prometheus
+      cf bind-route-service london.cloudapps.digital "support-service-ip-safelist-route-service-$CF_SPACE"--hostname "$HOSTNAME" --path metrics

--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -94,3 +94,4 @@ run:
       cf push govuk-coronavirus-shielded-vulnerable-people-form --strategy rolling -i "$INSTANCES"
       cf map-route govuk-coronavirus-shielded-vulnerable-people-form london.cloudapps.digital --hostname "$HOSTNAME"
 
+      cf bind-service govuk-coronavirus-shielded-vulnerable-people-form prometheus


### PR DESCRIPTION
This relies on the IP safelist as managed and deployed by the Support
Tool (which shares this PaaS org and space)[1]. This has be done for
expediency. This route service should be extracted out of the Support
Tool at some point.