### PR TITLE
Add PROD environment (automated) smoke test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,13 @@ concourse_e2e:
 	behave behave/features/ --tags='@e2e_happy_path_no_nhs_login' --stop
 
 smoke_test:
+ifeq ($(ENV),PRODUCTION)
+	@echo "Executing smoke test without submission..."
+	behave behave/features/ --tags='@e2e_happy_path_no_nhs_login_no_submission' --stop
+else
 	@echo "Executing smoke tests..."
 	behave behave/features/ --tags='@e2e_happy_path_no_nhs_login' --stop
+endif
 
 test_e2e_local:
 	@echo "Executing e2e automated tests against the local environment..."

--- a/behave/features/2.e2e_journey_no_nhs_login_and_no_submission.feature
+++ b/behave/features/2.e2e_journey_no_nhs_login_and_no_submission.feature
@@ -1,5 +1,5 @@
 # COVID-19 -
-@e2e_happy_path_no_nhs_login
+@e2e_happy_path_no_nhs_login_no_submission
 Feature: COVID-19 Shielded vulnerable people service - basic e2e user journey - no NHS login
     Scenario: can load homepage
         When you navigate to "/start"
@@ -84,11 +84,3 @@ Feature: COVID-19 Shielded vulnerable people service - basic e2e user journey - 
         Given I am on the "check-contact-details" page
         When I submit the form
         Then I am redirected to the "check-your-answers" page
-
-    Scenario: Should be redirected to confirmation when no answered to basic care needs help
-        Given I am on the "check-your-answers" page
-        When I submit the form
-        Then I am redirected to the "confirmation" page
-
-
-

--- a/behave/features/environment.py
+++ b/behave/features/environment.py
@@ -8,13 +8,15 @@ from selenium.webdriver.chrome.options import Options
 def before_all(context):
     chrome_options = Options()
     chrome_options.binary = "bin/headless-chromium"
-    chrome_options.add_argument("-headless")
-    chrome_options.add_argument("--no-sandbox")
+    chrome_options.headless = True
+    chrome_options.add_argument("--no-sandbox")  # Bypass OS security model
     chrome_options.add_argument("--single-process")
     chrome_options.add_argument("--disable-dev-shm-usage")
+    chrome_options.add_argument("window-size=1200,800")
 
     context.browser = webdriver.Chrome(options=chrome_options)
-    context.browser.set_page_load_timeout(time_to_wait=200)
+    context.browser.set_page_load_timeout(time_to_wait=30)
+    context.browser.delete_all_cookies()
 
     context.config.setup_logging(os.environ.get("LOG_LEVEL", "ERROR"))
     context.logger = logging.getLogger("behave")

--- a/concourse/tasks/smoke-test.yml
+++ b/concourse/tasks/smoke-test.yml
@@ -20,5 +20,5 @@ run:
     - -c
     - |
       echo "running smoke tests against \"${WEB_APP_BASE_URL}\""
-      make smoke_test
+      make smoke_test ENV="${ENVIRONMENT}"
   dir: git-master


### PR DESCRIPTION
A smoke test for the production environment is required
that will not record a submission to the PROD database.

A new behave feature file has been added for the happy
path journey that progresses to the /check-your-answers
page (just prior to persisting answers to the database).

The Makefile and the concourse smoke-test.yml have been
updated accordingly.