### PR TITLE
847 Use gzip instead of zip.

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -245,9 +245,9 @@ jobs:
                     - |
                       set -euo pipefail
                       source aws-credentials/.env
-                      zip -r $(date +%FT%T).zip gatling-results 
+                      tar zcvf $(date +%FT%T).tar.gz gatling-results 
                       aws s3 cp \
-                        $(date +%FT%T).zip \
+                        $(date +%FT%T).tar.gz \
                         s3://gds-ons-covid-19-system-test-results-staging/gatling/workflow-load-tests/ \
                         --recursive
             - task: clean-out-gatling-test-submissions-from-rds


### PR DESCRIPTION
Zip is not installed in the awscli docker image as standard.

Rather than having the image install zip, use gzip.

Example of a dummy run working in the awscli docker image.

```
/ # tar zcvf  gatling.tar.gz gatling-results
gatling-results/
gatling-results/blah
/ # ls
bin              etc              gatling.tar.gz

```