### PR TITLE
Increase smoke test frequency

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -24,10 +24,10 @@ resources:
       url: ((slack_hook_automate))
       channel: covid-engineering-team
 
-  - name: every-5m
+  - name: every-2m
     type: time
     source:
-      interval: 5m
+      interval: 2m
 
   - name: trigger-at-1am
     type: cron-resource
@@ -179,7 +179,7 @@ jobs:
 
   - name: continuous-smoke-test-staging
     plan:
-      - get: every-5m
+      - get: every-2m
         trigger: true
       - get: git-master
       - task: smoke-test
@@ -196,7 +196,7 @@ jobs:
 
   - name: continuous-smoke-test-prod
     plan:
-      - get: every-5m
+      - get: every-2m
         trigger: true
       - get: git-master
       - task: smoke-test

--- a/concourse/tasks/cronitor.yml
+++ b/concourse/tasks/cronitor.yml
@@ -10,5 +10,5 @@ run:
     - |
       set -ue
       echo 'Curling cronitor'
-      curl --fail "$CRONITOR_URL"
+      curl --fail "$CRONITOR_URL/complete"
       echo 'Curled cronitor successfully'


### PR DESCRIPTION
We were paged at around midnight because there was a delay of >10
minutes between these two smoke tests:

https://cd.gds-reliability.engineering/teams/covid19/pipelines/svp-form/jobs/continuous-smoke-test-prod/builds/1599
https://cd.gds-reliability.engineering/teams/covid19/pipelines/svp-form/jobs/continuous-smoke-test-prod/builds/1600

This seems to be related to the Concourse worker rolling job that
happened at the same time:

https://cd.gds-reliability.engineering/teams/main/pipelines/roll-instances/jobs/roll-covid19-concourse-workers/builds/162

This change means that we have a better chance of not hitting the 10m
alert threshold without relaxing this limit.

**The deploy of this will need to be coordinated with config changes in Cronitor**