### PR TITLE
Lower prod instances temporarily for gatling staging test

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -140,7 +140,7 @@ jobs:
         file: git-master/concourse/tasks/deploy-to-govuk-paas.yml
         params:
           CF_SPACE: prod
-          INSTANCES: 30
+          INSTANCES: 20
           CF_STARTUP_TIMEOUT: 15 # minutes
           HOSTNAME: gds-shielded-vulnerable-people-service-prod
           GOVUK_NOTIFY_SPL_MATCH_EMAIL_TEMPLATE_ID: a951e38f-1dbb-4732-9cdc-ea611785c607


### PR DESCRIPTION
We want to test app in staging with same number of instances as well have for
prod, need to decrease prod number of instances temporarily so we can do this
without exceeding quota