### PR TITLE
Hide back link when changing answers

### DIFF
--- a/tests/shared/test_render.py
+++ b/tests/shared/test_render.py
@@ -32,11 +32,38 @@ def test_render_template_with_title_invokes_render_template_with_correct_argumen
                                                 ga_tracking_id="ga-id",
                                                 ga_cross_domain_tracking_id="cd-ga-id",
                                                 cookie_preferences_set=False,
+                                                form_base_template="base-with-back-link.html",
                                                 **{
                                                     "nhs_user": expected_nhs_user_value,
                                                     "button_text": expected_button_text,
                                                     "previous_path": "/date-of-birth",
                                                     "values": {"postcode": "LS1 1BA"}
+                                                })
+
+
+@pytest.mark.parametrize("session_variables, expected_nhs_user_value, expected_button_text",
+                         [({"nhs_sub": "value"}, True, "Continue"),
+                          ({"accessing_saved_answers": True}, False, "Save and continue")])
+def test_render_template_with_title_invokes_render_template_with_correct_form_base_template(
+        session_variables, expected_nhs_user_value, expected_button_text):
+    with patch("vulnerable_people_form.form_pages.shared.render.render_template") as mock_render_template, \
+         _current_app.test_request_context('/?ca=1'):
+        render_template_with_title(
+            "date-of-birth.html",
+            previous_path="/name",
+            values={"day": "10", "month": "12", "year": "1987"})
+
+        mock_render_template.assert_called_with("date-of-birth.html",
+                                                title_text="What is your date of birth?",
+                                                ga_tracking_id="ga-id",
+                                                ga_cross_domain_tracking_id="cd-ga-id",
+                                                cookie_preferences_set=False,
+                                                form_base_template="base.html",
+                                                **{
+                                                    "nhs_user": False,
+                                                    "button_text": "Continue",
+                                                    "previous_path": "/name",
+                                                    "values": {"day": "10", "month": "12", "year": "1987"}
                                                 })
 
 

--- a/tests/shared/test_session.py
+++ b/tests/shared/test_session.py
@@ -279,4 +279,4 @@ def test_persist_answers_from_session():
 def _make_summary_row_assertions(summary_row, key, expected_value, is_html=False, expected_text=None):
     assert summary_row["key"]["text"] == (PAGE_TITLES[key] if expected_text is None else expected_text)
     assert summary_row["value"]["html" if is_html else "text"] == expected_value
-    assert summary_row["actions"]["items"][0]["href"] == "/" + key
+    assert summary_row["actions"]["items"][0]["href"] == f"/{key}?ca=1"

--- a/vulnerable_people_form/form_pages/shared/render.py
+++ b/vulnerable_people_form/form_pages/shared/render.py
@@ -11,6 +11,7 @@ def render_template_with_title(template_name, *args, **kwargs):
     cookie_prefs_value = request.cookies.get("cookies_preferences_set")
     cookies_preferences_set = cookie_prefs_value is not None and cookie_prefs_value.lower() == "true"
     cross_domain_tracking_id = current_app.config.get("GA_CROSS_DOMAIN_TRACKING_ID")
+    is_changing_form_answer = request.args.get("ca") and request.args["ca"] == "1"
     return render_template(
         template_name,
         *args,
@@ -18,6 +19,7 @@ def render_template_with_title(template_name, *args, **kwargs):
         ga_tracking_id=current_app.config.get("GA_TRACKING_ID"),
         ga_cross_domain_tracking_id=cross_domain_tracking_id if cross_domain_tracking_id is not None else "",
         cookie_preferences_set=cookies_preferences_set,
+        form_base_template="base.html" if is_changing_form_answer else "base-with-back-link.html",
         **{
             "nhs_user": session.get("nhs_sub") is not None,
             "button_text": "Save and continue" if accessing_saved_answers() else "Continue",

--- a/vulnerable_people_form/form_pages/shared/session.py
+++ b/vulnerable_people_form/form_pages/shared/session.py
@@ -122,7 +122,7 @@ def get_summary_rows_from_form_answers(exclude_answers=None):
             "actions": {
                 "items": [
                     {
-                        "href": f"/{dashed_key}",
+                        "href": f"/{dashed_key}?ca=1",
                         "text": "Change",
                         "visuallyHiddenText": question,
                     }

--- a/vulnerable_people_form/templates/form-base.html
+++ b/vulnerable_people_form/templates/form-base.html
@@ -1,7 +1,7 @@
 {%- from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary -%}
 {%- from 'govuk_frontend_jinja/components/button/macro.html' import govukButton -%}
 
-{% extends "base-with-back-link.html" %}
+{% extends form_base_template %}
 
 {% block centered_content %}
     <form method="post" novalidate>


### PR DESCRIPTION
Given a user has arrived at either the /check-your-answers
or /view-answers page when they click the 'Change' link then
the form page  'Back' link should not be present.
As the user should simply be changing a single answer at a time.

The implementation utilises a query string param entitled ca
(changing answer). When the query string param ca=1 is present
the form-base.html template will extend the base.html template
rather than the usual base-with-back-link.html template.