### PR TITLE
Fix error for returning user amending address

### DIFF
--- a/vulnerable_people_form/form_pages/postcode_lookup.py
+++ b/vulnerable_people_form/form_pages/postcode_lookup.py
@@ -5,7 +5,12 @@ from .blueprint import form
 from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
-from .shared.session import get_errors_from_session, request_form, delete_answer_from_form
+from .shared.session import (
+    get_errors_from_session,
+    request_form,
+    delete_answer_from_form,
+    accessing_saved_answers
+)
 from .shared.validation import validate_postcode
 
 
@@ -15,7 +20,9 @@ def post_postcode_lookup():
     if not validate_postcode(session["postcode"], "postcode"):
         return redirect("/postcode-lookup")
 
-    delete_answer_from_form("support_address")
+    if not accessing_saved_answers():
+        delete_answer_from_form("support_address")
+
     session["error_items"] = {}
     return route_to_next_form_page()
 

--- a/vulnerable_people_form/form_pages/shared/routing.py
+++ b/vulnerable_people_form/form_pages/shared/routing.py
@@ -72,7 +72,7 @@ def get_redirect_to_terminal_page_if_applicable():
         return get_redirect_to_terminal_page()
 
 
-def redirect_to_next_form_page(redirect_target=True):
+def redirect_to_next_form_page(redirect_target):
     next_page_name = redirect_target.strip("/")
     next_page_does_not_need_answer = (
         form_answers().get(FORM_PAGE_TO_DATA_CHECK_SECTION_NAME[next_page_name]) is not None
@@ -214,6 +214,10 @@ def route_to_next_form_page():
 
         lives_in_england_referrer = session.get(SESSION_KEY_LIVES_IN_ENGLAND_REFERRER)
         next_form_url = get_next_form_url_after_lives_in_england(lives_in_england_referrer)
+
+        if accessing_saved_answers() and lives_in_england_referrer == "/postcode-lookup":
+            return redirect(next_form_url)
+
         return redirect_to_next_form_page(next_form_url)
     else:
         raise RuntimeError("An unexpected error occurred")


### PR DESCRIPTION
When a returning user was changing their postcode
then an error occurred due to the support_address
being cleared from the session.

The support_address is now no longer cleared from
the session form_answers for returning users.