### PR TITLE
Amend address-lookup back link (NHS login user)

### DIFF
--- a/vulnerable_people_form/form_pages/address_lookup.py
+++ b/vulnerable_people_form/form_pages/address_lookup.py
@@ -8,7 +8,7 @@ from .shared.constants import SESSION_KEY_ADDRESS_SELECTED
 from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
-from .shared.session import get_errors_from_session, request_form, form_answers
+from .shared.session import get_errors_from_session, request_form, form_answers, is_nhs_login_user
 from .shared.validation import validate_address_lookup
 
 
@@ -42,9 +42,11 @@ def get_address_lookup():
         }
         return redirect("/support-address")
 
+    prev_path = append_querystring_params("/nhs-letter" if is_nhs_login_user() else "/date-of-birth")
+
     return render_template_with_title(
         "address-lookup.html",
-        previous_path=append_querystring_params("/date-of-birth"),
+        previous_path=prev_path,
         postcode=postcode,
         addresses=addresses,
         **get_errors_from_session("postcode"),

--- a/vulnerable_people_form/form_pages/shared/render.py
+++ b/vulnerable_people_form/form_pages/shared/render.py
@@ -1,7 +1,7 @@
-from flask import render_template, session, current_app, request
+from flask import render_template, current_app, request
 
 from .constants import PAGE_TITLES
-from .session import accessing_saved_answers
+from .session import accessing_saved_answers, is_nhs_login_user
 
 
 def render_template_with_title(template_name, *args, **kwargs):
@@ -21,7 +21,7 @@ def render_template_with_title(template_name, *args, **kwargs):
         cookie_preferences_set=cookies_preferences_set,
         form_base_template="base.html" if is_changing_form_answer else "base-with-back-link.html",
         **{
-            "nhs_user": session.get("nhs_sub") is not None,
+            "nhs_user": is_nhs_login_user(),
             "button_text": "Save and continue" if accessing_saved_answers() else "Continue",
             **kwargs,
         },


### PR DESCRIPTION
Given a user signs in to their NHS login account and
continues through the journey to the /address-lookup
page, when they click the back link it erroneously
navigates them to the /date-of-birth page.

The assignment of the URL for the back link now takes
into consideration if the user is an NHS login user.
Only non NHS login users are now directed to the
/date-of-birth page.