### PR TITLE
Limit content length of SMS notifications

### DIFF
--- a/vulnerable_people_form/integrations/notification_content.py
+++ b/vulnerable_people_form/integrations/notification_content.py
@@ -2,6 +2,8 @@ from flask import render_template
 
 from vulnerable_people_form.form_pages.shared.session import form_answers, is_nhs_login_user
 
+_GOVUK_NOTIFY_SMS_CHAR_LIMIT = 918
+
 
 def create_spl_no_match_email_content(reference_number):
     return render_template(
@@ -15,14 +17,21 @@ def create_spl_no_match_email_content(reference_number):
 
 
 def create_spl_no_match_sms_content(reference_number):
-    return render_template(
-        "_spl_no_match_sms_template.txt",
-        first_name=form_answers()["name"]["first_name"],
-        last_name=form_answers()["name"]["last_name"],
-        reference_number=reference_number,
-        has_someone_to_shop=form_answers().get("do_you_have_someone_to_go_shopping_for_you"),
-        told_to_shield=form_answers()["nhs_letter"],
-    ).replace("\n", "")
+    context = {
+        "first_name": form_answers()["name"]["first_name"],
+        "last_name": form_answers()["name"]["last_name"],
+        "reference_number": reference_number,
+        "has_someone_to_shop": form_answers().get("do_you_have_someone_to_go_shopping_for_you"),
+        "told_to_shield": form_answers()["nhs_letter"]
+    }
+    rendered_template = render_template(
+        "_spl_no_match_sms_template.txt", **context).replace("\n", "")
+
+    if len(rendered_template) > _GOVUK_NOTIFY_SMS_CHAR_LIMIT:
+        rendered_template = render_template(
+            "_spl_no_match_sms_template_succinct.txt", **context).replace("\n", "")
+
+    return rendered_template
 
 
 def create_spl_no_match_letter_content(reference_number):
@@ -50,16 +59,24 @@ def create_spl_match_email_content(reference_number):
 
 
 def create_spl_match_sms_content(reference_number):
-    return render_template(
-        "_spl_match_sms_template.txt",
-        first_name=form_answers()["name"]["first_name"],
-        last_name=form_answers()["name"]["last_name"],
-        reference_number=reference_number,
-        has_someone_to_shop=form_answers().get("do_you_have_someone_to_go_shopping_for_you"),
-        wants_supermarket_deliveries=form_answers().get("priority_supermarket_deliveries"),
-        wants_social_care=form_answers().get("basic_care_needs"),
-        has_set_up_account=is_nhs_login_user(),
-    ).replace("\n", "")
+    context = {
+        "first_name": form_answers()["name"]["first_name"],
+        "last_name": form_answers()["name"]["last_name"],
+        "reference_number": reference_number,
+        "has_someone_to_shop": form_answers().get("do_you_have_someone_to_go_shopping_for_you"),
+        "wants_supermarket_deliveries": form_answers().get("priority_supermarket_deliveries"),
+        "wants_social_care": form_answers().get("basic_care_needs"),
+        "has_set_up_account": is_nhs_login_user()
+    }
+
+    rendered_template = render_template(
+        "_spl_match_sms_template.txt", **context).replace("\n", "")
+
+    if len(rendered_template) > _GOVUK_NOTIFY_SMS_CHAR_LIMIT:
+        rendered_template = render_template(
+            "_spl_match_sms_template_succinct.txt", **context).replace("\n", "")
+
+    return rendered_template
 
 
 def create_spl_match_letter_content(reference_number):

--- a/vulnerable_people_form/templates/_spl_match_sms_template_succinct.txt
+++ b/vulnerable_people_form/templates/_spl_match_sms_template_succinct.txt
@@ -1,0 +1,34 @@
+Your registration for the shielding service is {{reference_number}}.
+
+{% if not has_someone_to_shop %}
+ Contact your local authority if you need urgent help: www.gov.uk/coronavirus-local-help
+{% endif %}
+
+{% if wants_supermarket_deliveries and wants_social_care %}
+ You should be able to start booking priority supermarket deliveries in the next 1 to 7 days, depending on the supermarket. If you do not already have an account with a supermarket, set one up now. You can set up accounts with more than one supermarket.
+ Someone from your local authority will contact you about your care needs within the next week.
+{% endif %}
+
+{% if wants_supermarket_deliveries and not wants_social_care %}
+ You should be able to start booking priority supermarket deliveries in the next 1 to 7 days, depending on the supermarket. If you do not already have an account with a supermarket, set one up now. You can set up accounts with more than one supermarket.
+{% endif %}
+
+{% if not wants_supermarket_deliveries and wants_social_care %}
+ Someone from your local authority will contact you about your care needs within the next week.
+{% endif %}
+
+{% if not wants_supermarket_deliveries and not wants_social_care %}
+ Based on what you told us, at the moment you do not need help getting supplies or meeting your basic care needs.
+{% endif %}
+
+{% if has_set_up_account %}
+ Use your NHS login to update your personal details or support needs: www.gov.uk/coronavirus-shielding-support
+{% endif %}
+
+{% if not has_set_up_account %}
+ Go through the questions in the service again to update your personal details or support needs: www.gov.uk/coronavirus-shielding-support
+{% endif %}
+
+{% if has_someone_to_shop %}
+ Contact your local authority if you need support urgently and cannot rely on family, friends or neighbours: www.gov.uk/coronavirus-local-help
+{% endif %}

--- a/vulnerable_people_form/templates/_spl_no_match_sms_template_succinct.txt
+++ b/vulnerable_people_form/templates/_spl_no_match_sms_template_succinct.txt
@@ -1,0 +1,15 @@
+Your registration for the shielding service is {{reference_number}}.
+
+{% if told_to_shield == 1 %}
+ You'll only be able to get the support you need if you've given us the correct personal details. If you think you might have made a mistake, go through the questions again: www.gov.uk/coronavirus-shielding-support
+ You do not need to do anything else if you've been told to shield by the NHS or your doctor and they've put you on the NHS list of people who should be shielding.
+ We’ll check your details, then contact you to confirm whether you’re eligible for support. You will not start getting support until we’ve confirmed that you’re eligible. This can take up to 2 weeks.
+{% endif %}
+
+{% if told_to_shield == 2 or told_to_shield == 3 %}
+ Contact your GP or hospital clinician as soon as possible so they can put you on the NHS list of people who should be shielding. You may not get the support you need if you do not contact them.
+ You'll only be able to get the support you need if you've given us the correct personal details. If you think you might have made a mistake, go through the questions again: www.gov.uk/coronavirus-shielding-support
+ We'll check your details, then contact you to confirm whether you're eligible for support. This can take up to 2 weeks from when your GP or hospital clinician puts you on the NHS list of people who should be shielding.
+{% endif %}
+
+ Contact your local authority if you need support urgently and cannot rely on family, friends or neighbours: www.gov.uk/coronavirus-local-help


### PR DESCRIPTION
If a user enters a long first name and last name
then it's possible that the GOVUK Notify service
would return an error due to the max content length
being exceeded when attempting to send an SMS.

An alternate, more succinct SMS template is now used when
the SMS content length exceeds the 918 character limit.