### PR TITLE
Fix (intermittent) failing e2e test

### DIFF
--- a/behave/features/1.e2e_journey_no_nhs_login.feature
+++ b/behave/features/1.e2e_journey_no_nhs_login.feature
@@ -3,43 +3,43 @@
 Feature: COVID-19 Shielded vulnerable people service - basic e2e user journey - no NHS login
     Scenario: can load homepage
         When you navigate to "/"
-        Then wait "5" seconds
+        Then wait up to "30" seconds until element with selector ".govuk-fieldset__heading" is present
         Then the content of element with selector ".govuk-fieldset__heading" equals "Are you using this service for yourself or for someone else?"
 
     Scenario: Should be re-directed to nhs-login when yes answered to applying on own behalf
         Given I am on the "applying-on-own-behalf" page
         When I click the ".govuk-radios__item input[value='0']" element
         And I submit the form
-        Then wait "2" seconds
+        Then wait "3" seconds
         Then I am redirected to the "nhs-login" page
 
     Scenario: Should be re-directed to postcode eligibility when no answered to nhs login
         Given I am on the "nhs-login" page
         When I click the ".govuk-radios__item input[value='0']" element
         And I submit the form
-        Then wait "2" seconds
+        Then wait "3" seconds
         Then I am redirected to the "postcode-eligibility" page
 
     Scenario: Should be re-directed to shielding because vulnerable when eligible postcode entered
         Given I am on the "postcode-eligibility" page
         When I give the "#postcode" field the value "BB1 1TA"
         And I submit the form
-        Then wait "2" seconds
+        Then wait "3" seconds
         Then I am redirected to the "nhs-letter" page
 
     Scenario: Should be re-directed to nhs number when yes answered to told to shield
         Given I am on the "nhs-letter" page
         When I click the ".govuk-radios__item input[value='1']" element
         And I submit the form
-        Then wait "2" seconds
+        Then wait "3" seconds
         Then I am redirected to the "nhs-number" page
 
     Scenario: Should be re-directed to name entry when valid nhs number entered
         Given I am on the "nhs-number" page
-        # This is passes the NHS number checksum but will never be assigned to a real person
+        # This passes the NHS number checksum but will never be assigned to a real person
         When I give the "#nhs_number" field the value "1116432455"
         And I submit the form
-        Then wait "2" seconds
+        Then wait "3" seconds
         Then I am redirected to the "name" page
 
     Scenario: Should be re-directed to date of birth when first name and last name entered
@@ -47,7 +47,7 @@ Feature: COVID-19 Shielded vulnerable people service - basic e2e user journey - 
         When I give the "#first_name" field the value "Terry"
         And I give the "#last_name" field the value "Tester"
         And I submit the form
-        Then wait "2" seconds
+        Then wait "3" seconds
         Then I am redirected to the "date-of-birth" page
 
     Scenario: Should be re-directed to address lookup when valid date of birth entered
@@ -56,53 +56,53 @@ Feature: COVID-19 Shielded vulnerable people service - basic e2e user journey - 
         And I give the "#date_of_birth-month" field the value "05"
         And I give the "#date_of_birth-year" field the value "2006"
         And I submit the form
-        Then wait "2" seconds
+        Then wait "3" seconds
         Then I am redirected to the "address-lookup" page
 
     Scenario: Should be redirected to shopping assistance when an address is selected
         Given I am on the "address-lookup" page
         When I submit the form
-        Then wait "2" seconds
+        Then wait "3" seconds
         Then I am redirected to the "do-you-have-someone-to-go-shopping-for-you" page
 
     Scenario: Should be redirected to priority supermarket deliveries when no answered to shopping help
         Given I am on the "do-you-have-someone-to-go-shopping-for-you" page
         When I click the ".govuk-radios__item input[value='0']" element
         And I submit the form
-        Then wait "2" seconds
+        Then wait "3" seconds
         Then I am redirected to the "priority-supermarket-deliveries" page
 
     Scenario: Should be redirected to basic care needs when yes answered to priority shopping deliveries
         Given I am on the "priority-supermarket-deliveries" page
         When I click the ".govuk-radios__item input[value='1']" element
         And I submit the form
-        Then wait "2" seconds
+        Then wait "3" seconds
         Then I am redirected to the "basic-care-needs" page
 
     Scenario: Should be redirected to contact details when no answered to basic care needs help
         Given I am on the "basic-care-needs" page
         When I click the ".govuk-radios__item input[value='0']" element
         And I submit the form
-        Then wait "2" seconds
+        Then wait "3" seconds
         Then I am redirected to the "contact-details" page
 
     Scenario: Should be redirected to check contact details when email entered
         Given I am on the "contact-details" page
         When I give the "#email" field the value "coronavirus-services-smoke-tests@digital.cabinet-office.gov.uk"
         And I submit the form
-        Then wait "2" seconds
+        Then wait "3" seconds
         Then I am redirected to the "check-contact-details" page
 
     Scenario: Should be redirected to check-your-answers when form submitted
         Given I am on the "check-contact-details" page
         When I submit the form
-        Then wait "2" seconds
+        Then wait "3" seconds
         Then I am redirected to the "check-your-answers" page
 
     Scenario: Should be redirected to confirmation when no answered to basic care needs help
         Given I am on the "check-your-answers" page
         When I submit the form
-        Then wait "2" seconds
+        Then wait "3" seconds
         Then I am redirected to the "confirmation" page
 
 

--- a/behave/features/steps/general.py
+++ b/behave/features/steps/general.py
@@ -2,6 +2,9 @@ import time
 import os
 
 from behave import then, when, given
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions
+from selenium.webdriver.support.wait import WebDriverWait
 
 _BASE_URL = os.environ["WEB_APP_BASE_URL"]
 
@@ -9,6 +12,12 @@ _BASE_URL = os.environ["WEB_APP_BASE_URL"]
 @then('wait "{seconds}" seconds')
 def wait_step(context, seconds):
     time.sleep(int(seconds))
+
+
+@then('wait up to "{timeout_seconds}" seconds until element with selector "{element_css_selector}" is present')
+def wait_until_element_present(context, timeout_seconds, element_css_selector):
+    WebDriverWait(context.browser, int(timeout_seconds)).until(
+        expected_conditions.presence_of_element_located((By.CSS_SELECTOR, element_css_selector)))
 
 
 @when('you navigate to "{path}"')


### PR DESCRIPTION
An intermittent e2e test failure has been occurring
due to it not being possible to find an element and
verify it's inner text.

A delay of up to 30 seconds has now been added
to wait for the element to be present before
checking it's contents.