### PR TITLE
847 Temporary increase in gatling users

### DIFF
--- a/concourse/tasks/gatling-workflow-load-test.yml
+++ b/concourse/tasks/gatling-workflow-load-test.yml
@@ -20,10 +20,11 @@ run:
     # Run simulation for 30 mins (1800s) to ensure workflow + mi workflow execution time is covered.
     # Suppress html file output (doesn't seem possible to completely remove file output...)
     # Suppress console log to final report only (done by turning off console writer)
+    # Temporarily increase to 7 to test 200-ish users.
     - |
       cd loadtests
       mvn gatling:test \
-        -DinjectUsersPerSecond=4 \
+        -DinjectUsersPerSecond=7 \
         -DinjectDurationSeconds=1800 \
         -DpauseBetweenRequestsInSecondsMax=1 \
         -DpauseBetweenRequestsInSecondsMin=1 \


### PR DESCRIPTION
In order to see how we might do in extreme peaks of users
increase number of users to 7, which should be about 210 users
in flight at a time.