### PR TITLE
Fix navigation error for returning user

### DIFF
--- a/vulnerable_people_form/form_pages/shared/routing.py
+++ b/vulnerable_people_form/form_pages/shared/routing.py
@@ -197,4 +197,4 @@ def dynamic_back_url(default="/"):
 
 
 def get_back_url_for_shopping_assistance():
-    return "/address-lookup" if session[SESSION_KEY_ADDRESS_SELECTED] else "/support-address"
+    return "/address-lookup" if session.get(SESSION_KEY_ADDRESS_SELECTED) else "/support-address"


### PR DESCRIPTION
Given a user has signed in using NHS login after
a submission when they view their and answers and
use the 'change' link to modify their address then
an error occurs due to a session value not being
present.

The error has been corrected by using the 'get'
function on the session dict to handle the scenario
where the key is not present.