### PR TITLE
Make smoke test use not_eligible_postcode journey

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ concourse_e2e:
 
 smoke_test:
 	@echo "Executing smoke test without submission..."
-	behave behave/features/2.e2e_journey_no_nhs_login_and_no_submission.feature --stop
+	behave behave/features/5.not_eligible_postcode.feature --stop
 
 test_e2e_local:
 	@echo "Executing e2e automated tests against the local environment..."


### PR DESCRIPTION
The smoke test is using the e2e_journey_no_nhs_login_and_no_submission
behave journey, but that requires a valid postcode to exist in the
database and the OS Places API. This is difficult to do safely in prod
where real users might notice the postcode is eligible.

Make the smoke test use the not_eligible_postcode journey for now while
we work out how to cover a more complete journey safely in prod. This
will at least test the front end is up and responding and that the
`is_postcode_in_lockdown` database function is responding.