### PR TITLE
Fix blueprint for non-journey pages

### DIFF
--- a/vulnerable_people_form/form_pages/accessibility_statement.py
+++ b/vulnerable_people_form/form_pages/accessibility_statement.py
@@ -1,8 +1,8 @@
-from .blueprint import form
+from .default import app_default
 from .shared.render import render_template_with_title
 from .shared.routing import dynamic_back_url
 
 
-@form.route("/accessibility-statement", methods=["GET"])
+@app_default.route("/accessibility-statement", methods=["GET"])
 def get_accessibility_statement():
     return render_template_with_title("accessibility.html", previous_path=dynamic_back_url())

--- a/vulnerable_people_form/form_pages/cookies.py
+++ b/vulnerable_people_form/form_pages/cookies.py
@@ -1,8 +1,8 @@
-from .blueprint import form
+from .default import app_default
 from .shared.render import render_template_with_title
 from .shared.routing import dynamic_back_url
 
 
-@form.route("/cookies", methods=["GET"])
+@app_default.route("/cookies", methods=["GET"])
 def get_cookies():
     return render_template_with_title("cookies.html", previous_path=dynamic_back_url())

--- a/vulnerable_people_form/form_pages/privacy.py
+++ b/vulnerable_people_form/form_pages/privacy.py
@@ -1,8 +1,8 @@
-from .blueprint import form
+from .default import app_default
 from .shared.render import render_template_with_title
 from .shared.routing import dynamic_back_url
 
 
-@form.route("/privacy", methods=["GET"])
+@app_default.route("/privacy", methods=["GET"])
 def get_privacy():
     return render_template_with_title("privacy.html", previous_path=dynamic_back_url())


### PR DESCRIPTION
Pages that are not part of the journey should use the not be part of the
form blueprint as they require you to have started a journey.

Instead they should have the app_default blueprint so they can be
accessible normally.