### PR TITLE
Implement local authority query string param

### DIFF
--- a/tests/shared/test_querystring_utils.py
+++ b/tests/shared/test_querystring_utils.py
@@ -1,0 +1,50 @@
+import pytest
+
+from vulnerable_people_form.form_pages.shared.constants import SESSION_KEY_QUERYSTRING_PARAMS
+from vulnerable_people_form.form_pages.shared.querystring_utils import (
+    get_querystring_params_to_retain,
+    append_querystring_params
+)
+
+from flask import Flask
+
+_current_app = Flask(__name__)
+_current_app.secret_key = 'test_secret'
+
+
+def test_get_querystring_params_to_retain_should_return_empty_dict_when_no_relevant_querystring_params_present():
+    with _current_app.test_request_context("/"):
+        params_to_retain = get_querystring_params_to_retain()
+        assert len(params_to_retain) == 0
+
+
+def test_get_querystring_params_to_retain_should_return_dict_with_la_param():
+    with _current_app.test_request_context("/test?irrelevant=1&la=1"):
+        params_to_retain = get_querystring_params_to_retain()
+        assert len(params_to_retain) == 1
+        assert params_to_retain["la"] == "1"
+
+
+@pytest.mark.parametrize("initial_url, expected_output", [
+    ("/next-page", "/next-page?la=3"),
+    ("/next-page?another-param=1", "/next-page?another-param=1&la=3")
+])
+def test_append_querystring_params_should_append_la_param_when_present_in_request_args(
+    initial_url, expected_output
+):
+    with _current_app.test_request_context("/test?irrelevant=1&la=3"):
+        url = append_querystring_params(initial_url)
+        assert url == expected_output
+
+
+def test_append_querystring_params_should_not_append_la_param_when_already_present():
+    with _current_app.test_request_context("/test?irrelevant=1&la=3"):
+        url = append_querystring_params("/next-page?la=4")
+        assert url == "/next-page?la=4"
+
+
+def test_append_querystring_params_should_append_la_param_when_present_in_session():
+    with _current_app.test_request_context("/test?irrelevant=1") as test_request_ctx:
+        test_request_ctx.session[SESSION_KEY_QUERYSTRING_PARAMS] = {"la": "5"}
+        url = append_querystring_params("/next-page")
+        assert url == "/next-page?la=5"

--- a/vulnerable_people_form/__init__.py
+++ b/vulnerable_people_form/__init__.py
@@ -9,6 +9,7 @@ from prometheus_flask_exporter import PrometheusMetrics
 from sentry_sdk.integrations.flask import FlaskIntegration
 
 from . import form_pages
+from vulnerable_people_form.form_pages.shared.querystring_utils import append_querystring_params
 from .integrations import nhs_openconnect_id, persistence
 
 _ENV_DEVELOPMENT = "DEVELOPMENT"
@@ -99,6 +100,8 @@ def create_app(scriptinfo):
         ),
     )
 
+    app.context_processor(utility_processor)
+
     return app
 
 
@@ -130,3 +133,7 @@ def _init_security(app):
         content_security_policy=csp,
         content_security_policy_nonce_in=['script-src']
     )
+
+
+def utility_processor():
+    return dict(append_querystring_params=append_querystring_params)

