### PR TITLE
Correct postcode input validation (regex)

### DIFF
--- a/tests/shared/test_validation.py
+++ b/tests/shared/test_validation.py
@@ -263,7 +263,7 @@ def test_validate_postcode_should_return_false_when_no_postcode_present(postcode
             == "What is the postcode where you need support?"
 
 
-@pytest.mark.parametrize("postcode", [" ", "invalid_post_code", "ssss 12345"])
+@pytest.mark.parametrize("postcode", [" ", "invalid_post_code", "ssss 12345", "LS1 1AB ABC"])
 def test_validate_postcode_should_return_false_when_invalid_postcode_present(postcode):
     with _current_app.test_request_context() as test_request_ctx:
         is_valid = validation.validate_postcode(postcode, "postcode")

--- a/vulnerable_people_form/form_pages/shared/validation.py
+++ b/vulnerable_people_form/form_pages/shared/validation.py
@@ -205,7 +205,7 @@ def validate_date_of_birth():
 
 def validate_postcode(postcode, error_section_name):
     postcode.replace(" ", "")
-    postcode_regex = "(([A-Z]{1,2}[0-9][A-Z0-9]?|ASCN|STHL|TDCU|BBND|[BFS]IQQ|PCRN|TKCA) ?[0-9][A-Z]{2}|BFPO ?[0-9]{1,4}|(KY[0-9]|MSR|VG|AI)[ -]?[0-9]{4}|[A-Z]{2} ?[0-9]{2}|GE ?CX|GIR ?0A{2}|SAN ?TA1)"  # noqa: E501
+    postcode_regex = "^(([A-Z]{1,2}[0-9][A-Z0-9]?|ASCN|STHL|TDCU|BBND|[BFS]IQQ|PCRN|TKCA) ?[0-9][A-Z]{2}|BFPO ?[0-9]{1,4}|(KY[0-9]|MSR|VG|AI)[ -]?[0-9]{4}|[A-Z]{2} ?[0-9]{2}|GE ?CX|GIR ?0A{2}|SAN ?TA1)$"  # noqa: E501
     error = None
     if not postcode:
         error = "What is the postcode where you need support?"


### PR DESCRIPTION
The postcode validation regex was missing the start ( ^ )
and end ( $ ) characters. Therefore, it was possible to get
the validation to pass by entering a valid postcode followed
by any random characters.

The input validation erroneously allowed invalid postcodes to be
passed to the postcode eligibility check stored procedure
resulting in an error.