### PR TITLE
Fix postcode input validation

### DIFF
--- a/vulnerable_people_form/form_pages/postcode_eligibility.py
+++ b/vulnerable_people_form/form_pages/postcode_eligibility.py
@@ -7,6 +7,7 @@ from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
 from .shared.session import get_errors_from_session, request_form, get_answer_from_form
 from .shared.validation import validate_postcode
+from vulnerable_people_form.integrations.postcode_lookup_helper import format_postcode
 
 
 @form.route("/postcode-eligibility", methods=["GET"])
@@ -29,7 +30,7 @@ def get_postcode_eligibility():
 
 @form.route("/postcode-eligibility", methods=["POST"])
 def post_postcode_verification():
-    session["postcode"] = request_form().get("postcode")
+    session["postcode"] = format_postcode(request_form().get("postcode"))
     if not validate_postcode(session["postcode"], "postcode"):
         return redirect("/postcode-eligibility")
 

--- a/vulnerable_people_form/form_pages/postcode_lookup.py
+++ b/vulnerable_people_form/form_pages/postcode_lookup.py
@@ -6,11 +6,12 @@ from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
 from .shared.session import get_errors_from_session, request_form
 from .shared.validation import validate_postcode
+from vulnerable_people_form.integrations.postcode_lookup_helper import format_postcode
 
 
 @form.route("/postcode-lookup", methods=["POST"])
 def post_postcode_lookup():
-    session["postcode"] = request_form().get("postcode")
+    session["postcode"] = format_postcode(request_form().get("postcode"))
     if not validate_postcode(session["postcode"], "postcode"):
         return redirect("/postcode-lookup")
 

--- a/vulnerable_people_form/form_pages/shared/form_utils.py
+++ b/vulnerable_people_form/form_pages/shared/form_utils.py
@@ -3,6 +3,6 @@ from stdnum.gb.nhs import clean
 
 def clean_nhs_number(nhs_number):
     if nhs_number:
-        return clean(nhs_number, '- ')  # spaces and hyphens removed
+        return clean(nhs_number, '- ')  # remove spaces & hyphens
 
     return None

--- a/vulnerable_people_form/form_pages/shared/validation.py
+++ b/vulnerable_people_form/form_pages/shared/validation.py
@@ -204,14 +204,14 @@ def validate_date_of_birth():
 
 
 def validate_postcode(postcode, error_section_name):
-    postcode.replace(" ", "")
-    postcode_regex = "^(([A-Z]{1,2}[0-9][A-Z0-9]?|ASCN|STHL|TDCU|BBND|[BFS]IQQ|PCRN|TKCA) ?[0-9][A-Z]{2}|BFPO ?[0-9]{1,4}|(KY[0-9]|MSR|VG|AI)[ -]?[0-9]{4}|[A-Z]{2} ?[0-9]{2}|GE ?CX|GIR ?0A{2}|SAN ?TA1)$"  # noqa: E501
+    character_limiting_regex = "^[A-Z0-9]{5,7}$"
+    postcode_regex = r"^([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]?))))\s?[0-9][A-Za-z]{2})$"  # noqa: E501
     error = None
     if not postcode:
         error = "What is the postcode where you need support?"
-    elif re.match(postcode_regex, postcode.upper()) is None:
+    elif re.match(character_limiting_regex, postcode) is None or \
+            re.match(postcode_regex, postcode.upper()) is None:
         error = "Enter a real postcode"
-
     if error:
         error_section = session.setdefault("error_items", {}).get(error_section_name, {})
         session["error_items"] = {

--- a/vulnerable_people_form/integrations/postcode_lookup_helper.py
+++ b/vulnerable_people_form/integrations/postcode_lookup_helper.py
@@ -120,6 +120,13 @@ def get_addresses_from_postcode(postcode):
         raise ErrorFindingAddress()
 
 
+def format_postcode(postcode):
+    if postcode:
+        return postcode.replace(" ", "").upper()
+
+    return None
+
+
 def _log_postcode_lookup_failure(failure_reason, postcode):
     logger.error(create_log_message(log_event_names["ORDNANCE_SURVEY_LOOKUP_FAILURE"],
                                     f"Failure reason: {failure_reason}, Postcode: {postcode}"))


### PR DESCRIPTION
The regex for the postcode input validation was
incorrectly allowing partial postcodes through,
e.g. NE11

Two separate input validation regular expressions
are now used to check only alphanumeric characters
are present & to assert the postcode is valid.

The regex for verifying the validity of the postcode
is based on the implementation in the alphagov/collections
repository.