### PR TITLE
Clear support address after postcode change

### DIFF
--- a/vulnerable_people_form/form_pages/postcode_lookup.py
+++ b/vulnerable_people_form/form_pages/postcode_lookup.py
@@ -1,12 +1,12 @@
 from flask import redirect, session
 
+from vulnerable_people_form.integrations.postcode_lookup_helper import format_postcode
 from .blueprint import form
 from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
-from .shared.session import get_errors_from_session, request_form
+from .shared.session import get_errors_from_session, request_form, clear_answer_in_form
 from .shared.validation import validate_postcode
-from vulnerable_people_form.integrations.postcode_lookup_helper import format_postcode
 
 
 @form.route("/postcode-lookup", methods=["POST"])
@@ -15,6 +15,7 @@ def post_postcode_lookup():
     if not validate_postcode(session["postcode"], "postcode"):
         return redirect("/postcode-lookup")
 
+    clear_answer_in_form("support_address")
     session["error_items"] = {}
     return route_to_next_form_page()
 

--- a/vulnerable_people_form/form_pages/shared/session.py
+++ b/vulnerable_people_form/form_pages/shared/session.py
@@ -23,6 +23,12 @@ def request_form():
     return {k: sanitise_input(v) for k, v in request.form.items() if k != "csrf_token"}
 
 
+def clear_answer_in_form(answer_key):
+    answers = session["form_answers"]
+    if answer_key in answers:
+        answers[answer_key] = None
+
+
 def get_errors_from_session(error_group_name):
     error_list = []
     error_messages = {}


### PR DESCRIPTION
When the user changes postcode the support address in the session is now cleared so they can re-enter their address