### PR TITLE
847 Reduce load to around 100 page requests per second

### DIFF
--- a/concourse/tasks/gatling-workflow-load-test.yml
+++ b/concourse/tasks/gatling-workflow-load-test.yml
@@ -25,7 +25,8 @@ run:
       mvn gatling:test \
         -DinjectUsersPerSecond=4 \
         -DinjectDurationSeconds=1800 \
-        -DpauseBetweenRequestsInSeconds=1 \
+        -DpauseBetweenRequestsInSecondsMax=1 \
+        -DpauseBetweenRequestsInSecondsMin=1 \
         -DnumberOfRepetitions=1 \
         -Dgatling.simulationClass=svp.SvpSimulationConstantUsersPerSec \
         -Dgatling.data.writers.0=file \

--- a/concourse/tasks/gatling-workflow-load-test.yml
+++ b/concourse/tasks/gatling-workflow-load-test.yml
@@ -16,15 +16,14 @@ run:
     - -euo
     - pipefail
     - -c
-    # User journey is 16 requests long, and we want close to 1000 req/s, so inject 1000/16 users/s here (63),
-    # with a pause of 1 second between requests.
-    # Run simulation for 30 mins (1800s) to ensure workflow execution time is covered.
+    # 4 users per second causes around 100 page requests/s which is our current non-functional requirement. 
+    # Run simulation for 30 mins (1800s) to ensure workflow + mi workflow execution time is covered.
     # Suppress html file output (doesn't seem possible to completely remove file output...)
     # Suppress console log to final report only (done by turning off console writer)
     - |
       cd loadtests
       mvn gatling:test \
-        -DinjectUsersPerSecond=36 \
+        -DinjectUsersPerSecond=4 \
         -DinjectDurationSeconds=1800 \
         -DpauseBetweenRequestsInSeconds=1 \
         -DnumberOfRepetitions=1 \


### PR DESCRIPTION
We need to simulate 100 user simulataenous users (not total web
requests). This change tries to hit this requirement rather than trying
to hit 1000 requests per second (as this is hard to tell from gatling,
and can cause confusion).

Also make the pause between request time (1 seconds) be picked up by the tests.