### PR TITLE
Implement date of birth sanitisation

### DIFF
--- a/tests/form_pages/shared/test_form_utils.py
+++ b/tests/form_pages/shared/test_form_utils.py
@@ -1,6 +1,10 @@
 import pytest
 
-from vulnerable_people_form.form_pages.shared.form_utils import clean_nhs_number
+from vulnerable_people_form.form_pages.shared.form_utils import (
+    clean_nhs_number,
+    sanitise_date,
+    strip_non_digits
+)
 
 
 @pytest.mark.parametrize("nhs_num", ["", None])
@@ -26,3 +30,43 @@ def test_clean_nhs_number_should_strip_whitespace_from_input(nhs_num, expected_o
 def test_clean_nhs_number_should_strip_whitespace_and_hyphens_from_input(nhs_num, expected_output):
     cleaned_nhs_number = clean_nhs_number(nhs_num)
     assert cleaned_nhs_number == expected_output
+
+
+def test_strip_non_digits_should_remove_characters_that_are_not_digits():
+    stripped_value = strip_non_digits("123sdfsd4 !~)%|*-")
+    assert stripped_value == "1234"
+
+
+def test_strip_non_digits_should_not_remove_digit_characters():
+    stripped_value = strip_non_digits("12345")
+    assert stripped_value == "12345"
+
+
+def test_sanitise_date_of_birth_should_remove_non_digit_characters_from_date():
+    test_date = {"day": "12  ", "month": "^05!", "year": "1987xdvxv^&*"}
+    sanitise_date(test_date)
+    assert test_date["day"] == "12"
+    assert test_date["month"] == "05"
+    assert test_date["year"] == "1987"
+
+
+def test_sanitise_date_of_birth_should_not_remove_digit_characters_from_date():
+    test_date = {"day": "13", "month": "7", "year": "1991"}
+    sanitise_date(test_date)
+    assert test_date["day"] == "13"
+    assert test_date["month"] == "7"
+    assert test_date["year"] == "1991"
+
+
+def test_sanitise_date_of_birth_should_raise_error_when_invalid_length_dict_supplied():
+    test_date = {"day": "13", "month": "7", "year": "1991", "random_field": "test"}
+    with pytest.raises(ValueError) as exception_info:
+        sanitise_date(test_date)
+        assert "Unexpected date_of_birth encountered" in str(exception_info.value)
+
+
+def test_sanitise_date_of_birth_should_raise_error_when_invalid_dict_supplied():
+    test_date = {"day": "13", "month": "7", "invalid_field": "test"}
+    with pytest.raises(ValueError) as exception_info:
+        sanitise_date(test_date)
+        assert "Unexpected date_of_birth encountered" in str(exception_info.value)

--- a/vulnerable_people_form/form_pages/date_of_birth.py
+++ b/vulnerable_people_form/form_pages/date_of_birth.py
@@ -1,6 +1,7 @@
 from flask import redirect, session
 
 from .blueprint import form
+from .shared.form_utils import sanitise_date
 from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
@@ -20,9 +21,12 @@ def get_date_of_birth():
 
 @form.route("/date-of-birth", methods=["POST"])
 def post_date_of_birth():
+    posted_date_of_birth = request_form()
+    sanitise_date(posted_date_of_birth)
+
     session["form_answers"] = {
         **session.setdefault("form_answers", {}),
-        "date_of_birth": {**request_form()},
+        "date_of_birth": {**posted_date_of_birth},
     }
     if not validate_date_of_birth():
         return redirect("/date-of-birth")

--- a/vulnerable_people_form/form_pages/shared/form_utils.py
+++ b/vulnerable_people_form/form_pages/shared/form_utils.py
@@ -1,4 +1,5 @@
 from stdnum.gb.nhs import clean
+import re
 
 
 def clean_nhs_number(nhs_number):
@@ -6,3 +7,21 @@ def clean_nhs_number(nhs_number):
         return clean(nhs_number, '- ')  # remove spaces & hyphens
 
     return None
+
+
+def strip_non_digits(value):
+    if value:
+        return re.sub("[^0-9]", "", value)
+
+    return value
+
+
+def sanitise_date(date_value):
+    if date_value:
+        if len(date_value.keys()) != 3 or \
+          not all(k in date_value for k in ["day", "month", "year"]):
+            raise ValueError("Unexpected date_value encountered: " + str(date_value))
+
+        date_value["day"] = strip_non_digits(date_value["day"])
+        date_value["month"] = strip_non_digits(date_value["month"])
+        date_value["year"] = strip_non_digits(date_value["year"])


### PR DESCRIPTION
Errors could be raised if a user mistakenly entered
a date of birth containing a non-digit character
such as a white-space.

The date of birth is now stripped of all non numeric
characters prior to input validation.