### PR TITLE
change git-dev ref to git-master in gatling-workflow-load-test.yml

### DIFF
--- a/concourse/tasks/gatling-workflow-load-test.yml
+++ b/concourse/tasks/gatling-workflow-load-test.yml
@@ -33,4 +33,4 @@ run:
         -Dgatling.data.charting.indicators.lowerBound=1000 \
         -Dgatling.data.charting.indicators.higherBound=1500 \
 
-  dir: git-dev
+  dir: git-master


### PR DESCRIPTION
Replace reference to dev resource (git-dev) with reference to
prod resource (git-master) in concourse task definition file
gatling-workflow-load-test.yml. This change needed to make the
thing run!