### PR TITLE
Amend notification template content

### DIFF
--- a/vulnerable_people_form/templates/_spl_match_email_template.md
+++ b/vulnerable_people_form/templates/_spl_match_email_template.md
@@ -38,7 +38,7 @@ Someone from your local authority will contact you about your care needs within 
 
 {% if not wants_supermarket_deliveries and not wants_social_care %}
 
-Based on what you told us, at the moment you do not help getting supplies or meeting your basic care needs.
+Based on what you told us, at the moment you do not need help getting supplies or meeting your basic care needs.
 
 {% endif %}
 

--- a/vulnerable_people_form/templates/_spl_match_letter_template.md
+++ b/vulnerable_people_form/templates/_spl_match_letter_template.md
@@ -38,7 +38,7 @@ Someone from your local authority will contact you about your care needs within 
 
 {% if not wants_supermarket_deliveries and not wants_social_care %}
 
-Based on what you told us, at the moment you do not help getting supplies or meeting your basic care needs.
+Based on what you told us, at the moment you do not need help getting supplies or meeting your basic care needs.
 
 {% endif %}
 

--- a/vulnerable_people_form/templates/_spl_match_sms_template.txt
+++ b/vulnerable_people_form/templates/_spl_match_sms_template.txt
@@ -1,13 +1,12 @@
 Hello {{first_name}} {{last_name}} - your registration for the shielding service is {{reference_number}}.
 
 {% if not has_someone_to_shop %}
-Contact your local authority if you need urgent help: www.gov.uk/coronavirus-local-help
+ Contact your local authority if you need urgent help: www.gov.uk/coronavirus-local-help
 {% endif %}
 
 {% if wants_supermarket_deliveries and wants_social_care %}
  You should be able to start booking priority supermarket deliveries in the next 1 to 7 days, depending on the supermarket. If you do not already have an account with a supermarket, set one up now. You can set up accounts with more than one supermarket.
-
-Someone from your local authority will contact you about your care needs within the next week.
+ Someone from your local authority will contact you about your care needs within the next week.
 {% endif %}
 
 {% if wants_supermarket_deliveries and not wants_social_care %}
@@ -19,15 +18,15 @@ Someone from your local authority will contact you about your care needs within 
 {% endif %}
 
 {% if not wants_supermarket_deliveries and not wants_social_care %}
- Based on what you told us, at the moment you do not help getting supplies or meeting your basic care needs.
+ Based on what you told us, at the moment you do not need help getting supplies or meeting your basic care needs.
 {% endif %}
 
 {% if has_set_up_account %}
- Use your NHS login to update your personal details or support needs: www.gov.uk/coronavirus-shielding-support.
+ Use your NHS login to update your personal details or support needs: www.gov.uk/coronavirus-shielding-support
 {% endif %}
 
 {% if not has_set_up_account %}
- Go through the questions in the service again to update your personal details or support needs: www.gov.uk/coronavirus-shielding-support.
+ Go through the questions in the service again to update your personal details or support needs: www.gov.uk/coronavirus-shielding-support
 {% endif %}
 
 {% if has_someone_to_shop %}

--- a/vulnerable_people_form/templates/_spl_no_match_sms_template.txt
+++ b/vulnerable_people_form/templates/_spl_no_match_sms_template.txt
@@ -1,17 +1,15 @@
 Hello {{first_name}} {{last_name}} - your registration for the shielding service is {{reference_number}}.
 
 {% if told_to_shield == 1 %}
- You'll only be able to get the support you need if you've given us the correct personal details. If you think you might have made a mistake, go through the questions again: www.gov.uk/coronavirus-shielding-support.
- Contact your local authority if you need help using the service: www.gov.uk/coronavirus-local-help.
+ You'll only be able to get the support you need if you've given us the correct personal details. If you think you might have made a mistake, go through the questions again: www.gov.uk/coronavirus-shielding-support
  You do not need to do anything else if you've been told to shield by the NHS or your doctor and they've put you on the NHS list of people who should be shielding.
  We’ll check your details, then contact you to confirm whether you’re eligible for support. You will not start getting support until we’ve confirmed that you’re eligible. This can take up to 2 weeks.
 {% endif %}
 
 {% if told_to_shield == 2 or told_to_shield == 3 %}
  Contact your GP or hospital clinician as soon as possible so they can put you on the NHS list of people who should be shielding. You may not get the support you need if you do not contact them.
- You'll only be able to get the support you need if you've given us the correct personal details. If you think you might have made a mistake, go through the questions again: www.gov.uk/coronavirus-shielding-support.
- Contact your local authority if you need help using the service: www.gov.uk/coronavirus-local-help.
- We’ll check your details, then contact you to confirm whether you’re eligible for support. This can take up to 2 weeks from when your GP or hospital clinician puts you on the NHS list of people who should be shielding.
+ You'll only be able to get the support you need if you've given us the correct personal details. If you think you might have made a mistake, go through the questions again: www.gov.uk/coronavirus-shielding-support
+ We'll check your details, then contact you to confirm whether you're eligible for support. This can take up to 2 weeks from when your GP or hospital clinician puts you on the NHS list of people who should be shielding.
 {% endif %}
 
  Contact your local authority if you need support urgently and cannot rely on family, friends or neighbours: www.gov.uk/coronavirus-local-help


### PR DESCRIPTION
Typos have been corrected.

An attempt has been made to shorten the content for the
SMS templates due to the GOVUK Notify API 918 char limit.