### PR TITLE
Update NHS login no consent given to log warning

### DIFF
--- a/vulnerable_people_form/form_pages/nhs_login_callback.py
+++ b/vulnerable_people_form/form_pages/nhs_login_callback.py
@@ -17,13 +17,16 @@ def get_nhs_login_callback():
 
     if "error" in request.args:
         error_description = request.args.get("error_description", "")
-        logger.error(create_log_message(
-            log_event_names["NHS_LOGIN_FAIL"],
-            f"NHS login error: {request.args['error']}, error description: {error_description}"))
+        error = request.args['error']
 
         if error_description == "ConsentNotGiven":
+            logger.warning(create_log_message(log_event_names["NHS_LOGIN_USER_CONSENT_NOT_GIVEN"],
+                                              f"NHS login warning: {error}, error description: {error_description}"))
             return redirect("/no-consent")
         else:
+            logger.error(create_log_message(
+                log_event_names["NHS_LOGIN_FAIL"],
+                f"NHS login error: {error}, error description: {error_description}"))
             abort(500)
 
     nhs_user_info = current_app.nhs_oidc_client.get_nhs_user_info_from_authorization_callback(request.args)

--- a/vulnerable_people_form/form_pages/nhs_registration_callback.py
+++ b/vulnerable_people_form/form_pages/nhs_registration_callback.py
@@ -5,7 +5,6 @@ from flask import abort, current_app, redirect, request, session
 from vulnerable_people_form.form_pages.shared.logger_utils import create_log_message, log_event_names, init_logger
 from vulnerable_people_form.form_pages.shared.routing import get_next_form_url_after_nhs_number, \
     get_redirect_to_terminal_page
-from ..integrations import google_analytics
 from .blueprint import form
 from .shared.constants import NHS_USER_INFO_TO_FORM_ANSWERS, JourneyProgress
 from .shared.session import (
@@ -14,11 +13,14 @@ from .shared.session import (
     set_form_answers_from_nhs_user_info,
     load_answers_into_session_if_available
 )
+from ..integrations import google_analytics
+
+_CONFIRMATION_URL = "/confirmation"
 logger = logging.getLogger(__name__)
 init_logger(logger)
 
 
-def log_form_and_nhs_answers_differences(nhs_user_info):
+def _log_form_and_nhs_answers_differences(nhs_user_info):
     different_answers = []
     for answers_key, nhs_user_info_key in NHS_USER_INFO_TO_FORM_ANSWERS.items():
         form_value = get_answer_from_form(answers_key)
@@ -44,27 +46,29 @@ def log_form_and_nhs_answers_differences(nhs_user_info):
 def get_nhs_registration_callback():
     if "error" in request.args:
         error_description = request.args.get('error_description')
-
-        logger.error(create_log_message(
-            log_event_names["NHS_LOGIN_FAIL"],
-            f"NHS login error: {request.args['error']} , error description: {error_description}"))
+        error = request.args['error']
 
         if error_description == "ConsentNotGiven" and session.get('registration_number'):
-            return redirect("/confirmation")
+            _log_no_consent(error, error_description)
+            return redirect(_CONFIRMATION_URL)
         elif error_description == "ConsentNotGiven":
+            _log_no_consent(error, error_description)
             return redirect("/no-consent-registration")
         else:
+            logger.error(create_log_message(
+                log_event_names["NHS_LOGIN_FAIL"],
+                f"NHS login error: {error} , error description: {error_description}"))
             abort(500)
 
     state_from_query_string = request.args.get('state')
     if state_from_query_string:
-        last_char_of_state = state_from_query_string[len(state_from_query_string)-1]
+        last_char_of_state = state_from_query_string[len(state_from_query_string) - 1]
         journey_progress = JourneyProgress(int(last_char_of_state))
     else:
         abort(500)
 
     nhs_user_info = current_app.nhs_oidc_client.get_nhs_user_info_from_registration_callback(request.args)
-    log_form_and_nhs_answers_differences(nhs_user_info)
+    _log_form_and_nhs_answers_differences(nhs_user_info)
     session["nhs_sub"] = nhs_user_info["sub"]
     session["form_answers"]["nhs_number"] = nhs_user_info["nhs_number"]
 
@@ -76,8 +80,13 @@ def get_nhs_registration_callback():
         redirect_url = get_next_form_url_after_nhs_number()
     elif journey_progress is JourneyProgress.NHS_REGISTRATION:
         persist_answers_from_session()
-        redirect_url = "/confirmation"
+        redirect_url = _CONFIRMATION_URL
     else:
         raise ValueError("Unexpected JourneyProgress value extracted from state: " + last_char_of_state)
 
     return redirect(redirect_url)
+
+
+def _log_no_consent(error, error_description):
+    logger.warning(create_log_message(log_event_names["NHS_LOGIN_USER_CONSENT_NOT_GIVEN"],
+                                      f"NHS login warning: {error}, error description: {error_description}"))

--- a/vulnerable_people_form/form_pages/shared/logger_utils.py
+++ b/vulnerable_people_form/form_pages/shared/logger_utils.py
@@ -13,6 +13,7 @@ log_event_names = {
     "NHS_LOGIN_FAIL": "NhsLoginFailed",
     "NHS_LOGIN_SUCCESS": "NhsLoginSucceeded",
     "NHS_LOGIN_USER_INFO_REQUEST_FAIL": "NhsLoginUserInfoRequestFailed",
+    "NHS_LOGIN_USER_CONSENT_NOT_GIVEN": "NhsLoginUserConsentNotGiven",
     "POSTCODE_INELIGIBLE": "IneligiblePostcodeEntered",
     "POSTCODE_ELIGIBLE": "EligiblePostcodeEntered",
     "ORDNANCE_SURVEY_LOOKUP_SUCCESS": "OrdnanceSurveyPlacesApiPostcodeLookupSucceeded",


### PR DESCRIPTION
If a user decides to use NHS login to register with the service they must accept and give consent to share their information with the SVP app. Currently if they reject consent it is logged as an error this has been changed to a warning.