### PR TITLE
Update email in e2e test with backend pipeline

### DIFF
--- a/behave/features/e2e_test_features/01.simple_web_submission_entry.feature
+++ b/behave/features/e2e_test_features/01.simple_web_submission_entry.feature
@@ -75,7 +75,7 @@ Scenario: Should be redirected to contact details when no answered to basic care
 
 Scenario: Should be redirected to check contact details when email entered
     Given I am on the "contact-details" page
-    When I give the "#email" field the value "coronavirus-services-smoke-tests@digital.cabinet-office.gov.uk"
+    When I give the "#email" field the value "coronavirus-services-smoke-tests+E2E@digital.cabinet-office.gov.uk"
     And I submit the form
     Then I am redirected to the "check-contact-details" page
 


### PR DESCRIPTION
Gatling submissions cleanup script `rds_delete_gatling_test_data.py` deletes record where
contact_email='coronavirus-services-smoke-tests@digital.cabinet-office.gov.uk'. This is also email used in e2e test
with backend testing. The test is failing because records keep on getting deleted in daily run.

Hence the test is now modified to use a different email which wont be deleted through gatling data cleanup.