### PR TITLE
Improve session expiration handling

### DIFF
--- a/behave/features/1.e2e_journey_no_nhs_login.feature
+++ b/behave/features/1.e2e_journey_no_nhs_login.feature
@@ -2,7 +2,7 @@
 @e2e_happy_path_no_nhs_login
 Feature: COVID-19 Shielded vulnerable people service - basic e2e user journey - no NHS login
     Scenario: can load homepage
-        When you navigate to "/start"
+        When I navigate to "/start"
         Then the content of element with selector ".govuk-fieldset__heading" equals "Are you using this service for yourself or for someone else?"
 
     Scenario: Should be re-directed to nhs-login when yes answered to applying on own behalf

--- a/behave/features/2.e2e_journey_no_nhs_login_and_no_submission.feature
+++ b/behave/features/2.e2e_journey_no_nhs_login_and_no_submission.feature
@@ -2,7 +2,7 @@
 @e2e_happy_path_no_nhs_login_no_submission
 Feature: COVID-19 Shielded vulnerable people service - basic e2e user journey - no NHS login & no record submission
     Scenario: can load homepage
-        When you navigate to "/start"
+        When I navigate to "/start"
         Then the content of element with selector ".govuk-fieldset__heading" equals "Are you using this service for yourself or for someone else?"
 
     Scenario: Should be re-directed to nhs-login when yes answered to applying on own behalf

--- a/behave/features/3.e2e_with_la_query_string_param.feature
+++ b/behave/features/3.e2e_with_la_query_string_param.feature
@@ -2,7 +2,7 @@
 @e2e_happy_path_no_nhs_login_with_la_param
 Feature: COVID-19 Shielded vulnerable people service - basic e2e user journey - no NHS login
     Scenario: can load homepage
-        When you navigate to "/start?la=1"
+        When I navigate to "/start?la=1"
         Then the content of element with selector ".govuk-fieldset__heading" equals "Are you using this service for yourself or for someone else?"
 
     Scenario: Should be re-directed to nhs-login when yes answered to applying on own behalf

--- a/behave/features/4.not_eligible_medical.feature
+++ b/behave/features/4.not_eligible_medical.feature
@@ -2,7 +2,7 @@
 @e2e_partial_journey
 Feature: COVID-19 Shielded vulnerable people service - partial user journey - no medical conditions
     Scenario: can load homepage
-        When you navigate to "/start"
+        When I navigate to "/start"
         Then the content of element with selector ".govuk-fieldset__heading" equals "Are you using this service for yourself or for someone else?"
 
     Scenario: Should be re-directed to nhs-login when yes answered to applying on own behalf

--- a/behave/features/5.not_eligible_postcode.feature
+++ b/behave/features/5.not_eligible_postcode.feature
@@ -2,7 +2,7 @@
 @e2e_partial_journey
 Feature: COVID-19 Shielded vulnerable people service - partial user journey - ineligible postcode
     Scenario: can load homepage
-        When you navigate to "/start"
+        When I navigate to "/start"
         Then the content of element with selector ".govuk-fieldset__heading" equals "Are you using this service for yourself or for someone else?"
 
     Scenario: Should be re-directed to nhs-login when yes answered to applying on own behalf

--- a/behave/features/6.root_redirection.feature
+++ b/behave/features/6.root_redirection.feature
@@ -1,0 +1,4 @@
+Feature: COVID-19 Shielded vulnerable people service - gov.uk journey start page redirection
+  Scenario: Should be redirected to gov.uk journey start page
+      When I navigate to "/"
+      Then I am redirected to the external page with URL "https://www.gov.uk/coronavirus-shielding-support"

--- a/behave/features/steps/general.py
+++ b/behave/features/steps/general.py
@@ -15,13 +15,19 @@ def wait_until_url_present(context, next_page_url):
         expected_conditions.url_to_be(f"{_BASE_URL}/{next_page_url}"))
 
 
+@then('I am redirected to the external page with URL "{next_page_url}"')
+def wait_until_external_url_present(context, next_page_url):
+    WebDriverWait(context.browser, _DEFAULT_TIMEOUT).until(
+        expected_conditions.url_to_be(next_page_url))
+
+
 @then('wait up to "{timeout_seconds}" seconds until element with selector "{element_css_selector}" is present')
 def wait_until_element_present(context, timeout_seconds, element_css_selector):
     WebDriverWait(context.browser, int(timeout_seconds)).until(
         expected_conditions.presence_of_element_located((By.CSS_SELECTOR, element_css_selector)))
 
 
-@when('you navigate to "{path}"')
+@when('I navigate to "{path}"')
 def user_path_step(context, path):
     context.browser.get(_BASE_URL + path)
 

--- a/vulnerable_people_form/__init__.py
+++ b/vulnerable_people_form/__init__.py
@@ -71,6 +71,7 @@ def create_app(scriptinfo):
         request_bodies='never',
     )
 
+    app.register_blueprint(form_pages.default.app_default)
     app.register_blueprint(form_pages.blueprint.form)
 
     _init_security(app)

--- a/vulnerable_people_form/form_pages/applying_on_own_behalf.py
+++ b/vulnerable_people_form/form_pages/applying_on_own_behalf.py
@@ -5,6 +5,7 @@ from .shared.answers_enums import (
     ApplyingOnOwnBehalfAnswers,
     get_radio_options_from_enum,
 )
+from .shared.constants import GOVUK_JOURNEY_START_PAGE_URL
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
 from .shared.session import (
@@ -22,7 +23,7 @@ def get_apply_on_own_behalf():
         radio_items=get_radio_options_from_enum(
             ApplyingOnOwnBehalfAnswers, form_answers().get("applying_on_own_behalf")
         ),
-        previous_path="https://www.gov.uk/coronavirus-shielding-support",
+        previous_path=GOVUK_JOURNEY_START_PAGE_URL,
         **get_errors_from_session("applying_on_own_behalf"),
     )
 

