### PR TITLE
Update postcode to an invalid one

### DIFF
--- a/behave/features/5.not_eligible_postcode.feature
+++ b/behave/features/5.not_eligible_postcode.feature
@@ -18,6 +18,6 @@ Feature: COVID-19 Shielded vulnerable people service - partial user journey - in
 
     Scenario: Should be re-directed to not eligible postcode when unsupported postcode entered
         Given I am on the "postcode-eligibility" page
-        When I give the "#postcode" field the value "LS1 1BA"
+        When I give the "#postcode" field the value "QI1 2ZZ"
         And I submit the form
         Then I am redirected to the "not-eligible-postcode" page


### PR DESCRIPTION
Smoke test uses postcode which should never be in lockdown. Hence changing Leeds postcode to Edinburgh one. Thus this test will always be successful on account of postcode (since we wont have Edinburgh postcode in lockdown list).