### PR TITLE
Temporarily inline the tasks so we can use an old git

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -220,24 +220,50 @@ jobs:
         trigger: true
       - get: git-pre-do-you-live-in-england
       - task: smoke-test
-        file: git-master/concourse/tasks/smoke-test.yml
-        params:
-          WEB_APP_BASE_URL: "https://coronavirus-shielding-support.service.gov.uk"
-          MESSAGE: "Checks that the application deployed to production is not serving HTTP error codes"
-        on_failure:
-          task: cronitor-fail
-          file: git-master/concourse/tasks/cronitor.yml
-          timeout: 1m
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: gdscyber/concourse-chrome-driver
+              tag: latest
+              username: ((docker_hub_username))
+              password: ((docker_hub_password))
           params:
-            CRONITOR_URL: ((svp-form/cronitor-heartbeat-prod))
-            CRONITOR_ENDPOINT: "/fail"
-          ensure: *slack_alert_on_failure
+            CGO_ENABLE: "0"
+            DEBIAN_FRONTEND: "noninteractive"
+            PYTHONIOENCODING: "UTF-8"
+            WEB_APP_BASE_URL: "https://coronavirus-shielding-support.service.gov.uk"
+            MESSAGE: "Checks that the application deployed to production is not serving HTTP error codes"
+          inputs:
+          - name: git-pre-do-you-live-in-england
+          outputs:
+          - name: builds
+          run:
+            path: /bin/bash
+            args:
+              - -euo
+              - pipefail
+              - -c
+              - |
+                echo "running smoke tests against \"${WEB_APP_BASE_URL}\""
+                sleep 10
+                make smoke_test
+            dir: git-pre-do-you-live-in-england
+          on_failure:
+            task: cronitor-fail
+            file: git-pre-do-you-live-in-england/concourse/tasks/cronitor.yml
+            timeout: 1m
+            params:
+              CRONITOR_URL: ((svp-form/cronitor-heartbeat-prod))
+              CRONITOR_ENDPOINT: "/fail"
+            ensure: *slack_alert_on_failure
       - task: cronitor-heartbeat
         timeout: 1m
         params:
           CRONITOR_URL: ((svp-form/cronitor-heartbeat-prod))
           CRONITOR_ENDPOINT: "/complete"
-        file: git-master/concourse/tasks/cronitor.yml
+        file: git-pre-do-you-live-in-england/concourse/tasks/cronitor.yml
 
   - name: gatling-workflow-load-test-in-staging
     plan:


### PR DESCRIPTION
This is a hack built on top of the previous hack to run an old smoke
test in production whilst running the new one in production.