### PR TITLE
Revert "Up gatling tests to 200 active users"

### DIFF
--- a/concourse/tasks/gatling-workflow-load-test.yml
+++ b/concourse/tasks/gatling-workflow-load-test.yml
@@ -18,14 +18,14 @@ run:
     - -euo
     - pipefail
     - -c
-    # 8 users per second causes around 240 page requests/s which is over our current non-functional requirement. 
+    # 4 users per second causes around 100 page requests/s which is our current non-functional requirement. 
     # Run simulation for 30 mins (1800s) to ensure workflow + mi workflow execution time is covered.
     # Suppress html file output (doesn't seem possible to completely remove file output...)
     # Suppress console log to final report only (done by turning off console writer)
     - |
       cd loadtests
       mvn gatling:test \
-        -DinjectUsersPerSecond=8 \
+        -DinjectUsersPerSecond=4 \
         -DinjectDurationSeconds=1800 \
         -DpauseBetweenRequestsInSecondsMax=1 \
         -DpauseBetweenRequestsInSecondsMin=1 \


### PR DESCRIPTION
We don't want 200 active users running over night, as they are not our none-functional requirements.

Reverts alphagov/govuk-shielded-vulnerable-people-service#139