--- a/vulnerable_people_form/form_pages/__init__.py
+++ b/vulnerable_people_form/form_pages/__init__.py
@@ -1,6 +1,7 @@
 # flake8: noqa
 
 from . import (
+    default,
     accessibility_statement,
     address_lookup,
     applying_on_own_behalf,

--- a/vulnerable_people_form/form_pages/address_lookup.py
+++ b/vulnerable_people_form/form_pages/address_lookup.py
@@ -5,6 +5,7 @@ from flask import redirect, session
 from ..integrations import postcode_lookup_helper
 from .blueprint import form
 from .shared.constants import SESSION_KEY_ADDRESS_SELECTED
+from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
 from .shared.session import get_errors_from_session, request_form, form_answers
@@ -43,7 +44,7 @@ def get_address_lookup():
 
     return render_template_with_title(
         "address-lookup.html",
-        previous_path="/date-of-birth",
+        previous_path=append_querystring_params("/date-of-birth"),
         postcode=postcode,
         addresses=addresses,
         **get_errors_from_session("postcode"),

--- a/vulnerable_people_form/form_pages/basic_care_needs.py
+++ b/vulnerable_people_form/form_pages/basic_care_needs.py
@@ -1,7 +1,8 @@
 from flask import redirect
 
-from .shared.answers_enums import get_radio_options_from_enum, BasicCareNeedsAnswers
 from .blueprint import form
+from .shared.answers_enums import get_radio_options_from_enum, BasicCareNeedsAnswers
+from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
 from .shared.session import (
@@ -14,11 +15,13 @@ from .shared.validation import validate_basic_care_needs
 
 @form.route("/basic-care-needs", methods=["GET"])
 def get_basic_care_needs():
+    prev_path = "/priority-supermarket-deliveries" \
+        if form_answers().get("priority_supermarket_deliveries") is not None \
+        else "/do-you-have-someone-to-go-shopping-for-you"
+    prev_path = append_querystring_params(prev_path)
     return render_template_with_title(
         "basic-care-needs.html",
-        previous_path="/priority-supermarket-deliveries"
-        if form_answers().get("priority_supermarket_deliveries") is not None
-        else "/do-you-have-someone-to-go-shopping-for-you",
+        previous_path=prev_path,
         radio_items=get_radio_options_from_enum(BasicCareNeedsAnswers, form_answers().get("basic_care_needs")),
         **get_errors_from_session("basic_care_needs"),
     )

--- a/vulnerable_people_form/form_pages/blueprint.py
+++ b/vulnerable_people_form/form_pages/blueprint.py
@@ -1,3 +1,5 @@
+from http import HTTPStatus
+
 from flask import (
     Blueprint,
     redirect,
@@ -5,6 +7,12 @@ from flask import (
     session,
 )
 from flask_wtf.csrf import CSRFError
+
+from vulnerable_people_form.form_pages.shared.constants import SESSION_KEY_QUERYSTRING_PARAMS
+from vulnerable_people_form.form_pages.shared.querystring_utils import (
+    append_querystring_params,
+    get_querystring_params_to_retain
+)
 
 form = Blueprint("form", __name__)
 
@@ -14,11 +22,20 @@ def redirect_to_first_page():
     if not session.get("form_started"):
         session.clear()
         session["form_started"] = True
+
+        querystring_params = get_querystring_params_to_retain()
+        if querystring_params:
+            session[SESSION_KEY_QUERYSTRING_PARAMS] = querystring_params
+
         return redirect("/applying-on-own-behalf")
 
 
 @form.after_request
 def add_caching_headers(response):
+    if response.status_code == HTTPStatus.FOUND:
+        redirect_location = append_querystring_params(response.headers['Location'])
+        response = redirect(redirect_location)
+
     response.headers["Cache-Control"] = "no-store"
     response.headers["Pragma"] = "no-cache"
     return response

--- a/vulnerable_people_form/form_pages/check_contact_details.py
+++ b/vulnerable_people_form/form_pages/check_contact_details.py
@@ -1,6 +1,7 @@
 from flask import redirect, session
 
 from .blueprint import form
+from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
 from .shared.session import form_answers, get_errors_from_session, request_form
@@ -11,7 +12,7 @@ from .shared.validation import validate_contact_details
 def get_check_contact_details():
     return render_template_with_title(
         "check-contact-details.html",
-        previous_path="/contact-details",
+        previous_path=append_querystring_params("/contact-details"),
         values=form_answers().get("contact_details", {}),
         button_text="This is correct",
         **get_errors_from_session("check_contact_details"),

--- a/vulnerable_people_form/form_pages/contact_details.py
+++ b/vulnerable_people_form/form_pages/contact_details.py
@@ -2,6 +2,7 @@ import phonenumbers
 from flask import redirect, session
 
 from .blueprint import form
+from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
 from .shared.session import form_answers, get_errors_from_session, request_form
@@ -22,7 +23,7 @@ def format_phone_number_if_valid(phone_number):
 def get_contact_details():
     return render_template_with_title(
         "contact-details.html",
-        previous_path="/basic-care-needs",
+        previous_path=append_querystring_params("/basic-care-needs"),
         values=form_answers().get("contact_details", {}),
         **get_errors_from_session("contact_details"),
     )

--- a/vulnerable_people_form/form_pages/date_of_birth.py
+++ b/vulnerable_people_form/form_pages/date_of_birth.py
@@ -1,6 +1,7 @@
 from flask import redirect, session
 
 from .blueprint import form
+from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
 from .shared.session import form_answers, get_errors_from_session, request_form
@@ -11,7 +12,7 @@ from .shared.validation import validate_date_of_birth
 def get_date_of_birth():
     return render_template_with_title(
         "date-of-birth.html",
-        previous_path="/name",
+        previous_path=append_querystring_params("/name"),
         values=form_answers().get("date_of_birth", {}),
         **get_errors_from_session("date_of_birth"),
     )

--- a/vulnerable_people_form/form_pages/default.py
+++ b/vulnerable_people_form/form_pages/default.py
@@ -1,0 +1,26 @@
+from vulnerable_people_form.form_pages.shared.constants import SESSION_KEY_QUERYSTRING_PARAMS
+from vulnerable_people_form.form_pages.shared.querystring_utils import get_querystring_params_to_retain
+from .blueprint import form
+from flask import session, redirect
+
+
+@form.route("/", methods=["GET"])
+def get_default_route():
+    return _clear_session_and_create_redirect_response()
+
+
+@form.route("/start", methods=["GET"])
+def get_start():
+    return _clear_session_and_create_redirect_response()
+
+
+def _clear_session_and_create_redirect_response():
+    session.clear()
+    _populate_session_with_querystring_params_to_retain()
+    return redirect("/applying-on-own-behalf")
+
+
+def _populate_session_with_querystring_params_to_retain():
+    querystring_params = get_querystring_params_to_retain()
+    if querystring_params:
+        session[SESSION_KEY_QUERYSTRING_PARAMS] = querystring_params

--- a/vulnerable_people_form/form_pages/medical_conditions.py
+++ b/vulnerable_people_form/form_pages/medical_conditions.py
@@ -2,6 +2,7 @@ from flask import redirect
 
 from .shared.answers_enums import MedicalConditionsAnswers, get_radio_options_from_enum
 from .blueprint import form
+from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
 from .shared.session import (
@@ -25,6 +26,6 @@ def get_medical_conditions():
     return render_template_with_title(
         "medical-conditions.html",
         radio_items=get_radio_options_from_enum(MedicalConditionsAnswers, form_answers().get("medical_conditions")),
-        previous_path="/nhs-letter",
+        previous_path=append_querystring_params("/nhs-letter"),
         **get_errors_from_session("medical_conditions"),
     )

--- a/vulnerable_people_form/form_pages/name.py
+++ b/vulnerable_people_form/form_pages/name.py
@@ -1,6 +1,7 @@
 from flask import redirect, session
 
 from .blueprint import form
+from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
 from .shared.session import form_answers, get_errors_from_session, request_form
@@ -12,7 +13,7 @@ def get_name():
     return render_template_with_title(
         "name.html",
         values=form_answers().get("name", {}),
-        previous_path="/nhs-number",
+        previous_path=append_querystring_params("/nhs-number"),
         **get_errors_from_session("name"),
     )
 

--- a/vulnerable_people_form/form_pages/nhs_letter.py
+++ b/vulnerable_people_form/form_pages/nhs_letter.py
@@ -1,7 +1,8 @@
 from flask import redirect
 
-from .shared.answers_enums import NHSLetterAnswers, get_radio_options_from_enum
 from .blueprint import form
+from .shared.answers_enums import NHSLetterAnswers, get_radio_options_from_enum
+from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
 from .shared.session import (
@@ -17,7 +18,7 @@ def get_nhs_letter():
     return render_template_with_title(
         "nhs-letter.html",
         radio_items=get_radio_options_from_enum(NHSLetterAnswers, form_answers().get("nhs_letter")),
-        previous_path="/postcode-eligibility",
+        previous_path=append_querystring_params("/postcode-eligibility"),
         **get_errors_from_session("nhs_letter"),
     )
 

--- a/vulnerable_people_form/form_pages/nhs_login.py
+++ b/vulnerable_people_form/form_pages/nhs_login.py
@@ -1,7 +1,8 @@
 from flask import redirect
 
-from .shared.answers_enums import YesNoAnswers, get_radio_options_from_enum
 from .blueprint import form
+from .shared.answers_enums import YesNoAnswers, get_radio_options_from_enum
+from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
 from .shared.session import (
@@ -17,7 +18,7 @@ def get_nhs_login():
     return render_template_with_title(
         "nhs-login.html",
         radio_items=get_radio_options_from_enum(YesNoAnswers, form_answers().get("nhs_login")),
-        previous_path="/applying-on-own-behalf",
+        previous_path=append_querystring_params("/applying-on-own-behalf"),
         **get_errors_from_session("nhs_login"),
     )
 

--- a/vulnerable_people_form/form_pages/nhs_login_callback.py
+++ b/vulnerable_people_form/form_pages/nhs_login_callback.py
@@ -36,15 +36,3 @@ def get_nhs_login_callback():
     set_form_answers_from_nhs_user_info(nhs_user_info)
 
     return redirect("postcode-eligibility")
-
-
-@form.route("/start", methods=["GET"])
-def get_start():
-    session.clear()
-    return redirect("/applying-on-own-behalf")
-
-
-@form.route("/", methods=["GET"])
-def get_default_route():
-    session.clear()
-    return redirect("/applying-on-own-behalf")

--- a/vulnerable_people_form/form_pages/nhs_login_landing.py
+++ b/vulnerable_people_form/form_pages/nhs_login_landing.py
@@ -2,6 +2,7 @@ from flask import current_app, session
 
 from .blueprint import form
 from .shared.render import render_template_with_title
+from .shared.querystring_utils import append_querystring_params
 
 
 @form.route("/nhs-login-landing", methods=["GET"])
@@ -10,5 +11,5 @@ def get_nhs_login_landing():
     return render_template_with_title(
         "nhs-login-landing.html",
         nhs_login_href=current_app.nhs_oidc_client.get_authorization_url(),
-        continue_url="/applying-on-own-behalf"
+        continue_url=append_querystring_params("/applying-on-own-behalf")
     )

--- a/vulnerable_people_form/form_pages/nhs_login_link.py
+++ b/vulnerable_people_form/form_pages/nhs_login_link.py
@@ -1,6 +1,7 @@
 from flask import current_app
 
 from vulnerable_people_form.form_pages.shared.render import render_template_with_title
+from vulnerable_people_form.form_pages.shared.routing import dynamic_back_url
 from .blueprint import form
 
 
@@ -8,6 +9,6 @@ from .blueprint import form
 def get_nhs_login_link():
     return render_template_with_title(
         "nhs-login-link.html",
-        previous_path="/nhs-login",
+        previous_path=dynamic_back_url(),
         nhs_login_href=current_app.nhs_oidc_client.get_authorization_url(),
     )

--- a/vulnerable_people_form/form_pages/nhs_login_no_consent.py
+++ b/vulnerable_people_form/form_pages/nhs_login_no_consent.py
@@ -1,4 +1,5 @@
 from vulnerable_people_form.form_pages.shared.render import render_template_with_title
+from vulnerable_people_form.form_pages.shared.querystring_utils import append_querystring_params
 from .blueprint import form
 
 
@@ -6,7 +7,7 @@ from .blueprint import form
 def get_nhs_login_no_consent():
     return render_template_with_title(
         "nhs-login-no-consent.html",
-        continue_url="/postcode-eligibility",
+        continue_url=append_querystring_params("/postcode-eligibility"),
         hint_text="You can still register, then decide to share your NHS login information later."
     )
 
@@ -15,6 +16,6 @@ def get_nhs_login_no_consent():
 def get_nhs_login_no_consent_registration():
     return render_template_with_title(
         "nhs-login-no-consent.html",
-        continue_url="/nhs-number",
+        continue_url=append_querystring_params("/nhs-number"),
         hint_text="This means you will need to enter an NHS number."
     )

--- a/vulnerable_people_form/form_pages/nhs_number.py
+++ b/vulnerable_people_form/form_pages/nhs_number.py
@@ -1,6 +1,7 @@
 from flask import redirect, session
 
 from .blueprint import form
+from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
 from .shared.session import (
@@ -17,6 +18,8 @@ def get_nhs_number():
     previous_path = "/nhs-letter"
     if get_answer_from_form(("medical_conditions",)) is not None:
         previous_path = "/medical-conditions"
+
+    previous_path = append_querystring_params(previous_path)
     return render_template_with_title(
         "nhs-number.html",
         previous_path=previous_path,

--- a/vulnerable_people_form/form_pages/nhs_registration.py
+++ b/vulnerable_people_form/form_pages/nhs_registration.py
@@ -1,8 +1,9 @@
 from flask import current_app
 
-from vulnerable_people_form.form_pages.shared.constants import JourneyProgress
-from .shared.answers_enums import YesNoAnswers, get_radio_options_from_enum
 from .blueprint import form
+from .shared.answers_enums import YesNoAnswers, get_radio_options_from_enum
+from .shared.constants import JourneyProgress
+from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
 from .shared.session import form_answers, get_errors_from_session
 
@@ -13,6 +14,6 @@ def get_nhs_registration():
         "nhs-registration.html",
         radio_items=get_radio_options_from_enum(YesNoAnswers, form_answers().get("nhs_registration")),
         nhs_registration_href=current_app.nhs_oidc_client.get_registration_url(JourneyProgress.NHS_REGISTRATION),
-        previous_path="/basic-care-needs",
+        previous_path=append_querystring_params("/basic-care-needs"),
         **get_errors_from_session("nhs_registration"),
     )

--- a/vulnerable_people_form/form_pages/nhs_registration_link.py
+++ b/vulnerable_people_form/form_pages/nhs_registration_link.py
@@ -1,6 +1,7 @@
 from flask import current_app
 
 from vulnerable_people_form.form_pages.shared.constants import JourneyProgress
+from vulnerable_people_form.form_pages.shared.querystring_utils import append_querystring_params
 from vulnerable_people_form.form_pages.shared.render import render_template_with_title
 from vulnerable_people_form.form_pages.shared.routing import dynamic_back_url
 from .blueprint import form
@@ -12,5 +13,5 @@ def get_nhs_registration_link():
         "nhs-registration-link.html",
         previous_path=dynamic_back_url(),
         nhs_registration_href=current_app.nhs_oidc_client.get_registration_url(JourneyProgress.NHS_NUMBER),
-        continue_url="/applying-on-own-behalf"
+        continue_url=append_querystring_params("/applying-on-own-behalf")
     )

--- a/vulnerable_people_form/form_pages/postcode_eligibility.py
+++ b/vulnerable_people_form/form_pages/postcode_eligibility.py
@@ -1,7 +1,8 @@
 from flask import redirect, session
 
-from vulnerable_people_form.form_pages.shared.answers_enums import ApplyingOnOwnBehalfAnswers
 from .blueprint import form
+from .shared.answers_enums import ApplyingOnOwnBehalfAnswers
+from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
 from .shared.session import get_errors_from_session, request_form, get_answer_from_form
@@ -17,7 +18,7 @@ def get_postcode_eligibility():
         prev_path = "/applying-on-own-behalf"
     else:
         raise ValueError("Unexpected ApplyingOnOwnBehalfAnswers value encountered: " + applying_on_own_behalf_answer)
-
+    prev_path = append_querystring_params(prev_path)
     return render_template_with_title(
         "postcode-eligibility.html",
         previous_path=prev_path,

--- a/vulnerable_people_form/form_pages/postcode_lookup.py
+++ b/vulnerable_people_form/form_pages/postcode_lookup.py
@@ -1,6 +1,7 @@
 from flask import redirect, session
 
 from .blueprint import form
+from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
 from .shared.session import get_errors_from_session, request_form
@@ -21,7 +22,7 @@ def post_postcode_lookup():
 def get_postcode_lookup():
     return render_template_with_title(
         "postcode-lookup.html",
-        previous_path="/address-lookup",
+        previous_path=append_querystring_params("/address-lookup"),
         values={"postcode": session.get("postcode", "")},
         **get_errors_from_session("postcode"),
     )

--- a/vulnerable_people_form/form_pages/priority_supermarket_deliveries.py
+++ b/vulnerable_people_form/form_pages/priority_supermarket_deliveries.py
@@ -1,10 +1,11 @@
 from flask import redirect
 
+from .blueprint import form
 from .shared.answers_enums import (
     PrioritySuperMarketDeliveriesAnswers,
     get_radio_options_from_enum,
 )
-from .blueprint import form
+from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
 from .shared.session import (
@@ -23,7 +24,7 @@ def get_priority_supermarket_deliveries():
             PrioritySuperMarketDeliveriesAnswers,
             form_answers().get("priority_supermarket_deliveries"),
         ),
-        previous_path="/do-you-have-someone-to-go-shopping-for-you",
+        previous_path=append_querystring_params("/do-you-have-someone-to-go-shopping-for-you"),
         **get_errors_from_session("priority_supermarket_deliveries"),
     )
 

--- a/vulnerable_people_form/form_pages/shared/constants.py
+++ b/vulnerable_people_form/form_pages/shared/constants.py
@@ -64,6 +64,7 @@ NHS_USER_INFO_TO_FORM_ANSWERS = {
 }
 
 SESSION_KEY_ADDRESS_SELECTED = "auto_populated_address_selected"
+SESSION_KEY_QUERYSTRING_PARAMS = "querystring_params_to_retain"
 
 
 @enum.unique

--- a/vulnerable_people_form/form_pages/shared/querystring_utils.py
+++ b/vulnerable_people_form/form_pages/shared/querystring_utils.py
@@ -1,0 +1,36 @@
+from flask import request, session
+
+from vulnerable_people_form.form_pages.shared.constants import SESSION_KEY_QUERYSTRING_PARAMS
+
+_QUERY_STRING_PARAMS_TO_RETAIN = ["la"]  # local authority query string param key
+
+
+def append_querystring_params(initial_url):
+    output_url = initial_url
+    session_querystring_params_to_retain = session.get(SESSION_KEY_QUERYSTRING_PARAMS)
+    for query_str_param_key in _QUERY_STRING_PARAMS_TO_RETAIN:
+        if f"{query_str_param_key}=" in initial_url:
+            continue
+        if query_str_param_key in request.args:
+            output_url = _add_querystring_param_to_url(output_url,
+                                                       query_str_param_key,
+                                                       request.args[query_str_param_key])
+        elif session_querystring_params_to_retain and query_str_param_key in session_querystring_params_to_retain:
+            output_url = _add_querystring_param_to_url(output_url,
+                                                       query_str_param_key,
+                                                       session_querystring_params_to_retain[query_str_param_key])
+
+    return output_url
+
+
+def get_querystring_params_to_retain():
+    output = {}
+    for query_str_param in _QUERY_STRING_PARAMS_TO_RETAIN:
+        if query_str_param in request.args:
+            output[query_str_param] = request.args[query_str_param]
+    return output
+
+
+def _add_querystring_param_to_url(url, key, value):
+    prefix_char = "&" if ("?" in url or "&" in url) else "?"
+    return f"{url}{prefix_char}{key}={value}"

--- a/vulnerable_people_form/form_pages/shared/routing.py
+++ b/vulnerable_people_form/form_pages/shared/routing.py
@@ -8,6 +8,7 @@ from .answers_enums import (
     YesNoAnswers,
 )
 from .constants import SESSION_KEY_ADDRESS_SELECTED
+from .querystring_utils import append_querystring_params
 from .session import (
     accessing_saved_answers,
     form_answers,
@@ -197,4 +198,5 @@ def dynamic_back_url(default="/"):
 
 
 def get_back_url_for_shopping_assistance():
-    return "/address-lookup" if session.get(SESSION_KEY_ADDRESS_SELECTED) else "/support-address"
+    back_url = "/address-lookup" if session.get(SESSION_KEY_ADDRESS_SELECTED) else "/support-address"
+    return append_querystring_params(back_url)

--- a/vulnerable_people_form/form_pages/shared/session.py
+++ b/vulnerable_people_form/form_pages/shared/session.py
@@ -9,6 +9,7 @@ from .answers_enums import (
     BasicCareNeedsAnswers
 )
 from .constants import PAGE_TITLES, NHS_USER_INFO_TO_FORM_ANSWERS
+from .querystring_utils import append_querystring_params
 from .security import sanitise_input
 
 from ...integrations import persistence
@@ -117,6 +118,7 @@ def get_summary_rows_from_form_answers(excluded_answers=None):
         question = answer_labels[dashed_key]
 
         change_answer_url = (f"/{change_answer_urls[key]}" if key in change_answer_urls else f"/{dashed_key}") + "?ca=1"
+        change_answer_url = append_querystring_params(change_answer_url)
 
         value = {}
         row = {

--- a/vulnerable_people_form/form_pages/support_address.py
+++ b/vulnerable_people_form/form_pages/support_address.py
@@ -2,6 +2,7 @@ from flask import redirect, session
 
 from .blueprint import form
 from .shared.constants import SESSION_KEY_ADDRESS_SELECTED
+from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
 from .shared.session import form_answers, get_errors_from_session, request_form
@@ -30,7 +31,7 @@ def get_support_address():
 
     return render_template_with_title(
         "support-address.html",
-        previous_path="/address-lookup",
+        previous_path=append_querystring_params("/address-lookup"),
         values=form_answers().get("support_address", {}),
         **get_errors_from_session("support_address"),
     )

--- a/vulnerable_people_form/templates/400.html
+++ b/vulnerable_people_form/templates/400.html
@@ -3,6 +3,6 @@
 {% block centered_content %}
     <h1 class="govuk-heading-l">Bad request</h1>
     <p class="govuk-body">
-        There was an issue with a request you made. In order to start a new session <a class="govuk-link" href="/start">click here</a>.
+        There was an issue with a request you made. In order to start a new session <a class="govuk-link" href="{{ append_querystring_params("/start") }}">click here</a>.
     </p>
 {% endblock %}

--- a/vulnerable_people_form/templates/address-lookup.html
+++ b/vulnerable_people_form/templates/address-lookup.html
@@ -11,7 +11,7 @@
   <h2 class="govuk-heading-m govuk-!-margin-top-0 govuk-!-margin-bottom-3">Postcode</h2>
 <p class="govuk-body">
 <span class="govuk-!-font-weight-bold govuk-!-padding-right-3">{{postcode}}</span>
-<a href="/postcode-lookup" class="govuk-link govuk-link--no-visited-state">change<span class="govuk-visually-hidden"> postcode</span></a>
+<a href="{{ append_querystring_params("/postcode-lookup") }}" class="govuk-link govuk-link--no-visited-state">change<span class="govuk-visually-hidden"> postcode</span></a>
 </p>
 {{ 
 govukSelect({
@@ -27,7 +27,7 @@ govukSelect({
   }) 
   }}
   <p class="govuk-body">
-    <a class="govuk-link" href="/support-address">My address isn't listed or is wrong</a>
+    <a class="govuk-link" href="{{ append_querystring_params("/support-address") }}">My address isn't listed or is wrong</a>
   </p>
 {% endblock %}
 {% block form_end %}

--- a/vulnerable_people_form/templates/analytics_cookie_banner.html
+++ b/vulnerable_people_form/templates/analytics_cookie_banner.html
@@ -20,14 +20,14 @@
               "classes": "govuk-!-margin-right-3 govuk-!-margin-bottom-2",
               "text": "No"
             }) }}
-          <a class="cookie-banner__link govuk-link govuk-body-m govuk-!-margin-bottom-0" href="/cookies">How this service uses cookies</a>
+          <a class="cookie-banner__link govuk-link govuk-body-m govuk-!-margin-bottom-0" href="{{ append_querystring_params("/cookies") }}">How this service uses cookies</a>
         </div>
 
       </div>
     </div>
   </div>
    <div class="cookie-banner__confirmation govuk-width-container govuk-!-padding-top-1" tabindex="-1">
-    <p class="cookie-banner__confirmation-message govuk-!-margin-top-0 govuk-!-margin-right-4 govuk-body" role="alert">You’ve accepted analytics cookies. You can <a class='govuk-link' href='/cookies'>change your cookie settings</a> at any time.</p>
+    <p class="cookie-banner__confirmation-message govuk-!-margin-top-0 govuk-!-margin-right-4 govuk-body" role="alert">You’ve accepted analytics cookies. You can <a class='govuk-link' href="{{ append_querystring_params("/cookies") }}">change your cookie settings</a> at any time.</p>
     <button class="cookie-banner__hide-button govuk-body-m govuk-!-margin-bottom-0" data-hide-cookie-banner="true" data-module="track-click" data-track-category="cookieBanner" data-track-action="Hide cookie banner">Hide</button>
   </div>
 </div>

--- a/vulnerable_people_form/templates/base.html
+++ b/vulnerable_people_form/templates/base.html
@@ -1,6 +1,6 @@
 {% extends 'govuk_frontend_jinja/template.html' %}
 
-{%- from 'analytics_cookie_banner.html' import obtain_cookie_consent %}
+{%- from 'analytics_cookie_banner.html' import obtain_cookie_consent with context %}
 {%- from 'govuk_frontend_jinja/components/footer/macro.html' import govukFooter -%}
 
 {% set assetPath = url_for('static', filename='').rstrip('/') %}
@@ -40,15 +40,15 @@
     'meta': {
       'items': [
         {
-          'href': "/privacy",
+          'href': append_querystring_params("/privacy"),
           'text': "Privacy"
         },
         {
-          'href': "/cookies",
+          'href': append_querystring_params("/cookies"),
           'text': "Cookies"
         },
         {
-          'href': "/accessibility-statement",
+          'href': append_querystring_params("/accessibility-statement"),
           'text': "Accessibility statement"
         },
         {

--- a/vulnerable_people_form/templates/nhs-number.html
+++ b/vulnerable_people_form/templates/nhs-number.html
@@ -31,7 +31,7 @@
 }}
 
 {% set applying_on_own_behalf_detail_html %}
-<p class="govuk-body">If you do not know your NHS number, you can <a class="govuk-link" href="/nhs-registration-link">try using NHS login</a> instead.</p>
+<p class="govuk-body">If you do not know your NHS number, you can <a class="govuk-link" href="{{ append_querystring_params("/nhs-registration-link") }}">try using NHS login</a> instead.</p>
 <p class="govuk-body">If you do not have an NHS number <a class="govuk-link" href="https://www.nhs.uk/using-the-nhs/nhs-services/gps/how-to-register-with-a-gp-practice/">register with a GP</a>  to get one.</p>
 <p class="govuk-body">You cannot use an old NHS number with fewer than 10 digits. Look on NHS letters or ask your GP to find your new NHS number.</p>
 {% endset %}

--- a/vulnerable_people_form/templates/nhs-registration.html
+++ b/vulnerable_people_form/templates/nhs-registration.html
@@ -22,7 +22,7 @@
   </div>
   {{ govukButton({
     "text": "Continue without an account",
-    "href": "/confirmation",
+    "href": append_querystring_params("/confirmation"),
     "classes": "govuk-!-width-one-third"
   }) }}
 {% endblock %}

--- a/vulnerable_people_form/templates/not-eligible-postcode.html
+++ b/vulnerable_people_form/templates/not-eligible-postcode.html
@@ -8,7 +8,7 @@
     {{ title_text }}
   </h1>
   <p class="govuk-body">You're not in an area where people are being advised to 'shield' at the moment.</p>
-  <p class="govuk-body">You can read <a class="govuk-link" href="https://www.gov.uk/coronavirus-extremely-vulnerable-guidance">general guidance on protecting yourself if you're clinically extremely vulnerable to coronavirus</a>.
+  <p class="govuk-body">You can read <a class="govuk-link" href="https://www.gov.uk/coronavirus-extremely-vulnerable-guidance">general guidance on protecting yourself if you're clinically extremely vulnerable to coronavirus</a>.</p>
   <p class="govuk-body">There’s also guidance if you live in:</p>
   <ul class="govuk-list govuk-list--bullet">
     <li><a class="govuk-link" href="https://www.health-ni.gov.uk/coronavirus">Northern Ireland</a></li>

--- a/vulnerable_people_form/templates/view-answers.html
+++ b/vulnerable_people_form/templates/view-answers.html
@@ -14,6 +14,6 @@
 
       {{ govukButton({
         "text": "Save and sign out",
-        "href": "/nhs-login-landing"
+        "href": append_querystring_params("/nhs-login-landing")
       }) }}
 {% endblock %}


### PR DESCRIPTION
A querystring parameter is required to capture the
fact that a local authority is completing the form
on behalf of a user.

A new query string parameter with the key 'la' has been
added and is retained (in the url) throughout the user
journey.