### PR TITLE
Remove back button from view answers page

### DIFF
--- a/vulnerable_people_form/form_pages/view_answers.py
+++ b/vulnerable_people_form/form_pages/view_answers.py
@@ -2,7 +2,6 @@ from flask import session
 
 from .blueprint import form
 from .shared.render import render_template_with_title
-from .shared.routing import dynamic_back_url
 from .shared.session import get_summary_rows_from_form_answers
 
 
@@ -11,6 +10,5 @@ def get_view_answers():
     session["check_answers_page_seen"] = True
     return render_template_with_title(
         "view-answers.html",
-        summary_rows=get_summary_rows_from_form_answers(["nhs_number", "date_of_birth"]),
-        previous_path=dynamic_back_url(),
+        summary_rows=get_summary_rows_from_form_answers(["nhs_number", "date_of_birth"])
     )

--- a/vulnerable_people_form/templates/view-answers.html
+++ b/vulnerable_people_form/templates/view-answers.html
@@ -1,7 +1,7 @@
 {%- from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList -%}
 {%- from 'govuk_frontend_jinja/components/button/macro.html' import govukButton -%}
 
-{% extends "base-with-back-link.html" %}
+{% extends "base.html" %}
 
 {% block centered_content %}
   <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">


### PR DESCRIPTION
The back link should not be present on the view answers page as this does not align with figma