### PR TITLE
Modify database secrets tag to point to new secret

### DIFF
--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -41,7 +41,7 @@ params:
   FLASK_CONFIG: env_to_config_shim.py
   NHS_OIDC_REGISTRATION_CALLBACK_URL:
   DATABASE_CLUSTER_PREFIX: coronavirus-
-  DATABASE_SECRET_TAGS: role,coronavirus-web-form
+  DATABASE_SECRET_TAGS: role,coronavirus-web-form-v2
   SECRET_KEY:
   NHS_OIDC_LOGIN_PRIVATE_KEY:
   SENTRY_DSN:


### PR DESCRIPTION
This is to resolve issue and use a new secret. Old secret is having issue in
attempting to use and old password which always fail. Open ticket with AWS
7559528471 and 7559302041.

The new secret is pointing to a newRDS user which has same access rights as
existing one.