### PR TITLE
Add info screen when no consent given via nhs login

### DIFF
--- a/vulnerable_people_form/form_pages/__init__.py
+++ b/vulnerable_people_form/form_pages/__init__.py
@@ -31,7 +31,8 @@ from . import (
     privacy,
     support_address,
     view_answers,
-    nhs_login_landing
+    nhs_login_landing,
+    nhs_login_no_consent
 )
 
 __all__ = ["blueprint"]

--- a/vulnerable_people_form/form_pages/nhs_login_callback.py
+++ b/vulnerable_people_form/form_pages/nhs_login_callback.py
@@ -8,8 +8,14 @@ from .shared.session import load_answers_into_session_if_available, set_form_ans
 @form.route("/nhs-login-callback", methods=["GET"])
 def get_nhs_login_callback():
     session.permanent = True
+
     if "error" in request.args:
-        abort(500)
+        error_description = request.args.get('error_description')
+        if error_description == "ConsentNotGiven":
+            return redirect("/no-consent")
+        else:
+            abort(500)
+
     nhs_user_info = current_app.nhs_oidc_client.get_nhs_user_info_from_authorization_callback(request.args)
 
     session["nhs_sub"] = nhs_user_info["sub"]

--- a/vulnerable_people_form/form_pages/nhs_login_no_consent.py
+++ b/vulnerable_people_form/form_pages/nhs_login_no_consent.py
@@ -1,0 +1,20 @@
+from vulnerable_people_form.form_pages.shared.render import render_template_with_title
+from .blueprint import form
+
+
+@form.route("/no-consent", methods=["GET"])
+def get_nhs_login_no_consent():
+    return render_template_with_title(
+        "nhs-login-no-consent.html",
+        continue_url="/postcode-eligibility",
+        hint_text="You can still register, then decide to share your NHS login information later."
+    )
+
+
+@form.route("/no-consent-registration", methods=["GET"])
+def get_nhs_login_no_consent_registration():
+    return render_template_with_title(
+        "nhs-login-no-consent.html",
+        continue_url="/nhs-number",
+        hint_text="This means you will need to enter an NHS number."
+    )

--- a/vulnerable_people_form/form_pages/nhs_registration_callback.py
+++ b/vulnerable_people_form/form_pages/nhs_registration_callback.py
@@ -32,7 +32,14 @@ def log_form_and_nhs_answers_differences(nhs_user_info):
 @form.route("/nhs-registration-callback", methods=["GET"])
 def get_nhs_registration_callback():
     if "error" in request.args:
-        abort(500)
+        error_description = request.args.get('error_description')
+        if error_description == "ConsentNotGiven" and session.get('registration_number'):
+            return redirect("/confirmation")
+        elif error_description == "ConsentNotGiven":
+            return redirect("/no-consent-registration")
+        else:
+            abort(500)
+
     state_from_query_string = request.args.get('state')
     if state_from_query_string:
         last_char_of_state = state_from_query_string[len(state_from_query_string)-1]

--- a/vulnerable_people_form/form_pages/shared/constants.py
+++ b/vulnerable_people_form/form_pages/shared/constants.py
@@ -48,6 +48,7 @@ PAGE_TITLES = {
     "view-or-setup": "Do you want to set up this service, or access an existing account?",
     "view-answers": "Your saved details",
     "nhs-login-landing": "Sign in to update your details or change the support you need",
+    "nhs-login-no-consent": "You have decided not to share your NHS login information",
 }
 
 NHS_USER_INFO_TO_FORM_ANSWERS = {

--- a/vulnerable_people_form/templates/nhs-login-no-consent.html
+++ b/vulnerable_people_form/templates/nhs-login-no-consent.html
@@ -1,0 +1,12 @@
+{%- from 'govuk_frontend_jinja/components/button/macro.html' import govukButton -%}
+
+{% extends "base.html" %}
+
+{% block content %}
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-6">{{ title_text }}</h1>
+    <p id="nhs_login-no-consent-hint" class="govuk-hint">{{ hint_text }}</p>
+    {{ govukButton({
+        "text": "Continue",
+        "href": continue_url
+    }) }}
+{% endblock %}


### PR DESCRIPTION
When a user doesn't provide consent to share data with the SVP app when using NHS login a new screen has been added to explain to the user the implications of not doing so.