### PR TITLE
Use the originally sprocs that now support tiers

### DIFF
--- a/tests/integrations/test_persistence.py
+++ b/tests/integrations/test_persistence.py
@@ -152,7 +152,7 @@ def test_persist_answers_should_map_parameters_correctly():
 
         assert submission_reference == submission_ref
         mock_execute_sql.assert_called_once_with(
-            sql="CALL cv_staging.create_web_submission_with_tier("
+            sql="CALL cv_staging.create_web_submission("
                 ":nhs_number,"
                 ":first_name,"
                 ":middle_name,"

--- a/vulnerable_people_form/integrations/persistence.py
+++ b/vulnerable_people_form/integrations/persistence.py
@@ -207,7 +207,7 @@ def persist_answers(
     tier_at_submission,
 ):
     result = execute_sql(
-        sql="CALL cv_staging.create_web_submission_with_tier("
+        sql="CALL cv_staging.create_web_submission("
         ":nhs_number,"
         ":first_name,"
         ":middle_name,"
@@ -277,7 +277,7 @@ def persist_answers(
 
 def load_answers(nhs_uid):
     records = execute_sql(
-        "CALL cv_base.retrieve_latest_web_submission_with_tier_for_nhs_login(" "    :uid_nhs_login" ")",
+        "CALL cv_base.retrieve_latest_web_submission_for_nhs_login(" "    :uid_nhs_login" ")",
         (generate_string_parameter("uid_nhs_login", nhs_uid),),
     )["records"]
 


### PR DESCRIPTION
We've updated the originally named sprocs so that they use the tiers
now. After this change we can delete the `_with_tier` sprocs from the
DB.