### PR TITLE
Remove unnecessary wrong postcode sentry logging

### DIFF
--- a/vulnerable_people_form/integrations/postcode_lookup_helper.py
+++ b/vulnerable_people_form/integrations/postcode_lookup_helper.py
@@ -108,15 +108,14 @@ def get_addresses_from_postcode(postcode):
                     )
             return values
     elif response.status_code == HTTPStatus.UNAUTHORIZED.value:
-        _log_postcode_lookup_failure("Unauthorised request submitted to API", postcode)
+        _log_postcode_lookup_failure("Unauthorised request submitted to API", postcode, response.text)
         sentry_sdk.capture_message("Invalid ORDNANCE_SURVEY_PLACES_API_KEY", "error")
         raise ErrorFindingAddress()
     elif response.status_code == HTTPStatus.BAD_REQUEST.value:
-        _log_postcode_lookup_failure("Invalid request submitted to API", postcode)
-        sentry_sdk.capture_message("Invalid OS postcode request:" + response.text, "error")
+        _log_postcode_lookup_failure("Invalid request submitted to API", postcode, response.text)
         raise PostcodeNotFound()
     else:
-        _log_postcode_lookup_failure("Error finding address", postcode)
+        _log_postcode_lookup_failure("Error finding address", postcode, response.text)
         raise ErrorFindingAddress()
 
 
@@ -127,6 +126,7 @@ def format_postcode(postcode):
     return None
 
 
-def _log_postcode_lookup_failure(failure_reason, postcode):
+def _log_postcode_lookup_failure(failure_reason, postcode, response_body):
+    response_body_to_log = response_body if response_body else "response body empty"
     logger.error(create_log_message(log_event_names["ORDNANCE_SURVEY_LOOKUP_FAILURE"],
-                                    f"Failure reason: {failure_reason}, Postcode: {postcode}"))
+                                    f"Failure reason: {failure_reason}, Postcode: {postcode}, API response: {response_body_to_log}"))  # noqa


### PR DESCRIPTION
When the OS Places API is invoked to lookup an
address if the postcode entered by the user
isn't recognised an error was being logged to
sentry resulting in misleading errors.

Now address lookup failures are logged to
splunk only.