### PR TITLE
Task/update address validation

### DIFF
--- a/tests/form_pages/shared/test_form_utils.py
+++ b/tests/form_pages/shared/test_form_utils.py
@@ -4,7 +4,8 @@ from vulnerable_people_form.form_pages.shared.form_utils import (
     clean_nhs_number,
     sanitise_date,
     strip_non_digits,
-    sanitise_name)
+    sanitise_name,
+    sanitise_support_address)
 
 
 @pytest.mark.parametrize("nhs_num", ["", None])
@@ -62,33 +63,68 @@ def test_sanitise_date_of_birth_should_raise_error_when_invalid_length_dict_supp
     test_date = {"day": "13", "month": "7", "year": "1991", "random_field": "test"}
     with pytest.raises(ValueError) as exception_info:
         sanitise_date(test_date)
-        assert "Unexpected date_of_birth encountered" in str(exception_info.value)
+    assert "Unexpected date_value encountered" in str(exception_info.value)
 
 
 def test_sanitise_date_of_birth_should_raise_error_when_invalid_dict_supplied():
     test_date = {"day": "13", "month": "7", "invalid_field": "test"}
     with pytest.raises(ValueError) as exception_info:
         sanitise_date(test_date)
-        assert "Unexpected date_of_birth encountered" in str(exception_info.value)
+    assert "Unexpected date_value encountered" in str(exception_info.value)
 
 
 def test_sanitise_name_should_strip_leading_and_trailing_whitespace():
     test_name = {"first_name": "    ", "middle_name": " middle name  ", "last_name": "    Smith"}
-    sanitise_name(test_name)
-    assert test_name["first_name"] == ""
-    assert test_name["middle_name"] == "middle name"
-    assert test_name["last_name"] == "Smith"
+    sanitised_name = sanitise_name(test_name)
+    assert sanitised_name["first_name"] == ""
+    assert sanitised_name["middle_name"] == "middle name"
+    assert sanitised_name["last_name"] == "Smith"
 
 
 def test_sanitise_name_should_raise_error_when_invalid_length_dict_supplied():
     test_name = {"first_name": "Tom", "middle_name": "", "last_name": "Smith", "invalid_field": "test"}
     with pytest.raises(ValueError) as exception_info:
         sanitise_name(test_name)
-        assert "Unexpected name value encountered" in str(exception_info.value)
+    assert "Unexpected name value encountered" in str(exception_info.value)
 
 
 def test_sanitise_name_should_raise_error_when_invalid_dict_supplied():
     test_name = {"first_name": "Tom", "middle_name": "", "invalid_field": "test"}
     with pytest.raises(ValueError) as exception_info:
         sanitise_name(test_name)
-        assert "Unexpected name value encountered" in str(exception_info.value)
+    assert "Unexpected name value encountered" in str(exception_info.value)
+
+
+def test_sanitise_support_address_should_strip_leading_and_trailing_whitespace():
+    test_case_support_address = {
+        "building_and_street_line_1": " address line one   ",
+        "building_and_street_line_2": "  address line  two     ",
+        "town_city": "  test town city",
+        "postcode": "LS1 1BA  "
+    }
+    sanitised_support_address = sanitise_support_address(test_case_support_address)
+    assert sanitised_support_address["building_and_street_line_1"] == "address line one"
+    assert sanitised_support_address["building_and_street_line_2"] == "address line  two"
+    assert sanitised_support_address["town_city"] == "test town city"
+    assert sanitised_support_address["postcode"] == "LS1 1BA"
+
+
+def test_sanitise_support_address_should_raise_error_when_invalid_length_dict_supplied():
+    test_support_address = {
+        "building_and_street_line_1": "test",
+        "building_and_street_line_2": "",
+        "invalid_field": "test"
+    }
+    with pytest.raises(ValueError) as exception_info:
+        sanitise_support_address(test_support_address)
+    assert "Unexpected support_address value encountered" in str(exception_info.value)
+
+
+def test_sanitise_support_address_should_raise_error_when_invalid_dict_supplied():
+    test_support_address = {"building_and_street_line_1": "test",
+                            "building_and_street_line_2": "test",
+                            "town_city": "test",
+                            "invalid_field": "test"}
+    with pytest.raises(ValueError) as exception_info:
+        sanitise_support_address(test_support_address)
+    assert "Unexpected support_address value encountered" in str(exception_info.value)

--- a/tests/form_pages/shared/test_render.py
+++ b/tests/form_pages/shared/test_render.py
@@ -70,4 +70,4 @@ def test_render_template_with_title_invokes_render_template_with_correct_form_ba
 def test_render_template_with_title_raises_error_when_invalid_template_name_supplied():
     with pytest.raises(ValueError) as error_info:
         render_template_with_title("invalid-template-name")
