### PR TITLE
Correct concourse unit test execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,9 @@
-define execute_unit_tests
-	python3 -m pytest -sqx --disable-warnings
-	@echo "✔️ Unit tests passed!"
-endef
-
 test:
-	$(call execute_unit_tests)
+	python3 -m pytest -x --disable-warnings
+	@echo "✔️ Unit tests passed!"
 
 test_with_coverage:
-	$(call execute_unit_tests)
-	coverage run --source vulnerable_people_form/ -m pytest --disable-warnings
+	coverage run --source vulnerable_people_form/ -m pytest -qx --disable-warnings
 	coverage report -m
 
 install:

--- a/concourse/tasks/test.yml
+++ b/concourse/tasks/test.yml
@@ -17,7 +17,10 @@ run:
     - -c
     - |
       root=$(pwd)
-      make install
+      echo "Installing dependencies..."
+      pip3 install -r requirements-dev.txt
       echo "Executing unit tests..."
-      make test_with_coverage
+      coverage run --source vulnerable_people_form/ -m pytest -x --disable-warnings
+      echo "Reporting on unit test coverage..."
+      coverage report
   dir: git-master

--- a/tests/integrations/test_persistence.py
+++ b/tests/integrations/test_persistence.py
@@ -1,6 +1,6 @@
 import pytest
 from flask import Flask
-from mock import patch
+from unittest.mock import patch
 
 from vulnerable_people_form.integrations.persistence import (
     get_client_kwargs,


### PR DESCRIPTION
The previous unit test improvement commit contained
an erroneous import which referred to the mock
package rather than unittest.mock