### PR TITLE
Fix Makefile smoke_test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ concourse_e2e:
 
 smoke_test:
 	@echo "Executing smoke test without submission..."
-	behave behave/features/5.not_eligible_postcode.feature --stop
+	behave behave/features/5.e2e_not_eligible_postcode.feature --stop
 
 test_e2e_local:
 	@echo "Executing e2e automated tests against the local environment..."

--- a/behave/features/8.postcode_not_found_with_change_address.feature
+++ b/behave/features/8.postcode_not_found_with_change_address.feature
@@ -64,4 +64,4 @@ Feature: COVID-19 Shielded vulnerable people service - partial user journey - po
         Given I am on the "do-you-live-in-england" page
         When I click the ".govuk-radios__item input[value='1']" element
         And I submit the form
-        Then I am redirected to the "address-lookup" page
+        Then I am redirected to the "support-address" page


### PR DESCRIPTION
The Makefile smoke_test target refers to a feature file
that was previously renamed.

The smoke_test target has now been corrected to refer
to the renamed feature file.