-        assert error_info.value == "Template names must end with '.html' for a title to be assigned"
+    assert str(error_info.value) == "Template names must end with '.html' for a title to be assigned"

--- a/vulnerable_people_form/form_pages/name.py
+++ b/vulnerable_people_form/form_pages/name.py
@@ -21,8 +21,7 @@ def get_name():
 
 @form.route("/name", methods=["POST"])
 def post_name():
-    posted_name = request_form()
-    sanitise_name(posted_name)
+    posted_name = sanitise_name(request_form())
 
     session["form_answers"] = {
         **session.setdefault("form_answers", {}),

--- a/vulnerable_people_form/form_pages/shared/form_utils.py
+++ b/vulnerable_people_form/form_pages/shared/form_utils.py
@@ -20,19 +20,36 @@ def sanitise_date(date_value):
     if date_value:
         if len(date_value.keys()) != 3 or \
           not all(k in date_value for k in ["day", "month", "year"]):
-            raise ValueError("Unexpected date_value encountered: " + str(date_value))
+            raise ValueError(f"Unexpected date_value encountered: {date_value}")
 
-        date_value["day"] = strip_non_digits(date_value["day"])
-        date_value["month"] = strip_non_digits(date_value["month"])
-        date_value["year"] = strip_non_digits(date_value["year"])
+        for k in date_value.keys():
+            date_value[k] = strip_non_digits(date_value[k])
 
 
 def sanitise_name(name_value):
     if name_value:
         if len(name_value.keys()) != 3 or \
           not all(k in name_value for k in ["first_name", "middle_name", "last_name"]):
-            raise ValueError("Unexpected name value encountered: " + str(name_value))
+            raise ValueError(f"Unexpected name value encountered: {name_value}")
 
-        name_value["first_name"] = name_value["first_name"].strip()
-        name_value["middle_name"] = name_value["middle_name"].strip()
-        name_value["last_name"] = name_value["last_name"].strip()
+        return _strip_whitespace_from_dict_values(name_value)
+
+    return name_value
+
+
+def sanitise_support_address(support_address):
+    if support_address:
+        if len(support_address.keys()) != 4 or \
+           not all(k in support_address for k in [
+               "building_and_street_line_1",
+               "building_and_street_line_2",
+               "town_city",
+               "postcode"]):
+            raise ValueError(f"Unexpected support_address value encountered: {support_address}")
+        return _strip_whitespace_from_dict_values(support_address)
+
+    return support_address
+
+
+def _strip_whitespace_from_dict_values(input_dict):
+    return {k: v.strip() for k, v in input_dict.items()}

--- a/vulnerable_people_form/form_pages/shared/validation.py
+++ b/vulnerable_people_form/form_pages/shared/validation.py
@@ -252,13 +252,13 @@ def validate_support_address():
         [
             validate_length(
                 ("support_address", "building_and_street_line_1"),
-                75,
-                length_fstring.format("Address line 1", 75),
+                110,
+                length_fstring.format("Address line 1", 110),
             ),
             validate_length(
                 ("support_address", "building_and_street_line_2"),
-                75,
-                length_fstring.format("Address line 2", 75),
+                210,
+                length_fstring.format("Address line 2", 210),
             ),
             validate_mandatory_form_field(
                 "support_address",

--- a/vulnerable_people_form/form_pages/support_address.py
+++ b/vulnerable_people_form/form_pages/support_address.py
@@ -3,6 +3,7 @@ from flask import redirect, session
 from vulnerable_people_form.integrations.postcode_lookup_helper import format_postcode
 from .blueprint import form
 from .shared.constants import SESSION_KEY_ADDRESS_SELECTED
+from .shared.form_utils import sanitise_support_address
 from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
@@ -12,7 +13,7 @@ from .shared.validation import validate_support_address
 
 @form.route("/support-address", methods=["POST"])
 def post_support_address():
-    support_address_from_form = request_form()
+    support_address_from_form = sanitise_support_address(request_form())
     support_address_from_form["postcode"] = format_postcode(support_address_from_form["postcode"])
     original_address = {k: v for k, v in form_answers().get("support_address", {}).items() if k != "uprn"}
     session["postcode"] = support_address_from_form["postcode"]


### PR DESCRIPTION
The address line one and two fields were limited to 75 characters
by the database and input validation. The OS places API returns
addresses with that may contain address line two fields longer than
75 characters.
    
This pull request amends the input validation to permit up to 100
characters for address line 1 and 2. Furthermore, leading and trailing
whitespace is not stripped from the user-entered address field values
and unit tests have been added to cover the support_address input
validation.
