### PR TITLE
Fix (attempt) concourse failing smoke tests

### DIFF
--- a/behave/features/environment.py
+++ b/behave/features/environment.py
@@ -13,6 +13,7 @@ def before_all(context):
     chrome_options.add_argument("--single-process")
     chrome_options.add_argument("--disable-dev-shm-usage")
     chrome_options.add_argument("window-size=1200,800")
+    chrome_options.add_argument("--disable-gpu")
 
     context.browser = webdriver.Chrome(options=chrome_options)
     context.browser.set_page_load_timeout(time_to_wait=30)


### PR DESCRIPTION
When the concourse pipeline executes the smoke
tests it intermittently fails. This behaviour
has started to manifest after the
gdscyber/concourse-chrome-driver has been updated.

A --disable-gpu chrome driver configuration option
is now supplied in an attempt to remedy the
'Timed out receiving message from renderer' error.