### PR TITLE
Pin smoke test chromedriver to 1.1

### DIFF
--- a/concourse/tasks/smoke-test.yml
+++ b/concourse/tasks/smoke-test.yml
@@ -3,7 +3,7 @@ image_resource:
   type: registry-image
   source:
     repository: gdscyber/concourse-chrome-driver
-    tag: latest
+    tag: 1.1
     username: ((docker_hub_username))
     password: ((docker_hub_password))
 params:


### PR DESCRIPTION
We have been getting intermittent smoke test timeouts with the
chromedriver as it seems to fail to start.

This is causing alerts to occur. This seems to be a recent change, due
to some change in the gdscyber/chrome-concours-driver. It has gone
forward 5 different versions in the last 8 days, from 1.1 to 1.6.

1.1 is the last version that is significantly different to 1.6 and also
  works with the e2e tests.

It is hard to determine what master was before, as far as I can tell. I've asked cyber on slack.