--- a/vulnerable_people_form/form_pages/blueprint.py
+++ b/vulnerable_people_form/form_pages/blueprint.py
@@ -3,31 +3,20 @@ from http import HTTPStatus
 from flask import (
     Blueprint,
     redirect,
-    render_template,
-    session,
+    render_template
 )
 from flask_wtf.csrf import CSRFError
 
-from vulnerable_people_form.form_pages.shared.constants import SESSION_KEY_QUERYSTRING_PARAMS
-from vulnerable_people_form.form_pages.shared.querystring_utils import (
-    append_querystring_params,
-    get_querystring_params_to_retain
-)
+from vulnerable_people_form.form_pages.shared.querystring_utils import append_querystring_params
+from vulnerable_people_form.form_pages.shared.session import has_started_form
 
 form = Blueprint("form", __name__)
 
 
 @form.before_request
 def redirect_to_first_page():
-    if not session.get("form_started"):
-        session.clear()
-        session["form_started"] = True
-
-        querystring_params = get_querystring_params_to_retain()
-        if querystring_params:
-            session[SESSION_KEY_QUERYSTRING_PARAMS] = querystring_params
-
-        return redirect("/applying-on-own-behalf")
+    if not has_started_form():
+        return _redirect_to_session_expired()
 
 
 @form.after_request
@@ -43,7 +32,12 @@ def add_caching_headers(response):
 
 @form.errorhandler(CSRFError)
 def handle_csrf_error(e):
-    if "form_started" not in session:
-        return render_template("session-expired.html")
+    if not has_started_form():
+        return _redirect_to_session_expired()
     else:
         return render_template("400.html")
+
+
+def _redirect_to_session_expired():
+    redirect_location = append_querystring_params("/session-expired")
+    return redirect(redirect_location)

--- a/vulnerable_people_form/form_pages/default.py
+++ b/vulnerable_people_form/form_pages/default.py
@@ -1,23 +1,34 @@
-from vulnerable_people_form.form_pages.shared.constants import SESSION_KEY_QUERYSTRING_PARAMS
-from vulnerable_people_form.form_pages.shared.querystring_utils import get_querystring_params_to_retain
-from .blueprint import form
-from flask import session, redirect
+from vulnerable_people_form.form_pages.shared.constants import (
+    SESSION_KEY_QUERYSTRING_PARAMS,
+    GOVUK_JOURNEY_START_PAGE_URL
+)
+from vulnerable_people_form.form_pages.shared.querystring_utils import (
+    get_querystring_params_to_retain,
+    append_querystring_params
+)
+from flask import session, redirect, Blueprint, render_template
+
+app_default = Blueprint("app_default", __name__)
 
 
-@form.route("/", methods=["GET"])
+@app_default.route("/", methods=["GET"])
 def get_default_route():
-    return _clear_session_and_create_redirect_response()
+    return redirect(GOVUK_JOURNEY_START_PAGE_URL)
 
 
-@form.route("/start", methods=["GET"])
+@app_default.route("/start", methods=["GET"])
 def get_start():
-    return _clear_session_and_create_redirect_response()
-
-
-def _clear_session_and_create_redirect_response():
     session.clear()
+    session["form_started"] = True
     _populate_session_with_querystring_params_to_retain()
-    return redirect("/applying-on-own-behalf")
+    return redirect(append_querystring_params("/applying-on-own-behalf"))
+
+
+@app_default.route("/session-expired", methods=["GET"])
+def get_session_expired():
+    session.clear()
+    return render_template("session-expired.html",
+                           govuk_start_page_url=GOVUK_JOURNEY_START_PAGE_URL)
 
 
 def _populate_session_with_querystring_params_to_retain():

--- a/vulnerable_people_form/form_pages/shared/constants.py
+++ b/vulnerable_people_form/form_pages/shared/constants.py
@@ -66,6 +66,8 @@ NHS_USER_INFO_TO_FORM_ANSWERS = {
 SESSION_KEY_ADDRESS_SELECTED = "auto_populated_address_selected"
 SESSION_KEY_QUERYSTRING_PARAMS = "querystring_params_to_retain"
 
+GOVUK_JOURNEY_START_PAGE_URL = "https://gov.uk/coronavirus-shielding-support"
+
 
 @enum.unique
 class JourneyProgress(enum.Enum):

--- a/vulnerable_people_form/form_pages/shared/session.py
+++ b/vulnerable_people_form/form_pages/shared/session.py
@@ -65,6 +65,10 @@ def is_nhs_login_user():
     return session.get("nhs_sub") is not None
 
 
+def has_started_form():
+    return "form_started" in session
+
+
 def should_contact_gp():
     return NHSLetterAnswers(form_answers()["nhs_letter"]) is NHSLetterAnswers.YES
 

--- a/vulnerable_people_form/templates/session-expired.html
+++ b/vulnerable_people_form/templates/session-expired.html
@@ -5,5 +5,5 @@
     <p class="govuk-body">
         Your session timed out because you did not do anything for 60 minutes. We do this to keep your information secure.
     </p>
-    <p class="govuk-body">You can <a class="govuk-link" href="https://gov.uk/coronavirus-shielding-support">start your registration again</a>.</p>
+    <p class="govuk-body">You can <a class="govuk-link" href="{{ govuk_start_page_url }}">start your registration again</a>.</p>
 {% endblock %}


### PR DESCRIPTION
There are sentry log entries indicating invalid attempts
to access session variables.

When making a GET request if the user's session has
expired the user is now directed to the /session-expired
page (rather than a new session being setup).