### PR TITLE
Exclude non-postable addresses from address picker

### DIFF
--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -1,0 +1,27 @@
+import pytest
+
+from lib.fake_os_places_api_entry import fake_os_places_api_entry as _fake_os_places_api_entry
+from lib.fake_os_places_api_response import FakeOSPlacesAPIResponse
+
+
+@pytest.fixture(scope='session', autouse=True)
+def faker_session_locale():
+    return ['en_GB']
+
+
+@pytest.fixture()
+def fake_os_places_api_entry(faker):
+    return _fake_os_places_api_entry(faker)
+
+
+@pytest.fixture()
+def fake_os_places_api_response(faker):
+    def func(
+        postcode=None,
+        entries=None,
+    ):
+        return FakeOSPlacesAPIResponse(
+            postcode=postcode or faker.postcode(),
+            address_entries=entries,
+        )
+    return func

--- a/tests/integrations/lib/fake_os_places_api_entry.py
+++ b/tests/integrations/lib/fake_os_places_api_entry.py
@@ -1,0 +1,136 @@
+
+class FakeOSPlacesAPIEntry:
+    postcode = None
+    city = None
+    street = None
+    door_number = None
+    building_type = None
+    uprn = None
+    usrn = None
+    postal_address_code = None
+    lpi_key = None
+    x_coordinate = None
+    y_coordinate = None
+    local_custodian_code = None
+    topography_layer_toid = None
+    last_update_date = None
+    entry_date = None
+    blpu_state_date = None
+
+    def __init__(
+        self,
+        postcode=None,
+        city=None,
+        street=None,
+        door_number=None,
+        building_type=None,
+        uprn=None,
+        usrn=None,
+        postal_address_code=None,
+        lpi_key=None,
+        x_coordinate=None,
+        y_coordinate=None,
+        local_custodian_code=None,
+        topography_layer_toid=None,
+        last_update_date=None,
+        entry_date=None,
+        blpu_state_date=None,
+    ):
+        self.postcode = postcode
+        self.city = city
+        self.street = street
+        self.door_number = door_number
+        self.building_type = building_type
+        self.uprn = uprn
+        self.usrn = usrn
+        self.postal_address_code = postal_address_code
+        self.lpi_key = lpi_key
+        self.x_coordinate = x_coordinate
+        self.y_coordinate = y_coordinate
+        self.local_custodian_code = local_custodian_code
+        self.topography_layer_toid = topography_layer_toid
+        self.last_update_date = last_update_date
+        self.entry_date = entry_date
+        self.blpu_state_date = blpu_state_date
+
+    def to_json(self):
+        return {
+            "LPI" : {
+                "UPRN" : self.uprn,
+                "ADDRESS" : f'{self.door_number}, {self.street}, {self.city}, {self.postcode}',
+                "USRN" : self.usrn,
+                "LPI_KEY" : self.lpi_key,
+                "PAO_START_NUMBER" : self.door_number,
+                "STREET_DESCRIPTION" : self.street,
+                "TOWN_NAME" : self.city,
+                "ADMINISTRATIVE_AREA" : self.city,
+                "POSTCODE_LOCATOR" : self.postcode,
+                "RPC" : "1",
+                "X_COORDINATE" : self.x_coordinate,
+                "Y_COORDINATE" : self.y_coordinate,
+                "STATUS" : "APPROVED",
+                "LOGICAL_STATUS_CODE" : "1",
+                "CLASSIFICATION_CODE" : "RD03",
+                "CLASSIFICATION_CODE_DESCRIPTION" : self.building_type,
+                "LOCAL_CUSTODIAN_CODE" : self.local_custodian_code,
+                "LOCAL_CUSTODIAN_CODE_DESCRIPTION" : self.city,
+                "POSTAL_ADDRESS_CODE" : self.postal_address_code,
+                "POSTAL_ADDRESS_CODE_DESCRIPTION" : "A record which is linked to PAF",
+                "BLPU_STATE_CODE" : "2",
+                "BLPU_STATE_CODE_DESCRIPTION" : "In use",
+                "TOPOGRAPHY_LAYER_TOID" : self.topography_layer_toid,
+                "LAST_UPDATE_DATE" : self.last_update_date,
+                "ENTRY_DATE" : self.entry_date,
+                "BLPU_STATE_DATE" : self.blpu_state_date,
+                "STREET_STATE_CODE" : "2",
+                "STREET_STATE_CODE_DESCRIPTION" : "Open",
+                "STREET_CLASSIFICATION_CODE" : "8",
+                "STREET_CLASSIFICATION_CODE_DESCRIPTION" : "All vehicles",
+                "LPI_LOGICAL_STATUS_CODE" : "1",
+                "LPI_LOGICAL_STATUS_CODE_DESCRIPTION" : "APPROVED",
+                "LANGUAGE" : "EN",
+                "MATCH" : 1.0,
+                "MATCH_DESCRIPTION" : "EXACT"
+            }
+        }
+
+
+def fake_os_places_api_entry(faker):
+    def func(
+        postcode=None,
+        city=None,
+        street=None,
+        door_number=None,
+        building_type=None,
+        uprn=None,
+        usrn=None,
+        postal_address_code=None,
+        lpi_key=None,
+        x_coordinate=None,
+        y_coordinate=None,
+        local_custodian_code=None,
+        topography_layer_toid=None,
+        last_update_date=None,
+        entry_date=None,
+        blpu_state_date=None,
+    ):
+
+        return FakeOSPlacesAPIEntry(
+            postcode=postcode or faker.postcode(),
+            city=city or faker.city(),
+            street=street or faker.street_name(),
+            door_number=door_number or faker.building_number(),
+            building_type=building_type or faker.random_element(elements=('Semi-Detached', 'Terraced', 'Detached')),
+            uprn=uprn or faker.random_int(10000000, 99999999),
+            usrn=usrn or faker.random_int(10000000, 99999999),
+            postal_address_code=postal_address_code or faker.random_element(elements=('D', 'S', 'N', 'C', 'M')),
+            lpi_key=lpi_key or faker.bothify('####?#########'),
+            x_coordinate=x_coordinate or faker.numerify(text='######.0'),
+            y_coordinate=y_coordinate or faker.numerify(text='######.0'),
+            local_custodian_code=local_custodian_code or faker.random_int(1000, 9999),
+            topography_layer_toid=topography_layer_toid or faker.numerify('osgb#############'),
+            last_update_date=last_update_date or faker.date(pattern='%d/%m/%Y'),
+            entry_date=entry_date or faker.date(pattern='%d/%m/%Y'),
+            blpu_state_date=blpu_state_date or faker.date(pattern='%d/%m/%Y'),
+        )
+    return func

