### PR TITLE
Update continuous smoke tests to run every minute

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ concourse_e2e:
 	behave behave/features/1.e2e_journey_no_nhs_login.feature --stop
 
 smoke_test:
+	sleep 10
 	@echo "Executing smoke test without submission..."
 	behave behave/features/2.e2e_journey_no_nhs_login_and_no_submission.feature --stop
 

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -179,7 +179,7 @@ jobs:
 
   - name: continuous-smoke-test-staging
     plan:
-      - get: every-10m
+      - get: every-1m
         trigger: true
       - get: git-master
       - task: smoke-test


### PR DESCRIPTION
Updated pipeline to run the continuous smoke tests every minute and also added in a 10 second sleep to try fix the intermittent issue with test failures