### PR TITLE
Fix e2e-test-staging for deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,9 @@ install:
 
 concourse_e2e:
 	@echo "Executing e2e automated tests against the staging environment..."
-	# execute all scenarios except no submission ( the '-' character prefix means skip)
-	behave behave/features --stop --tags=-e2e_happy_path_no_nhs_login_no_submission
+	# execute all scenarios except no submission and backend submissions test ( the '-' character prefix means skip)
+	behave behave/features --stop --tags=-e2e_happy_path_no_nhs_login_no_submission \
+	                              --tags=-simple_web_submission_entry --tags=-s3_outputs_check
 
 smoke_test:
 	@echo "Executing smoke test without submission..."

--- a/behave/features/e2e_test_features/01.simple_web_submission_entry.feature
+++ b/behave/features/e2e_test_features/01.simple_web_submission_entry.feature
@@ -1,4 +1,3 @@
-# COVID-19 -
 @simple_web_submission_entry
 Feature: COVID-19 Shielded vulnerable people service - basic e2e user journey - no NHS login- Enter data for tomorrows pipeline run
 Scenario: can load homepage

--- a/behave/features/e2e_test_features/09.s3_outputs_check.feature
+++ b/behave/features/e2e_test_features/09.s3_outputs_check.feature
@@ -1,4 +1,3 @@
-# COVID-19 -
 @s3_outputs_check
 Feature: COVID-19 Shielded vulnerable people service - validate data from previous day
     Scenario: Pipeline should be executed and data validated for previous day run


### PR DESCRIPTION
This PR excludes the backend testing in deployment pipeline.

The original PR was tested using a stand-alone pipeline. However, there was a component missed where e2e test executes all features except no submission. This PR adds the backend test also as exclusion to e2e tests done during deployment.