### PR TITLE
Increase automated test coverage

### DIFF
--- a/behave/features/3.e2e_with_la_query_string_param.feature
+++ b/behave/features/3.e2e_with_la_query_string_param.feature
@@ -1,86 +1,91 @@
 # COVID-19 -
-@e2e_happy_path_no_nhs_login_no_submission
-Feature: COVID-19 Shielded vulnerable people service - basic e2e user journey - no NHS login & no record submission
+@e2e_happy_path_no_nhs_login_with_la_param
+Feature: COVID-19 Shielded vulnerable people service - basic e2e user journey - no NHS login
     Scenario: can load homepage
-        When you navigate to "/start"
+        When you navigate to "/start?la=1"
         Then the content of element with selector ".govuk-fieldset__heading" equals "Are you using this service for yourself or for someone else?"
 
     Scenario: Should be re-directed to nhs-login when yes answered to applying on own behalf
-        Given I am on the "applying-on-own-behalf" page
+        Given I am on the "applying-on-own-behalf?la=1" page
         When I click the ".govuk-radios__item input[value='0']" element
         And I submit the form
-        Then I am redirected to the "nhs-login" page
+        Then I am redirected to the "nhs-login?la=1" page
 
     Scenario: Should be re-directed to postcode eligibility when no answered to nhs login
-        Given I am on the "nhs-login" page
+        Given I am on the "nhs-login?la=1" page
         When I click the ".govuk-radios__item input[value='0']" element
         And I submit the form
-        Then I am redirected to the "postcode-eligibility" page
+        Then I am redirected to the "postcode-eligibility?la=1" page
 
     Scenario: Should be re-directed to shielding because vulnerable when eligible postcode entered
-        Given I am on the "postcode-eligibility" page
+        Given I am on the "postcode-eligibility?la=1" page
         When I give the "#postcode" field the value "BB1 1TA"
         And I submit the form
-        Then I am redirected to the "nhs-letter" page
+        Then I am redirected to the "nhs-letter?la=1" page
 
     Scenario: Should be re-directed to nhs number when yes answered to told to shield
-        Given I am on the "nhs-letter" page
+        Given I am on the "nhs-letter?la=1" page
         When I click the ".govuk-radios__item input[value='1']" element
         And I submit the form
-        Then I am redirected to the "nhs-number" page
+        Then I am redirected to the "nhs-number?la=1" page
 
     Scenario: Should be re-directed to name entry when valid nhs number entered
-        Given I am on the "nhs-number" page
+        Given I am on the "nhs-number?la=1" page
         # This passes the NHS number checksum but will never be assigned to a real person
         When I give the "#nhs_number" field the value "1116432455"
         And I submit the form
-        Then I am redirected to the "name" page
+        Then I am redirected to the "name?la=1" page
 
     Scenario: Should be re-directed to date of birth when first name and last name entered
-        Given I am on the "name" page
+        Given I am on the "name?la=1" page
         When I give the "#first_name" field the value "Terry"
         And I give the "#last_name" field the value "Tester"
         And I submit the form
-        Then I am redirected to the "date-of-birth" page
+        Then I am redirected to the "date-of-birth?la=1" page
 
     Scenario: Should be re-directed to address lookup when valid date of birth entered
-        Given I am on the "date-of-birth" page
+        Given I am on the "date-of-birth?la=1" page
         When I give the "#date_of_birth-day" field the value "08"
         And I give the "#date_of_birth-month" field the value "05"
         And I give the "#date_of_birth-year" field the value "2006"
         And I submit the form
-        Then I am redirected to the "address-lookup" page
+        Then I am redirected to the "address-lookup?la=1" page
 
     Scenario: Should be redirected to shopping assistance when an address is selected
-        Given I am on the "address-lookup" page
+        Given I am on the "address-lookup?la=1" page
         When I submit the form
-        Then I am redirected to the "do-you-have-someone-to-go-shopping-for-you" page
+        Then I am redirected to the "do-you-have-someone-to-go-shopping-for-you?la=1" page
 
     Scenario: Should be redirected to priority supermarket deliveries when no answered to shopping help
-        Given I am on the "do-you-have-someone-to-go-shopping-for-you" page
+        Given I am on the "do-you-have-someone-to-go-shopping-for-you?la=1" page
         When I click the ".govuk-radios__item input[value='0']" element
         And I submit the form
-        Then I am redirected to the "priority-supermarket-deliveries" page
+        Then I am redirected to the "priority-supermarket-deliveries?la=1" page
 
     Scenario: Should be redirected to basic care needs when yes answered to priority shopping deliveries
-        Given I am on the "priority-supermarket-deliveries" page
+        Given I am on the "priority-supermarket-deliveries?la=1" page
         When I click the ".govuk-radios__item input[value='1']" element
         And I submit the form
-        Then I am redirected to the "basic-care-needs" page
+        Then I am redirected to the "basic-care-needs?la=1" page
 
     Scenario: Should be redirected to contact details when no answered to basic care needs help
