### PR TITLE
Strip spaces & hyphens from NHS number

### DIFF
--- a/tests/shared/test_form_utils.py
+++ b/tests/shared/test_form_utils.py
@@ -1,0 +1,28 @@
+import pytest
+
+from vulnerable_people_form.form_pages.shared.form_utils import clean_nhs_number
+
+
+@pytest.mark.parametrize("nhs_num", ["", None])
+def test_clean_nhs_number_should_return_empty_string_when_non_truthy_input_provided(nhs_num):
+    cleaned_nhs_number = clean_nhs_number(nhs_num)
+    assert cleaned_nhs_number is None
+
+
+@pytest.mark.parametrize("nhs_num, expected_output", [("123-123-1234-", "1231231234"), ("-123456-1234", "1234561234")])
+def test_clean_nhs_number_should_strip_hyphens_from_input(nhs_num, expected_output):
+    cleaned_nhs_number = clean_nhs_number(nhs_num)
+    assert cleaned_nhs_number == expected_output
+
+
+@pytest.mark.parametrize("nhs_num, expected_output", [("123 123 1234", "1231231234"), (" 123456 1234 ", "1234561234")])
+def test_clean_nhs_number_should_strip_whitespace_from_input(nhs_num, expected_output):
+    cleaned_nhs_number = clean_nhs_number(nhs_num)
+    assert cleaned_nhs_number == expected_output
+
+
+@pytest.mark.parametrize("nhs_num, expected_output",
+                         [("-123-123 1234 ", "1231231234"), ("-123456 123-4 ", "1234561234")])
+def test_clean_nhs_number_should_strip_whitespace_and_hyphens_from_input(nhs_num, expected_output):
+    cleaned_nhs_number = clean_nhs_number(nhs_num)
+    assert cleaned_nhs_number == expected_output

--- a/tests/shared/test_validation.py
+++ b/tests/shared/test_validation.py
@@ -291,7 +291,7 @@ def test_validate_basic_care_needs_should_return_true_when_valid_answer_selected
     )
 
 
-@pytest.mark.parametrize("form_field_value", ["", None, "123"])
+@pytest.mark.parametrize("form_field_value", ["", None, "123", "11164324557"])
 def test_validate_nhs_number_should_return_false_when_empty_or_invalid_length_nhs_number_entered(
         form_field_value):
     _execute_input_validation_test_and_assert_validation_failed(
@@ -302,7 +302,7 @@ def test_validate_nhs_number_should_return_false_when_empty_or_invalid_length_nh
     )
 
 
-@pytest.mark.parametrize("form_field_value", ["1234567891", "abcd123456"])
+@pytest.mark.parametrize("form_field_value", ["1234567891", "abcd123456", "111~643245#5", "123 643245-5"])
 def test_validate_nhs_number_should_return_false_when_invalid_nhs_number_entered(form_field_value):
     _execute_input_validation_test_and_assert_validation_failed(
         validation.validate_nhs_number,

--- a/vulnerable_people_form/form_pages/nhs_number.py
+++ b/vulnerable_people_form/form_pages/nhs_number.py
@@ -1,6 +1,7 @@
 from flask import redirect, session
 
 from .blueprint import form
+from .shared.form_utils import clean_nhs_number
 from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
@@ -35,7 +36,7 @@ def get_nhs_number():
 def post_nhs_number():
     session["form_answers"] = {
         **session.setdefault("form_answers", {}),
-        "nhs_number": request_form().get("nhs_number").replace(" ", ""),
+        "nhs_number": clean_nhs_number(request_form().get("nhs_number")),
         "know_nhs_number": "Yes, I know my NHS number",
     }
 

--- a/vulnerable_people_form/form_pages/shared/form_utils.py
+++ b/vulnerable_people_form/form_pages/shared/form_utils.py
@@ -1,0 +1,8 @@
+from stdnum.gb.nhs import clean
+
+
+def clean_nhs_number(nhs_number):
+    if nhs_number:
+        return clean(nhs_number, '- ')  # spaces and hyphens removed
+
+    return None


### PR DESCRIPTION
Users are allowed to submit hyphens which in turn breaks the
stored proc call to RDS as the length of the nhs number is
greater than 10 characters.

The nhs clean function has been utilised to remove whitespace
and hypens from the value submitted in the form.

Additionally, the nhs number validation function checks the
length of the cleansed nhs number now rather than relying
on it's own internal invocation of the clean function.