### PR TITLE
Simplify smoke test execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,8 @@ concourse_e2e:
 	behave behave/features/1.e2e_journey_no_nhs_login.feature --stop
 
 smoke_test:
-ifeq ($(ENV),PRODUCTION)
 	@echo "Executing smoke test without submission..."
 	behave behave/features/2.e2e_journey_no_nhs_login_and_no_submission.feature --stop
-else
-	@echo "Executing smoke tests..."
-	behave behave/features/1.e2e_journey_no_nhs_login.feature --stop
-endif
 
 test_e2e_local:
 	@echo "Executing e2e automated tests against the local environment..."

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -111,7 +111,6 @@ jobs:
         params:
           WEB_APP_BASE_URL: "https://gds-shielded-vulnerable-people-service-staging.london.cloudapps.digital"
           MESSAGE: "Checks that the application deployed to staging is not serving HTTP error codes"
-          ENVIRONMENT: STAGING
         on_failure: *slack_alert_on_failure
 
   - name: e2e-test-staging
@@ -175,7 +174,6 @@ jobs:
         params:
           WEB_APP_BASE_URL: "https://coronavirus-shielding-support.service.gov.uk"
           MESSAGE: "Checks that the application deployed to production is not serving HTTP error codes"
-          ENVIRONMENT: PRODUCTION
         on_failure: *slack_alert_on_failure
         on_success: *slack_alert_on_success
 
@@ -189,7 +187,6 @@ jobs:
         params:
           WEB_APP_BASE_URL: "https://gds-shielded-vulnerable-people-service-staging.london.cloudapps.digital"
           MESSAGE: "Checks that the application deployed to staging is not serving HTTP error codes"
-          ENVIRONMENT: STAGING
         on_failure: *slack_alert_on_failure
       - task: cronitor-heartbeat
         timeout: 1m
@@ -207,7 +204,6 @@ jobs:
         params:
           WEB_APP_BASE_URL: "https://coronavirus-shielding-support.service.gov.uk"
           MESSAGE: "Checks that the application deployed to production is not serving HTTP error codes"
-          ENVIRONMENT: PRODUCTION
         on_failure: *slack_alert_on_failure
       - task: cronitor-heartbeat
         timeout: 1m

--- a/concourse/tasks/smoke-test.yml
+++ b/concourse/tasks/smoke-test.yml
@@ -20,5 +20,5 @@ run:
     - -c
     - |
       echo "running smoke tests against \"${WEB_APP_BASE_URL}\""
-      make smoke_test ENV="${ENVIRONMENT}"
+      make smoke_test
   dir: git-master


### PR DESCRIPTION
The e2e-test-staging job is now the only job that
persists data and the smoke tests simply navigate
through the journey until the /check-answers page.