### PR TITLE
Update pipeline to fix continuous smoke test in prod

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -213,7 +213,6 @@ jobs:
             CRONITOR_URL: ((svp-form/cronitor-heartbeat-prod))
             CRONITOR_ENDPOINT: "/fail"
           ensure: *slack_alert_on_failure
-        file: git-master/concourse/tasks/cronitor.yml
       - task: cronitor-heartbeat
         timeout: 1m
         params:


### PR DESCRIPTION
There are 2 file attributes in the pipeline task which caused an issue when running the smoke tests for prod.