### PR TITLE
Fix edit name - dob validation error - nhs user

### DIFF
--- a/tests/form_pages/shared/test_validation.py
+++ b/tests/form_pages/shared/test_validation.py
@@ -431,6 +431,17 @@ def test_validate_date_of_birth_should_return_false_when_an_invalid_date_of_birt
     )
 
 
+@pytest.mark.parametrize("form_field_value",
+                         [{"day": "12", "month": "12", "year": "1987"}, {"day": 8, "month": 5, "year": 2006}])
+def test_validate_date_of_birth_should_return_true_when_a_valid_date_of_birth_is_provided(
+        form_field_value):
+    _execute_input_validation_test_and_assert_validation_passed(
+        validation.validate_date_of_birth,
+        form_field_value,
+        "date_of_birth"
+    )
+
+
 def test_validate_support_address_should_return_true_when_a_valid_address_is_provided():
     with _current_app.test_request_context() as test_request_ctx:
         test_request_ctx.session["form_answers"] = {

--- a/vulnerable_people_form/form_pages/date_of_birth.py
+++ b/vulnerable_people_form/form_pages/date_of_birth.py
@@ -28,8 +28,8 @@ def post_date_of_birth():
         **session.setdefault("form_answers", {}),
         "date_of_birth": {**posted_date_of_birth},
     }
+    session["error_items"] = {}
     if not validate_date_of_birth():
         return redirect("/date-of-birth")
 
-    session["error_items"] = {}
     return route_to_next_form_page()


### PR DESCRIPTION
When a user's details are retrieved from the NHS login
API and subsequently used to populate the form_answers()
the data type for day/month/year is an int rather than a
string (the string data type is present when the user
manually enters their dob via the UI).

This was causing the validate_date_of_birth function to
raise an error as it was expecting to receive a string
when verifying the correct quanity of digits have been
entered for the day, month and year respectively.

This error was manifesting when an NHS login user was
attempting to change their name from either the
/check-your-answers (new submission journey) or
/view-answers (returning user journey) pages.

A fix has been implemented to only check the length
of values that are of the type string.