### PR TITLE
Add get aws creds pipeline task for gatling load tests

### DIFF
--- a/concourse_dev/pipeline.yml
+++ b/concourse_dev/pipeline.yml
@@ -13,14 +13,6 @@ resources:
       uri: https://github.com/alphagov/govuk-shielded-vulnerable-people-service
       branch: feature/794/gatling-in-concourse
 
-  - name: covid-engineering
-    icon: github
-    type: git
-    source:
-      branch: master
-      uri: git@github.com:alphagov/covid-engineering.git
-      private_key: ((git_deploy_key_covid_engineering))
-
   - name: trigger-at-1am
     type: cron-resource
     source:
@@ -45,13 +37,13 @@ jobs:
       - task: gatling
         file: git-dev/concourse_dev/tasks/gatling-workflow-load-test.yml
 
-  - name: run-daily-and-mi-workflows
+  - name: run-daily-and-mi-workflows-in-staging
     plan:
-      - get: covid-engineering
+      - get: git-dev
       - get: trigger-at-1am
         trigger: true
       - task: get-aws-credentials
-        file: covid-engineering/concourse/shared/get-aws-credentials.yml
+        file: git-dev/concourse_dev/tasks/get-gatling-tester-aws-creds.yml
         params:
           ACCOUNT_ID: 375282846305
           ENVIRONMENT: staging
@@ -68,7 +60,6 @@ jobs:
           inputs:
             - name: aws-credentials
           run:
-            dir: covid-engineering/end-to-end-tests
             path: ash
             args:
               - -c
@@ -77,3 +68,5 @@ jobs:
                 source aws-credentials/.env
                 aws glue start-workflow-run \
                   --name "cv-vulnerable-people-daily-wave-two-pipeline-staging"
+                aws glue start-workflow-run \
+                  --name "wave2-mvp-reporting-data-daily-pipeline-staging"

--- a/concourse_dev/tasks/get-gatling-tester-aws-creds.yml
+++ b/concourse_dev/tasks/get-gatling-tester-aws-creds.yml
@@ -1,0 +1,38 @@
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: governmentpaas/awscli
+    tag: latest
+inputs:
+  - name: git-dev
+params:
+  ACCOUNT_ID:
+  ENVIRONMENT:
+  REGION:
+  DURATION: 1800
+outputs:
+  - name: aws-credentials
+run:
+  path: ash
+  args:
+    - -c
+    - |
+      set -euo pipefail
+
+      echo "Assuming concourse gatling tester role"
+      target_arn="arn:aws:iam::${ACCOUNT_ID}:role/concourse-gatling-tester-${ENVIRONMENT}"
+
+      temp_role=$(aws sts assume-role \
+                  --role-arn "${target_arn}" \
+                  --role-session-name "concourse-task" \
+                  --duration-seconds $DURATION)
+
+      # Store the lambda exec role AWS credentials to be restored
+      echo "Writing .env file to aws-credentials"
+      cat > aws-credentials/.env <<EOF
+      export AWS_ACCESS_KEY_ID=$(echo $temp_role | jq -r '.Credentials.AccessKeyId')
+      export AWS_SECRET_ACCESS_KEY=$(echo $temp_role | jq -r '.Credentials.SecretAccessKey')
+      export AWS_SESSION_TOKEN=$(echo $temp_role | jq -r '.Credentials.SessionToken')
+      export AWS_DEFAULT_REGION=${REGION:-eu-west-2}
+      EOF


### PR DESCRIPTION
Add get-gatling-tester-aws-creds.yml task definition to retrieve
credentials for the gatling load tester IAM role.