### PR TITLE
Add sleep before behave test execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ concourse_e2e:
 	behave behave/features/1.e2e_journey_no_nhs_login.feature --stop
 
 smoke_test:
-	sleep 10
 	@echo "Executing smoke test without submission..."
 	behave behave/features/2.e2e_journey_no_nhs_login_and_no_submission.feature --stop
 

--- a/concourse/tasks/e2e-test.yml
+++ b/concourse/tasks/e2e-test.yml
@@ -23,5 +23,6 @@ run:
     - |
       echo "running e2e tests against staging..."
       root=$(pwd)
+      sleep 10
       make concourse_e2e
   dir: git-master

--- a/concourse/tasks/smoke-test.yml
+++ b/concourse/tasks/smoke-test.yml
@@ -20,5 +20,6 @@ run:
     - -c
     - |
       echo "running smoke tests against \"${WEB_APP_BASE_URL}\""
+      sleep 10
       make smoke_test
   dir: git-master


### PR DESCRIPTION
Added a sleep before running the continuous and e2e tests to allow concourse to complete successfully as it turns out there is an intermittent issue were the tests would fail without reason when running in concourse.