### PR TITLE
Make separate test step for sandbox

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -83,12 +83,22 @@ jobs:
         file: git-master/concourse/tasks/test.yml
     on_failure: *slack_alert_on_failure
 
+  - name: test-sandbox
+    serial: true
+    plan:
+      - get: git-sandbox
+        trigger: true
+      - task: test
+        file: git-sandbox/concourse/tasks/test.yml
+    on_failure: *slack_alert_on_failure
+
+
   - name: deploy-to-sandbox
     serial: true
     plan:
       - get: git-sandbox
         trigger: true
-        passed: [test]
+        passed: [test-sandbox]
       - task: deploy-to-paas
         config:
         file: git-sandbox/concourse/tasks/deploy-to-govuk-paas.yml

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -92,7 +92,6 @@ jobs:
         file: git-sandbox/concourse/tasks/test.yml
     on_failure: *slack_alert_on_failure
 
-
   - name: deploy-to-sandbox
     serial: true
     plan:


### PR DESCRIPTION
As we want sandbox to be tested before it is deployed and testing
git-master errors and is un-informative, instead test git-sandbox.

This does not rely on the pipeline having been updated using git-master, which
I think is okay