-        Given I am on the "basic-care-needs" page
+        Given I am on the "basic-care-needs?la=1" page
         When I click the ".govuk-radios__item input[value='0']" element
         And I submit the form
-        Then I am redirected to the "contact-details" page
+        Then I am redirected to the "contact-details?la=1" page
 
     Scenario: Should be redirected to check contact details when email entered
-        Given I am on the "contact-details" page
+        Given I am on the "contact-details?la=1" page
         When I give the "#email" field the value "coronavirus-services-smoke-tests@digital.cabinet-office.gov.uk"
         And I submit the form
-        Then I am redirected to the "check-contact-details" page
+        Then I am redirected to the "check-contact-details?la=1" page
 
     Scenario: Should be redirected to check-your-answers when form submitted
-        Given I am on the "check-contact-details" page
+        Given I am on the "check-contact-details?la=1" page
         When I submit the form
-        Then I am redirected to the "check-your-answers" page
+        Then I am redirected to the "check-your-answers?la=1" page
+
+    Scenario: Should be redirected to confirmation when no answered to basic care needs help
+        Given I am on the "check-your-answers?la=1" page
+        When I submit the form
+        Then I am redirected to the "confirmation?la=1" page

--- a/behave/features/4.not_eligible_medical.feature
+++ b/behave/features/4.not_eligible_medical.feature
@@ -1,0 +1,36 @@
+# COVID-19 -
+@e2e_partial_journey
+Feature: COVID-19 Shielded vulnerable people service - partial user journey - no medical conditions
+    Scenario: can load homepage
+        When you navigate to "/start"
+        Then the content of element with selector ".govuk-fieldset__heading" equals "Are you using this service for yourself or for someone else?"
+
+    Scenario: Should be re-directed to nhs-login when yes answered to applying on own behalf
+        Given I am on the "applying-on-own-behalf" page
+        When I click the ".govuk-radios__item input[value='0']" element
+        And I submit the form
+        Then I am redirected to the "nhs-login" page
+
+    Scenario: Should be re-directed to postcode eligibility when no answered to nhs login
+        Given I am on the "nhs-login" page
+        When I click the ".govuk-radios__item input[value='0']" element
+        And I submit the form
+        Then I am redirected to the "postcode-eligibility" page
+
+    Scenario: Should be re-directed to shielding because vulnerable when eligible postcode entered
+        Given I am on the "postcode-eligibility" page
+        When I give the "#postcode" field the value "BB1 1TA"
+        And I submit the form
+        Then I am redirected to the "nhs-letter" page
+
+    Scenario: Should be re-directed to nhs number when yes answered to told to shield
+        Given I am on the "nhs-letter" page
+        When I click the ".govuk-radios__item input[value='2']" element
+        And I submit the form
+        Then I am redirected to the "medical-conditions" page
+
+    Scenario: Should be re-directed to not eligible medical when no answered to medical conditions
+        Given I am on the "medical-conditions" page
+        When I click the ".govuk-radios__item input[value='0']" element
+        And I submit the form
+        Then I am redirected to the "not-eligible-medical" page

--- a/behave/features/5.not_eligible_postcode.feature
+++ b/behave/features/5.not_eligible_postcode.feature
@@ -1,0 +1,24 @@
+# COVID-19 -
+@e2e_partial_journey
+Feature: COVID-19 Shielded vulnerable people service - partial user journey - ineligible postcode
+    Scenario: can load homepage
+        When you navigate to "/start"
+        Then the content of element with selector ".govuk-fieldset__heading" equals "Are you using this service for yourself or for someone else?"
+
+    Scenario: Should be re-directed to nhs-login when yes answered to applying on own behalf
+        Given I am on the "applying-on-own-behalf" page
+        When I click the ".govuk-radios__item input[value='0']" element
+        And I submit the form
+        Then I am redirected to the "nhs-login" page
+
+    Scenario: Should be re-directed to postcode eligibility when no answered to nhs login
+        Given I am on the "nhs-login" page
+        When I click the ".govuk-radios__item input[value='0']" element
+        And I submit the form
+        Then I am redirected to the "postcode-eligibility" page
+
+    Scenario: Should be re-directed to not eligible postcode when unsupported postcode entered
+        Given I am on the "postcode-eligibility" page
+        When I give the "#postcode" field the value "LS1 1BA"
+        And I submit the form
+        Then I am redirected to the "not-eligible-postcode" page

--- a/behave/features/steps/general.py
+++ b/behave/features/steps/general.py
@@ -35,7 +35,7 @@ def assert_element_content_matches(context, element_css_selector, expected_eleme
 
 @given('I am on the "{expected_page}" page')
 def assert_on_specified_page(context, expected_page):
-    assert context.browser.current_url.startswith(f"{_BASE_URL}/{expected_page}")
+    assert context.browser.current_url == f"{_BASE_URL}/{expected_page}"
 
 
 @when('I click the "{css_selector}" element')


### PR DESCRIPTION
Initially, the behave tests were added as a starting
point for further tests to be added by QA team members.

Additional, automated tests have been added in relation
to the local authority query string parameter and the
ineligible for support journeys.