### PR TITLE
Update link on nhs login landing page (sign out)

### DIFF
--- a/vulnerable_people_form/form_pages/nhs_login_landing.py
+++ b/vulnerable_people_form/form_pages/nhs_login_landing.py
@@ -1,8 +1,8 @@
 from flask import current_app, session
 
 from .blueprint import form
+from .shared.constants import GOVUK_JOURNEY_START_PAGE_URL
 from .shared.render import render_template_with_title
-from .shared.querystring_utils import append_querystring_params
 
 
 @form.route("/nhs-login-landing", methods=["GET"])
@@ -11,5 +11,5 @@ def get_nhs_login_landing():
     return render_template_with_title(
         "nhs-login-landing.html",
         nhs_login_href=current_app.nhs_oidc_client.get_authorization_url(),
-        continue_url=append_querystring_params("/applying-on-own-behalf")
+        continue_url=GOVUK_JOURNEY_START_PAGE_URL
     )


### PR DESCRIPTION
The link on the signed out page via nhs login should point to the start of the journey for the user which is the gov uk page