### PR TITLE
Add fix for automation tests (behave)

### DIFF
--- a/behave/features/1.e2e_journey_no_nhs_login.feature
+++ b/behave/features/1.e2e_journey_no_nhs_login.feature
@@ -2,7 +2,7 @@
 @e2e_happy_path_no_nhs_login
 Feature: COVID-19 Shielded vulnerable people service - basic e2e user journey - no NHS login
     Scenario: can load homepage
-        When you navigate to "/"
+        When you navigate to "/start"
         Then wait up to "30" seconds until element with selector ".govuk-fieldset__heading" is present
         Then the content of element with selector ".govuk-fieldset__heading" equals "Are you using this service for yourself or for someone else?"
 
@@ -10,28 +10,24 @@ Feature: COVID-19 Shielded vulnerable people service - basic e2e user journey - 
         Given I am on the "applying-on-own-behalf" page
         When I click the ".govuk-radios__item input[value='0']" element
         And I submit the form
-        Then wait "3" seconds
         Then I am redirected to the "nhs-login" page
 
     Scenario: Should be re-directed to postcode eligibility when no answered to nhs login
         Given I am on the "nhs-login" page
         When I click the ".govuk-radios__item input[value='0']" element
         And I submit the form
-        Then wait "3" seconds
         Then I am redirected to the "postcode-eligibility" page
 
     Scenario: Should be re-directed to shielding because vulnerable when eligible postcode entered
         Given I am on the "postcode-eligibility" page
         When I give the "#postcode" field the value "BB1 1TA"
         And I submit the form
-        Then wait "3" seconds
         Then I am redirected to the "nhs-letter" page
 
     Scenario: Should be re-directed to nhs number when yes answered to told to shield
         Given I am on the "nhs-letter" page
         When I click the ".govuk-radios__item input[value='1']" element
         And I submit the form
-        Then wait "3" seconds
         Then I am redirected to the "nhs-number" page
 
     Scenario: Should be re-directed to name entry when valid nhs number entered
@@ -39,7 +35,6 @@ Feature: COVID-19 Shielded vulnerable people service - basic e2e user journey - 
         # This passes the NHS number checksum but will never be assigned to a real person
         When I give the "#nhs_number" field the value "1116432455"
         And I submit the form
-        Then wait "3" seconds
         Then I am redirected to the "name" page
 
     Scenario: Should be re-directed to date of birth when first name and last name entered
@@ -47,7 +42,6 @@ Feature: COVID-19 Shielded vulnerable people service - basic e2e user journey - 
         When I give the "#first_name" field the value "Terry"
         And I give the "#last_name" field the value "Tester"
         And I submit the form
-        Then wait "3" seconds
         Then I am redirected to the "date-of-birth" page
 
     Scenario: Should be re-directed to address lookup when valid date of birth entered
@@ -56,53 +50,45 @@ Feature: COVID-19 Shielded vulnerable people service - basic e2e user journey - 
         And I give the "#date_of_birth-month" field the value "05"
         And I give the "#date_of_birth-year" field the value "2006"
         And I submit the form
-        Then wait "3" seconds
         Then I am redirected to the "address-lookup" page
 
     Scenario: Should be redirected to shopping assistance when an address is selected
         Given I am on the "address-lookup" page
         When I submit the form
-        Then wait "3" seconds
         Then I am redirected to the "do-you-have-someone-to-go-shopping-for-you" page
 
     Scenario: Should be redirected to priority supermarket deliveries when no answered to shopping help
         Given I am on the "do-you-have-someone-to-go-shopping-for-you" page
         When I click the ".govuk-radios__item input[value='0']" element
         And I submit the form
-        Then wait "3" seconds
         Then I am redirected to the "priority-supermarket-deliveries" page
 
     Scenario: Should be redirected to basic care needs when yes answered to priority shopping deliveries
         Given I am on the "priority-supermarket-deliveries" page
         When I click the ".govuk-radios__item input[value='1']" element
         And I submit the form
-        Then wait "3" seconds
         Then I am redirected to the "basic-care-needs" page
 
     Scenario: Should be redirected to contact details when no answered to basic care needs help
         Given I am on the "basic-care-needs" page
         When I click the ".govuk-radios__item input[value='0']" element
         And I submit the form
-        Then wait "3" seconds
         Then I am redirected to the "contact-details" page
 
     Scenario: Should be redirected to check contact details when email entered
         Given I am on the "contact-details" page
         When I give the "#email" field the value "coronavirus-services-smoke-tests@digital.cabinet-office.gov.uk"
         And I submit the form
-        Then wait "3" seconds
         Then I am redirected to the "check-contact-details" page
 
     Scenario: Should be redirected to check-your-answers when form submitted
         Given I am on the "check-contact-details" page
         When I submit the form
-        Then wait "3" seconds
         Then I am redirected to the "check-your-answers" page
 
     Scenario: Should be redirected to confirmation when no answered to basic care needs help
         Given I am on the "check-your-answers" page
         When I submit the form
-        Then wait "3" seconds
         Then I am redirected to the "confirmation" page
 
 

--- a/behave/features/steps/general.py
+++ b/behave/features/steps/general.py
@@ -9,6 +9,12 @@ from selenium.webdriver.support.wait import WebDriverWait
 _BASE_URL = os.environ["WEB_APP_BASE_URL"]
 
 
+@then('I am redirected to the "{next_page_url}" page')
+def wait_until_url_present(context, next_page_url):
+    WebDriverWait(context.browser, 30).until(
+        expected_conditions.url_to_be(f"{_BASE_URL}/{next_page_url}"))
+
+
 @then('wait "{seconds}" seconds')
 def wait_step(context, seconds):
     time.sleep(int(seconds))
@@ -53,11 +59,6 @@ def set_element_value(context, css_selector, element_value):
 @when('I submit the form')
 def submit_the_form(context):
     click_element(context, "button[type='Submit']")
-
-
-@then('I am redirected to the "{expected_page}" page')
-def verify_the_current_url_matches_the_expected_url(context, expected_page):
-    assert context.browser.current_url == f"{_BASE_URL}/{expected_page}"
 
 
 @when('I enter the value "{value}" in the field with name "{field_name}"')


### PR DESCRIPTION
Intermittently the behave tests would fail to run all scenarios which could be due hitting a server with a cold start. A new method has been added to explicitly wait for the page to redirect and not rely on waiting 3 seconds per request.