### PR TITLE
Fix AWS RDS secret/db ARN refresh (on error)

### DIFF
--- a/vulnerable_people_form/form_pages/shared/logger_utils.py
+++ b/vulnerable_people_form/form_pages/shared/logger_utils.py
@@ -17,7 +17,9 @@ log_event_names = {
     "POSTCODE_INELIGIBLE": "IneligiblePostcodeEntered",
     "POSTCODE_ELIGIBLE": "EligiblePostcodeEntered",
     "ORDNANCE_SURVEY_LOOKUP_SUCCESS": "OrdnanceSurveyPlacesApiPostcodeLookupSucceeded",
-    "ORDNANCE_SURVEY_LOOKUP_FAILURE": "OrdnanceSurveyPlacesApiPostcodeLookupFailed"
+    "ORDNANCE_SURVEY_LOOKUP_FAILURE": "OrdnanceSurveyPlacesApiPostcodeLookupFailed",
+    "BOTO_CLIENT_ERROR": "BotoClientErrorOccurred",
+    "AWS_ARN_INIT": "AwsRdsDatabaseAndSecretArnInitialised"
 }
 
 


### PR DESCRIPTION
An error was occuring in the live environment
when the AWS RDS keys were being rotated.

It transpired that the error was due to
incorrect assignment of the RDS secret/db ARNs
when an error occurs.

A single method has now been created to set the
ARNS in the app configuration.