### PR TITLE
847 Make gatling tests save a zip file

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -245,9 +245,10 @@ jobs:
                     - |
                       set -euo pipefail
                       source aws-credentials/.env
+                      zip -r $(date +%FT%T).zip gatling-results 
                       aws s3 cp \
-                        gatling-results \
-                        s3://gds-ons-covid-19-system-test-results-staging/gatling/workflow-load-tests/$(date +%FT%T)/ \
+                        $(date +%FT%T).zip \
+                        s3://gds-ons-covid-19-system-test-results-staging/gatling/workflow-load-tests/ \
                         --recursive
             - task: clean-out-gatling-test-submissions-from-rds
               config:


### PR DESCRIPTION
To make it easier to download a gatling run, zip up the gatling test
output before uploading to s3