### PR TITLE
Modify the SPL check to point to performance efficient temp version

### DIFF
--- a/vulnerable_people_form/integrations/spl_check.py
+++ b/vulnerable_people_form/integrations/spl_check.py
@@ -8,11 +8,13 @@ init_logger(logger)
 
 
 def check_spl(nhs_number, date_of_birth):
+    test_mode = 'NO'
     records = execute_sql(
-        "CALL cv_base.is_person_currently_on_the_spl(:nhs_number, :date_of_birth)",
+        "CALL cv_base.is_person_currently_on_the_spl_new(:nhs_number, :date_of_birth, :test_mode)",
         (
             generate_string_parameter("nhs_number", nhs_number),
             generate_date_parameter("date_of_birth", date_of_birth),
+            generate_string_parameter("test_mode", test_mode),
         ),
     )["records"]
 


### PR DESCRIPTION
This PR modifies the app to use a new efficient temp versio of SPL check sproc. This is needed
so that the original/master sproc is updated without giving Front end app any downtime.

This should be deployed inline with instructions on https://github.com/alphagov/covid-engineering/pull/1001