### PR TITLE
Use new stored procedures with tiering

### DIFF
--- a/tests/form_pages/shared/test_session.py
+++ b/tests/form_pages/shared/test_session.py
@@ -243,7 +243,8 @@ def test_persist_answers_from_session():
             "nhs_letter": NHSLetterAnswers.YES.value,
             "basic_care_needs": YesNoAnswers.NO.value,
             "medical_conditions": MedicalConditionsAnswers.YES.value,
-            "do_you_live_in_england": LiveInEnglandAnswers.YES.value
+            "do_you_live_in_england": LiveInEnglandAnswers.YES.value,
+            "tier_at_submission": None,
         }
 
         test_request_ctx.session["nhs_sub"] = nhs_sub_value
@@ -274,7 +275,9 @@ def test_persist_answers_from_session():
             data_to_persist["basic_care_needs"],
             data_to_persist["do_you_have_someone_to_go_shopping_for_you"],
             data_to_persist["medical_conditions"],
-            data_to_persist["do_you_live_in_england"])
+            data_to_persist["do_you_live_in_england"],
+            data_to_persist["tier_at_submission"],
+        )
 
         assert test_request_ctx.session["form_uid"] == submission_ref
         assert returned_submission_ref == submission_ref

--- a/tests/integrations/test_persistence.py
+++ b/tests/integrations/test_persistence.py
@@ -122,6 +122,7 @@ def test_persist_answers_should_map_parameters_correctly():
     do_you_have_someone_to_go_shopping_for_you = 1
     do_you_have_one_of_the_listed_medical_conditions = 0
     do_you_live_in_england = 1
+    tier_at_submission = 1
 
     with patch("vulnerable_people_form.integrations.persistence.execute_sql",
                return_value={"records": [[None, {"stringValue": submission_ref}]]}) as mock_execute_sql:
@@ -146,11 +147,12 @@ def test_persist_answers_should_map_parameters_correctly():
             do_you_need_help_meeting_your_basic_care_needs,
             do_you_have_someone_to_go_shopping_for_you,
             do_you_have_one_of_the_listed_medical_conditions,
-            do_you_live_in_england)
+            do_you_live_in_england,
+            tier_at_submission)
 
         assert submission_reference == submission_ref
         mock_execute_sql.assert_called_once_with(
-            sql="CALL cv_staging.create_web_submission("
+            sql="CALL cv_staging.create_web_submission_with_tier("
                 ":nhs_number,"
                 ":first_name,"
                 ":middle_name,"
@@ -171,7 +173,8 @@ def test_persist_answers_should_map_parameters_correctly():
                 ":do_you_need_help_meeting_your_basic_care_needs,"
                 ":do_you_have_someone_to_go_shopping_for_you,"
                 ":do_you_have_one_of_the_listed_medical_conditions,"
-                ":do_you_live_in_england"
+                ":do_you_live_in_england,"
+                ":tier_at_submission"
                 ")",
             parameters=(
                 {"name": "nhs_number", "value": {"stringValue": nhs_number}},
@@ -219,6 +222,10 @@ def test_persist_answers_should_map_parameters_correctly():
                 {
                     "name": "do_you_live_in_england",
                     "value": {"doubleValue": do_you_live_in_england}
+                },
+                {
+                    "name": "tier_at_submission",
+                    "value": {"doubleValue": tier_at_submission},
                 }
             )
         )

--- a/vulnerable_people_form/form_pages/shared/session.py
+++ b/vulnerable_people_form/form_pages/shared/session.py
@@ -213,6 +213,7 @@ def persist_answers_from_session():
         form_answers().get("do_you_have_someone_to_go_shopping_for_you"),
         form_answers().get("medical_conditions"),
         lives_in_england,
+        None,
     )
 
     session["form_uid"] = submission_reference
@@ -253,7 +254,8 @@ def load_answers_into_session_if_available():
             do_you_need_help_meeting_your_basic_care_needs,
             do_you_have_someone_to_go_shopping_for_you,
             do_you_have_one_of_the_listed_medical_conditions,
-            do_you_live_in_england
+            do_you_live_in_england,
+            tier_at_submission,
         ) = stored_answers
 
         date_of_birth = datetime.date.fromisoformat(date_of_birth["stringValue"])
@@ -293,6 +295,7 @@ def load_answers_into_session_if_available():
             "basic_care_needs": do_you_need_help_meeting_your_basic_care_needs["longValue"],
             "do_you_have_someone_to_go_shopping_for_you": do_you_have_someone_to_go_shopping_for_you["longValue"],
             "do_you_live_in_england": do_you_live_in_england.get("longValue"),
+            "tier_at_submission": tier_at_submission.get("longValue"),
         }
         priority_supermarket_deliveries = do_you_want_supermarket_deliveries.get("longValue")
         if priority_supermarket_deliveries is not None:

--- a/vulnerable_people_form/integrations/persistence.py
+++ b/vulnerable_people_form/integrations/persistence.py
@@ -204,9 +204,10 @@ def persist_answers(
     do_you_have_someone_to_go_shopping_for_you,
     do_you_have_one_of_the_listed_medical_conditions,
     do_you_live_in_england,
+    tier_at_submission,
 ):
     result = execute_sql(
-        sql="CALL cv_staging.create_web_submission("
+        sql="CALL cv_staging.create_web_submission_with_tier("
         ":nhs_number,"
         ":first_name,"
         ":middle_name,"
@@ -227,7 +228,8 @@ def persist_answers(
         ":do_you_need_help_meeting_your_basic_care_needs,"
         ":do_you_have_someone_to_go_shopping_for_you,"
         ":do_you_have_one_of_the_listed_medical_conditions,"
-        ":do_you_live_in_england"
+        ":do_you_live_in_england,"
+        ":tier_at_submission"
         ")",
         parameters=(
             generate_string_parameter("nhs_number", nhs_number),
@@ -266,6 +268,7 @@ def persist_answers(
                 "do_you_live_in_england",
                 do_you_live_in_england,
             ),
+            generate_int_parameter("tier_at_submission", tier_at_submission),
         ),
     )
     submission_reference = result["records"][0][1]["stringValue"]
@@ -274,7 +277,7 @@ def persist_answers(
 
 def load_answers(nhs_uid):
     records = execute_sql(
-        "CALL cv_base.retrieve_latest_web_submission_for_nhs_login(" "    :uid_nhs_login" ")",
+        "CALL cv_base.retrieve_latest_web_submission_with_tier_for_nhs_login(" "    :uid_nhs_login" ")",
         (generate_string_parameter("uid_nhs_login", nhs_uid),),
     )["records"]
 


### PR DESCRIPTION
This change makes the web form able to store tiering information against
a submission but just stores NULL for the time being.

We are also in the process of migrating this new stored procedure to be
the same as the original stored procedure.