### PR TITLE
Update gatling tests for MI

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -300,5 +300,3 @@ jobs:
                 source aws-credentials/.env
                 aws glue start-workflow-run \
                   --name "cv-vulnerable-people-daily-wave-two-pipeline-staging"
-                aws glue start-workflow-run \
-                  --name "wave2-mvp-reporting-data-daily-pipeline-staging"

--- a/concourse/tasks/gatling-workflow-load-test.yml
+++ b/concourse/tasks/gatling-workflow-load-test.yml
@@ -25,7 +25,7 @@ run:
       cd loadtests
       mvn gatling:test \
         -DinjectUsersPerSecond=36 \
-        -DinjectDurationSeconds=1200 \
+        -DinjectDurationSeconds=1800 \
         -DpauseBetweenRequestsInSeconds=1 \
         -DnumberOfRepetitions=1 \
         -Dgatling.simulationClass=svp.SvpSimulationConstantUsersPerSec \


### PR DESCRIPTION
We have a better idea of what are MI pipeline looks like now.

It will run right after our main pipeline so we no longer need
to trigger a job (and that job was not the correct one).

Also the total pipeline will take longer, so load test for
30 mins instead of 20.