### PR TITLE
Revert "847/scale web form in response to failing load tests"

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,9 +1,8 @@
 ---
 applications:
 - name: govuk-coronavirus-shielded-vulnerable-people-form
-  instances: 4
   buildpack: python_buildpack
-  memory: 2G
+  memory: 1G
   services:
     - svp-form-splunk-service
   env:


### PR DESCRIPTION
Reverts alphagov/govuk-shielded-vulnerable-people-service#91
Turns out these instance numbers were being set in the Concourse task (overriding those set in this manifest), so it tried to create 50 instances each with 2GB memory, which exceeded our PaaS quota. Reverting this change.