### PR TITLE
Update Smoke test to use a (non-lockdown) postcode

### DIFF
--- a/behave/features/5.not_eligible_postcode.feature
+++ b/behave/features/5.not_eligible_postcode.feature
@@ -18,6 +18,6 @@ Feature: COVID-19 Shielded vulnerable people service - partial user journey - in
 
     Scenario: Should be re-directed to not eligible postcode when unsupported postcode entered
         Given I am on the "postcode-eligibility" page
-        When I give the "#postcode" field the value "QI1 2ZZ"
+        When I give the "#postcode" field the value "QJ5 7VC"
         And I submit the form
         Then I am redirected to the "not-eligible-postcode" page


### PR DESCRIPTION
Smoke test uses postcode which should never be in lockdown. Also there is a basic format check in pipeline on postcode to
look for format @___#@@ where
  @= Alphabet
  _= Alphabet or numeric
  #= Numeric

As per following link, UK postcodes follow below rules
https://en.wikipedia.org/wiki/Postcodes_in_the_United_Kingdom

```
Notes:
As all formats end with 9AA, the first part of a postcode can easily be extracted by ignoring the last three
characters.
Areas with only single-digit districts: BR, FY, HA, HD, HG, HR, HS, HX, JE, LD, SM, SR, WC, WN, ZE (although
WC is always subdivided by a further letter, e.g. WC1A)
Areas with only double-digit districts: AB, LL, SO
Areas with a district '0' (zero): BL, BS, CM, CR, FY, HA, PR, SL, SS (BS is the only area to have both a district 0 and
a district 10)
The following central London single-digit districts have been further divided by inserting a letter after the digit and
before the space: EC1–EC4 (but not EC50), SW1, W1, WC1, WC2 and parts of E1 (E1W), N1 (N1C and N1P), NW1 (NW1W) and
SE1 (SE1P).
The letters Q, V and X are not used in the first position.
The letters I, J and Z are not used in the second position.
The only letters to appear in the third position are A, B, C, D, E, F, G, H, J, K, P, S, T, U and W when the structure
starts with A9A.
The only letters to appear in the fourth position are A, B, E, H, M, N, P, R, V, W, X and Y when the structure starts
with AA9A.
The final two letters do not use C, I, K, M, O or V, so as not to resemble digits or each other when hand-written.
Postcode sectors are one of ten digits: 0 to 9, with 0 only used once 9 has been used in a post town, save for Croydon
and Newport (see above).
```

There is also validation on Front end with regex
r"^([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]?))))\s?[0-9][A-Za-z]{2})$"

Hence the test postcode for smoke testing is changed to `QJ5 7VC`. This ensures
- It is not a valid UK postcode and defies above rules. Hence highly unlikely that it will ever be used as valid postcode
- It meets the basic formatting test, so it wont fail on processing.
- Smoke test cannot fail on account that test postcode gets added in the lockdown list (even for a national lockdown).