### PR TITLE
Remove ASDA from supermarket deliveries page

### DIFF
--- a/vulnerable_people_form/templates/priority-supermarket-deliveries.html
+++ b/vulnerable_people_form/templates/priority-supermarket-deliveries.html
@@ -29,7 +29,6 @@
       <p>You will need to create accounts with supermarkets if you do not already have them.</p>
       <p>Supermarkets involved:</p>
       <ul class='govuk-list govuk-list--bullet'>
-          <li>ASDA</li>
           <li>Iceland</li>
           <li>Morrisons</li>
           <li>Ocado</li>


### PR DESCRIPTION
Remove ASDA from the list as Asda have stopped accepting new referrals from the NSSS