### PR TITLE
Fixes for bugs found via sentry logging

### DIFF
--- a/tests/form_pages/shared/test_form_utils.py
+++ b/tests/form_pages/shared/test_form_utils.py
@@ -3,8 +3,8 @@ import pytest
 from vulnerable_people_form.form_pages.shared.form_utils import (
     clean_nhs_number,
     sanitise_date,
-    strip_non_digits
-)
+    strip_non_digits,
+    sanitise_name)
 
 
 @pytest.mark.parametrize("nhs_num", ["", None])
@@ -70,3 +70,25 @@ def test_sanitise_date_of_birth_should_raise_error_when_invalid_dict_supplied():
     with pytest.raises(ValueError) as exception_info:
         sanitise_date(test_date)
         assert "Unexpected date_of_birth encountered" in str(exception_info.value)
+
+
+def test_sanitise_name_should_strip_leading_and_trailing_whitespace():
+    test_name = {"first_name": "    ", "middle_name": " middle name  ", "last_name": "    Smith"}
+    sanitise_name(test_name)
+    assert test_name["first_name"] == ""
+    assert test_name["middle_name"] == "middle name"
+    assert test_name["last_name"] == "Smith"
+
+
+def test_sanitise_name_should_raise_error_when_invalid_length_dict_supplied():
+    test_name = {"first_name": "Tom", "middle_name": "", "last_name": "Smith", "invalid_field": "test"}
+    with pytest.raises(ValueError) as exception_info:
+        sanitise_name(test_name)
+        assert "Unexpected name value encountered" in str(exception_info.value)
+
+
+def test_sanitise_name_should_raise_error_when_invalid_dict_supplied():
+    test_name = {"first_name": "Tom", "middle_name": "", "invalid_field": "test"}
+    with pytest.raises(ValueError) as exception_info:
+        sanitise_name(test_name)
+        assert "Unexpected name value encountered" in str(exception_info.value)

--- a/vulnerable_people_form/form_pages/name.py
+++ b/vulnerable_people_form/form_pages/name.py
@@ -1,6 +1,7 @@
 from flask import redirect, session
 
 from .blueprint import form
+from .shared.form_utils import sanitise_name
 from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
@@ -20,9 +21,12 @@ def get_name():
 
 @form.route("/name", methods=["POST"])
 def post_name():
+    posted_name = request_form()
+    sanitise_name(posted_name)
+
     session["form_answers"] = {
         **session.setdefault("form_answers", {}),
-        "name": {**request_form()},
+        "name": {**posted_name},
     }
     if not validate_name():
         return redirect("/name")

--- a/vulnerable_people_form/form_pages/shared/constants.py
+++ b/vulnerable_people_form/form_pages/shared/constants.py
@@ -56,7 +56,6 @@ NHS_USER_INFO_TO_FORM_ANSWERS = {
     ("name", "first_name"): "given_name",
     ("name", "last_name"): "family_name",
     ("contact_details", "phone_number_calls"): "phone_number",
-    ("contact_details", "phone_number_texts"): "phone_number",
     ("contact_details", "email"): "email",
     ("nhs_number",): "nhs_number",
     ("date_of_birth", "day"): partial(get_partial_date_from_userinfo, "day"),

--- a/vulnerable_people_form/form_pages/shared/form_utils.py
+++ b/vulnerable_people_form/form_pages/shared/form_utils.py
@@ -25,3 +25,14 @@ def sanitise_date(date_value):
         date_value["day"] = strip_non_digits(date_value["day"])
         date_value["month"] = strip_non_digits(date_value["month"])
         date_value["year"] = strip_non_digits(date_value["year"])
+
+
+def sanitise_name(name_value):
+    if name_value:
+        if len(name_value.keys()) != 3 or \
+          not all(k in name_value for k in ["first_name", "middle_name", "last_name"]):
+            raise ValueError("Unexpected name value encountered: " + str(name_value))
+
+        name_value["first_name"] = name_value["first_name"].strip()
+        name_value["middle_name"] = name_value["middle_name"].strip()
+        name_value["last_name"] = name_value["last_name"].strip()

--- a/vulnerable_people_form/form_pages/shared/validation.py
+++ b/vulnerable_people_form/form_pages/shared/validation.py
@@ -144,7 +144,7 @@ def validate_address_lookup():
     return True
 
 
-def isNumber(string):
+def is_number(string):
     try:
         int(string)
         return True
@@ -152,7 +152,7 @@ def isNumber(string):
         return False
 
 
-def isPositiveInt(string):
+def is_positive_int(string):
     try:
         value = int(string)
     except ValueError:
@@ -164,26 +164,35 @@ def failing_field(field_bools, field_names):
     return field_names[field_bools.index(True)]
 
 
+def _date_field_exceeds_max_permitted_length(value, field_name):
+    permitted_max_field_lengths = {"day": 2, "month": 2, "year": 4}
+    return value and len(value) > permitted_max_field_lengths[field_name]
+
+
 def validate_date_of_birth():
     day = form_answers().get("date_of_birth", {}).get("day", "")
     month = form_answers().get("date_of_birth", {}).get("month", "")
     year = form_answers().get("date_of_birth", {}).get("year", "")
 
     fields = [month, day, year]
-    fieldsEmpty = [period == "" for period in fields]
-    fieldsNotNumbers = [not isNumber(period) for period in fields]
-    fieldsNotPositiveInt = [not isPositiveInt(period) for period in fields]
-    fieldNames = ("month", "day", "year")
+    field_names = ("month", "day", "year")
+    fields_empty = [period == "" for period in fields]
+    fields_not_numbers = [not is_number(period) for period in fields]
+    fields_not_positive_int = [not is_positive_int(period) for period in fields]
+    fields_invalid_length = [_date_field_exceeds_max_permitted_length(period, field_names[idx])
+                             for (idx, period) in enumerate(fields)]
 
     error = None
-    if all(fieldsEmpty):
+    if all(fields_empty):
         error = "Enter your date of birth"
-    elif any(fieldsEmpty):
-        error = "Enter your date of birth and include a day month and a year"
-    elif any(fieldsNotNumbers):
-        error = f"Enter {failing_field(fieldsNotNumbers, fieldNames)} as a number"
-    elif any(fieldsNotPositiveInt):
-        error = f"Enter a real {failing_field(fieldsNotPositiveInt, fieldNames)}"
+    elif any(fields_empty):
+        error = "Enter your date of birth and include a day, month and a year"
+    elif any(fields_not_numbers):
+        error = f"Enter {failing_field(fields_not_numbers, field_names)} as a number"
+    elif any(fields_not_positive_int):
+        error = f"Enter a real {failing_field(fields_not_positive_int, field_names)}"
+    elif any(fields_invalid_length):
+        error = f"Enter a {failing_field(fields_invalid_length, field_names)} with the correct amount of digits"
 
     invalid_date_message = "Enter a real date of birth"
     if error is None:


### PR DESCRIPTION
Date of birth input validation - no longer allows
incorrect dates such as 10-010-1980

Name validation - no longer allows names consisting
of white space characters only to pass validation.

NHS login callback - the phone number retrieved from
NHS login API is now no longer used to populate the
phone number for SMS.