### PR TITLE
Alert Cronitor immediately when a smoke test fails

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -192,6 +192,7 @@ jobs:
         timeout: 1m
         params:
           CRONITOR_URL: ((svp-form/cronitor-heartbeat-stg))
+          CRONITOR_ENDPOINT: "/complete"
         file: git-master/concourse/tasks/cronitor.yml
 
   - name: continuous-smoke-test-prod
@@ -204,11 +205,20 @@ jobs:
         params:
           WEB_APP_BASE_URL: "https://coronavirus-shielding-support.service.gov.uk"
           MESSAGE: "Checks that the application deployed to production is not serving HTTP error codes"
-        on_failure: *slack_alert_on_failure
+        on_failure:
+          task: cronitor-fail
+          file: git-master/concourse/tasks/cronitor.yml
+          timeout: 1m
+          params:
+            CRONITOR_URL: ((svp-form/cronitor-heartbeat-prod))
+            CRONITOR_ENDPOINT: "/fail"
+          ensure: *slack_alert_on_failure
+        file: git-master/concourse/tasks/cronitor.yml
       - task: cronitor-heartbeat
         timeout: 1m
         params:
           CRONITOR_URL: ((svp-form/cronitor-heartbeat-prod))
+          CRONITOR_ENDPOINT: "/complete"
         file: git-master/concourse/tasks/cronitor.yml
 
   - name: gatling-workflow-load-test-in-staging

--- a/concourse/tasks/cronitor.yml
+++ b/concourse/tasks/cronitor.yml
@@ -9,6 +9,6 @@ run:
     - -c
     - |
       set -ue
-      echo 'Curling cronitor'
-      curl --fail "$CRONITOR_URL/complete"
-      echo 'Curled cronitor successfully'
+      echo 'Curling cronitor ${CRONITOR_ENDPOINT}...'
+      curl --fail "${CRONITOR_URL}${CRONITOR_ENDPOINT}"
+      echo 'Curled cronitor successfully.'


### PR DESCRIPTION
This means we should get more timely alerting. This means we can change
Cronitor so that it only alerts if it sees 2 consecutive failures.

Relax the Cronitor expected `/complete` ping timeout. This means we can
hopefully avoid alerting when the workers are restarted.

**I'm not entirely convinced this will do what I expect so we'll have to manually test it, I'm currently on-call in hours so I'll be the one that gets pestered**