### PR TITLE
847/scale web form in response to failing load tests

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,8 +1,9 @@
 ---
 applications:
 - name: govuk-coronavirus-shielded-vulnerable-people-form
+    instances: 4
   buildpack: python_buildpack
-  memory: 1G
+  memory: 2G
   services:
     - svp-form-splunk-service
   env:

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: govuk-coronavirus-shielded-vulnerable-people-form
-    instances: 4
+  instances: 4
   buildpack: python_buildpack
   memory: 2G
   services:


### PR DESCRIPTION
Change CF settings to increase memory and instances of app

Given failing Gatling load tests, increase instances to 4 (from 1) and memory
from 1G to 2G to test improvement on performance