--- a/tests/integrations/lib/fake_os_places_api_response.py
+++ b/tests/integrations/lib/fake_os_places_api_response.py
@@ -1,0 +1,30 @@
+
+class FakeOSPlacesAPIResponse():
+    postcode = None
+    address_entries = []
+
+    def __init__(self, postcode=None, address_entries=None):
+        self.postcode = postcode
+        self.address_entries = address_entries
+
+    def to_json(self):
+        entries = []
+        for entry in self.address_entries:
+            entries.append(entry.to_json())
+
+        response = {
+          "header" : {
+            "uri" : f'https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?postcode={self.postcode}&dataset=LPI', # noqa E501
+            "query" : f'postcode={self.postcode}',
+            "offset" : 0,
+            "totalresults" : len(self.address_entries),
+            "format" : "JSON",
+            "dataset" : "LPI",
+            "lr" : "EN,CY",
+            "maxresults" : 100,
+            "epoch" : "78",
+            "output_srs" : "EPSG:27700"
+          },
+          "results" : entries
+        }
+        return response

--- a/tests/integrations/test_postcode_lookup_helper.py
+++ b/tests/integrations/test_postcode_lookup_helper.py
@@ -1,0 +1,100 @@
+import pytest
+import requests
+import json
+from unittest import mock
+from flask import Flask
+
+from vulnerable_people_form.integrations.postcode_lookup_helper import \
+        entry_is_a_postal_address, \
+        get_addresses_from_postcode, \
+        PostcodeNotFound, ErrorFindingAddress
+
+_current_app = Flask(__name__)
+
+
+def test_entry_is_a_postal_address_function(fake_os_places_api_entry):
+    postable_entry = fake_os_places_api_entry(postal_address_code='D')
+    non_postable_entry = fake_os_places_api_entry(postal_address_code='N')
+
+    assert entry_is_a_postal_address(postable_entry.to_json()) is True
+    assert entry_is_a_postal_address(non_postable_entry.to_json()) is False
+
+
+@mock.patch('requests.get')
+def test_get_addresses_from_postcode(mock_get, faker, fake_os_places_api_entry, fake_os_places_api_response):
+    postcode = faker.postcode()
+
+    entries = []
+    # GIVEN 5 postable address entries for a postcode
+    for _ in range(0, 5):
+        entries.append(fake_os_places_api_entry(postcode=postcode, postal_address_code='D'))
+    # and one non-postable entry.
+    non_postable_entry = fake_os_places_api_entry(postcode=postcode, postal_address_code='N')
+
+    fake_api_response = fake_os_places_api_response(
+        postcode=postcode,
+        entries=[*entries, non_postable_entry],
+    )
+    mock_get.return_value = create_response_object(200, fake_api_response.to_json())
+
+    # WHEN we call the get_addresses_from_postcode function
+    with _current_app.test_request_context():
+        addresses = get_addresses_from_postcode(fake_api_response.postcode)
+
+        # THEN we get 5 postable address entries back with the details we expect.
+        assert len(addresses) == 5
+        api_response_and_function_result_should_match(entries, addresses)
+
+
+@mock.patch('requests.get')
+def test_get_addresses_from_postcode_handles_400_status_code(mock_get, faker):
+    postcode = faker.postcode()
+    mock_get.return_value = create_response_object(400, '')
+    with pytest.raises(PostcodeNotFound):
+        with _current_app.test_request_context():
+            get_addresses_from_postcode(postcode)
+
+
+@mock.patch('requests.get')
+def test_get_addresses_from_postcode_handles_401_status_code(mock_get, faker):
+    postcode = faker.postcode()
+    mock_get.return_value = create_response_object(401, '')
+    with pytest.raises(ErrorFindingAddress):
+        with _current_app.test_request_context():
+            get_addresses_from_postcode(postcode)
+
+
+@mock.patch('requests.get')
+def test_get_addresses_from_postcode_handles_500_status_code(mock_get, faker):
+    postcode = faker.postcode()
+    mock_get.return_value = create_response_object(500, '')
+    with pytest.raises(ErrorFindingAddress):
+        with _current_app.test_request_context():
+            get_addresses_from_postcode(postcode)
+
+
+def api_response_and_function_result_should_match(expected_entries, addresses):
+    assert len(expected_entries) == len(addresses)
+    for i in range(0, len(expected_entries)):
+        api_response_entry_json = json.loads(json.dumps(expected_entries[i].to_json()))
+        assert addresses[i]['text'] == api_response_entry_json['LPI']['ADDRESS']
+        values = json.loads(addresses[i]['value'])
+        assert values['uprn'] == expected_entries[i].uprn
+        assert values['town_city'] == expected_entries[i].city.title()
+        assert values['postcode'] == expected_entries[i].postcode
+        assert values['building_and_street_line_1'] == '{door_number} {street}'.format(
+            door_number=expected_entries[i].door_number,
+            street=expected_entries[i].street,
+        ).title()
+        assert values['building_and_street_line_2'] == ''
+
+
+def create_response_object(status_code, json_body):
+    r = requests.Response()
+    r.status_code = status_code
+
+    def json_func():
+        return json_body
+
+    r.json = json_func
+    return r


### PR DESCRIPTION
The address picker gets address data for postcodes from the Ordnance
Survey Places API. The API supports two datasets, a DPA dataset, which
is compiled by Royal Mail and includes all residential and most
commercial postal addresses; and an LPI dataset, which is compiled by
local authorities and contains both postal addresses, and non-postable
assets such as carparks and streets, which should not appear in the
address picker. We are using the LPI dataset on the address picker.

The address picker should probably use the DBA dataset. However, DPA
records have a different structure to LPI records, which would require a
more extensive rewrite of the postcode_lookup_helper. The documentation
about these datasets is poor, so I've made the decision to simply
exclude records where `POSTAL_ADDRESS_CODE=N`, which indicates a
non-postable address.

This probably needs a more thorough rewrite at some point to make sure
we are using the OS Places API efficiently, and to add a thorough set of
unit tests.

Also, add some pytest tests for the postcode_lookup_helper module.

1. https://apidocs.os.uk/docs/os-places-dpa-output
2. https://apidocs.os.uk/docs/os-places-lpi-output
3. https://gbgplc.zendesk.com/hc/en-us/articles/207710315-AddressBase-Premium-Codes