### PR TITLE
Implement returning user dynamic journey

### DIFF
--- a/tests/form_pages/shared/test_postcode_tier.py
+++ b/tests/form_pages/shared/test_postcode_tier.py
@@ -5,8 +5,8 @@ import pytest
 from vulnerable_people_form.form_pages.shared.constants import PostcodeTier
 from vulnerable_people_form.form_pages.shared.postcode_tier import (
     update_postcode_tier,
-    is_tier_very_high_or_above
-)
+    is_tier_very_high_or_above,
+    is_tier_less_than_very_high)
 
 _current_app = Flask(__name__)
 _current_app.secret_key = 'test_secret'
@@ -46,3 +46,13 @@ def test_update_postcode_tier_should_update_session_when_tiering_logic_enabled()
                           (PostcodeTier.VERY_HIGH_PLUS_SHIELDING.value, True)])
 def test_is_tier_very_high_or_above_should_return_expected_value(postcode_tier, expected_output):
     assert is_tier_very_high_or_above(postcode_tier) == expected_output
+
+
+@pytest.mark.parametrize("postcode_tier, expected_output",
+                         [(None, False),
+                          (PostcodeTier.MEDIUM.value, True),
+                          (PostcodeTier.HIGH.value, True),
+                          (PostcodeTier.VERY_HIGH.value, False),
+                          (PostcodeTier.VERY_HIGH_PLUS_SHIELDING.value, False)])
+def test_is_tier_less_than_very_high_should_return_expected_value(postcode_tier, expected_output):
+    assert is_tier_less_than_very_high(postcode_tier) == expected_output

--- a/vulnerable_people_form/form_pages/nhs_login_callback.py
+++ b/vulnerable_people_form/form_pages/nhs_login_callback.py
@@ -2,10 +2,13 @@ import logging
 
 from flask import abort, current_app, redirect, request, session
 
-from vulnerable_people_form.form_pages.shared.logger_utils import init_logger, create_log_message, log_event_names
 from .blueprint import form
-from .shared.routing import get_redirect_to_terminal_page
-from .shared.session import load_answers_into_session_if_available, set_form_answers_from_nhs_user_info
+from .shared.logger_utils import init_logger, create_log_message, log_event_names
+from .shared.routing import get_redirect_to_terminal_page, get_redirect_for_returning_user_based_on_tier
+from .shared.session import (
+    load_answers_into_session_if_available,
+    set_form_answers_from_nhs_user_info
+)
 
 logger = logging.getLogger(__name__)
 init_logger(logger)
@@ -34,6 +37,9 @@ def get_nhs_login_callback():
     session["nhs_sub"] = nhs_user_info["sub"]
 
     if load_answers_into_session_if_available():
+        if current_app.is_tiering_logic_enabled:
+            return get_redirect_for_returning_user_based_on_tier()
+
         return get_redirect_to_terminal_page()
 
     set_form_answers_from_nhs_user_info(nhs_user_info)

--- a/vulnerable_people_form/form_pages/not_eligible_postcode.py
+++ b/vulnerable_people_form/form_pages/not_eligible_postcode.py
@@ -1,6 +1,6 @@
 from flask import current_app
 
-from vulnerable_people_form.form_pages.shared.constants import PostcodeTier
+from vulnerable_people_form.form_pages.shared.postcode_tier import is_tier_less_than_very_high
 from vulnerable_people_form.form_pages.shared.session import get_postcode_tier
 from .blueprint import form
 from .shared.render import render_template_with_title
@@ -13,11 +13,21 @@ def get_not_eligible_postcode():
     return render_template_with_title(template_name, previous_path=dynamic_back_url())
 
 
+@form.route("/not-eligible-postcode-returning-user", methods=["GET"])
+def get_not_eligible_postcode_returning_user():
+    return render_template_with_title("not-eligible-postcode-returning-user.html")
+
+
+@form.route("/not-eligible-postcode-returning-user-tier-not-found", methods=["GET"])
+def get_not_eligible_postcode_returning_user_tier_not_found():
+    return render_template_with_title("not-eligible-postcode-returning-user-tier-not-found.html")
+
+
 def _get_template_name():
     if current_app.is_tiering_logic_enabled:
         postcode_tier = get_postcode_tier()
-        if postcode_tier and postcode_tier not in [PostcodeTier.MEDIUM.value, PostcodeTier.HIGH.value]:
-            raise ValueError(f"Unexpected postcode tier encountered: {postcode_tier}")
+        if is_tier_less_than_very_high(postcode_tier):
+            return "not-eligible-postcode-tier.html"
         return "not-eligible-postcode-tier.html" if postcode_tier else "not-eligible-postcode-not-found.html"
 
     return "not-eligible-postcode.html"

--- a/vulnerable_people_form/form_pages/shared/constants.py
+++ b/vulnerable_people_form/form_pages/shared/constants.py
@@ -43,6 +43,8 @@ PAGE_TITLES = {
     "not-eligible-postcode": "Sorry, this service is only available in England",
     "not-eligible-postcode-tier": "Sorry, this service is not available in your area",
     "not-eligible-postcode-not-found": "Sorry, we could not find your postcode in our system",
+    "not-eligible-postcode-returning-user": "Sorry, this service is not available in your area",
+    "not-eligible-postcode-returning-user-tier-not-found": "Sorry, we could not find your postcode in our system",
     "not-eligible-medical": "Sorry, you’re not eligible for help through this service",
     "postcode-lookup": "What is the postcode where you need support?",
     "postcode-eligibility": "What is the postcode where you need support?",
@@ -80,8 +82,15 @@ class JourneyProgress(enum.Enum):
 
 
 @enum.unique
-class PostcodeTier(enum.Enum):
+class PostcodeTier(enum.IntEnum):
     MEDIUM = 1
     HIGH = 2
     VERY_HIGH = 3
     VERY_HIGH_PLUS_SHIELDING = 4
+
+
+@enum.unique
+class PostcodeTierStatus(enum.IntEnum):
+    NO_CHANGE = 1
+    INCREASED = 2
+    DECREASED = 3

--- a/vulnerable_people_form/form_pages/shared/postcode_tier.py
+++ b/vulnerable_people_form/form_pages/shared/postcode_tier.py
@@ -1,4 +1,4 @@
-from vulnerable_people_form.form_pages.shared.constants import PostcodeTier
+from vulnerable_people_form.form_pages.shared.constants import PostcodeTier, PostcodeTierStatus
 from vulnerable_people_form.form_pages.shared.session import set_postcode_tier
 from vulnerable_people_form.integrations.postcode_eligibility import get_postcode_tier
 
@@ -10,5 +10,28 @@ def update_postcode_tier(postcode, app):
 
 
 def is_tier_very_high_or_above(postcode_tier):
-    return postcode_tier is not None and (postcode_tier == PostcodeTier.VERY_HIGH.value
-                                          or postcode_tier == PostcodeTier.VERY_HIGH_PLUS_SHIELDING.value)
+    return postcode_tier is not None \
+           and (postcode_tier in [PostcodeTier.VERY_HIGH.value, PostcodeTier.VERY_HIGH_PLUS_SHIELDING.value])
+
+
+def is_tier_less_than_very_high(postcode_tier):
+    return postcode_tier is not None and (postcode_tier in [PostcodeTier.MEDIUM.value, PostcodeTier.HIGH.value])
+
+
+def get_latest_postcode_tier(original_postcode, original_postcode_tier):
+    latest_postcode_tier = get_postcode_tier(original_postcode)
+
+    if latest_postcode_tier is None:
+        return latest_postcode_tier
+
+    if latest_postcode_tier == original_postcode_tier:
+        change_status = PostcodeTierStatus.NO_CHANGE
+    elif latest_postcode_tier < original_postcode_tier:
+        change_status = PostcodeTierStatus.DECREASED
+    elif latest_postcode_tier > original_postcode_tier:
+        change_status = PostcodeTierStatus.INCREASED
+
+    return {
+        "latest_postcode_tier": latest_postcode_tier,
+        "change_status": change_status.value
+    }

--- a/vulnerable_people_form/form_pages/shared/querystring_utils.py
+++ b/vulnerable_people_form/form_pages/shared/querystring_utils.py
@@ -2,7 +2,7 @@ from flask import request, session
 
 from vulnerable_people_form.form_pages.shared.constants import SESSION_KEY_QUERYSTRING_PARAMS
 
-_QUERY_STRING_PARAMS_TO_RETAIN = ["la"]  # local authority query string param key
+_QUERY_STRING_PARAMS_TO_RETAIN = ["la", "ca"]  # local authority query string param key
 
 
 def append_querystring_params(initial_url):

--- a/vulnerable_people_form/form_pages/shared/session.py
+++ b/vulnerable_people_form/form_pages/shared/session.py
@@ -300,7 +300,7 @@ def load_answers_into_session_if_available():
             ),
             "applying_on_own_behalf": are_you_applying_on_behalf_of_someone_else["longValue"],
             "nhs_letter": have_you_received_an_nhs_letter["longValue"],
-            "basic_care_needs": do_you_need_help_meeting_your_basic_care_needs["longValue"],
+            "basic_care_needs": do_you_need_help_meeting_your_basic_care_needs.get("longValue"),
             "do_you_have_someone_to_go_shopping_for_you": do_you_have_someone_to_go_shopping_for_you["longValue"],
             "do_you_live_in_england": do_you_live_in_england.get("longValue")
         }

--- a/vulnerable_people_form/form_pages/view_answers.py
+++ b/vulnerable_people_form/form_pages/view_answers.py
@@ -1,21 +1,38 @@
-from flask import session, current_app
+from flask import session, current_app, redirect
 
 from .blueprint import form
 from .shared.constants import PostcodeTier
 from .shared.render import render_template_with_title
-from .shared.session import get_summary_rows_from_form_answers, get_postcode_tier
+from .shared.session import (
+    get_summary_rows_from_form_answers,
+    get_postcode_tier,
+    is_nhs_login_user,
+    get_answer_from_form,
+    accessing_saved_answers
+)
 
 
 @form.route("/view-answers", methods=["GET"])
 def get_view_answers():
     session["check_answers_page_seen"] = True
-
     exclude_answers = ["nhs_number", "date_of_birth"]
 
-    if current_app.is_tiering_logic_enabled and get_postcode_tier() == PostcodeTier.VERY_HIGH.value:
-        exclude_answers.append('basic_care_needs')
+    if current_app.is_tiering_logic_enabled:
+        if is_returning_nhs_login_user_without_basic_care_needs_answer():
+            return redirect("/basic-care-needs")
+        if get_postcode_tier() == PostcodeTier.VERY_HIGH.value:
+            exclude_answers.append('basic_care_needs')
 
     return render_template_with_title(
         "view-answers.html",
         summary_rows=get_summary_rows_from_form_answers(exclude_answers)
     )
+
+
+def is_returning_nhs_login_user_without_basic_care_needs_answer():
+    # Scenario: Where the postcode tier has increased to VERY_HIGH_PLUS_SHIELDING
+    # and no answer is present for 'basic_care_needs'
+    return is_nhs_login_user() \
+           and accessing_saved_answers() \
+           and get_postcode_tier() == PostcodeTier.VERY_HIGH_PLUS_SHIELDING.value \
+           and get_answer_from_form(["basic_care_needs"]) is None

--- a/vulnerable_people_form/templates/not-eligible-postcode-not-found.html
+++ b/vulnerable_people_form/templates/not-eligible-postcode-not-found.html
@@ -7,15 +7,14 @@
   <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-8">
     {{ title_text }}
   </h1>
-  <p class="govuk-body">If you live in England, <a class="govuk-link" href="https://www.gov.uk/coronavirus-local-help">contact your local authority to get support</a>.</p>
-  <h2 class="govuk-heading-m">If you do not live in England</h2>
-  <p class="govuk-body">This service is only available in England.</p>
-  <p class="govuk-body">There’s guidance if you live in:</p>
+  <p class="govuk-body">If you live in England, your postcode is missing from our system. This means you’ll need to <a class="govuk-link" href="https://www.gov.uk/coronavirus-local-help">contact your local authority</a> if you need support.</p>
+  <p class="govuk-body">You won’t get the support you need if you do not contact your local authority.</p>
+  <h2 class="govuk-heading-m">If you're not in England</h2>
+  <p class="govuk-body">This service is only available in England. There’s guidance if you live in:</p>
   <ul class="govuk-list govuk-list--bullet">
     <li><a class="govuk-link" href="https://www.health-ni.gov.uk/coronavirus">Northern Ireland</a></li>
     <li><a class="govuk-link" href="https://www.gov.scot/publications/covid-shielding-contacts/">Scotland</a></li>
     <li><a class="govuk-link" href="https://gov.wales/get-coronavirus-support-extremely-vulnerable-person">Wales</a></li>
   </ul>
-  <p class="govuk-body">We won’t store the information you entered into this service.</p>
+  <p class="govuk-body">We won’t store information you entered into this service.</p>
 {% endblock %}
-

--- a/vulnerable_people_form/templates/not-eligible-postcode-returning-user-tier-not-found.html
+++ b/vulnerable_people_form/templates/not-eligible-postcode-returning-user-tier-not-found.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block centered_content %}
+  <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-8">
+    {{ title_text }}
+  </h1>
+  <p class="govuk-body">Your postcode is missing from our system. This means you’ll need to <a class="govuk-link" href="https://www.gov.uk/coronavirus-local-help">contact your local authority</a>if you need support.</p>
+  <p class="govuk-body">You won’t get the support you need if you do not contact your local authority.</p>
+{% endblock %}

--- a/vulnerable_people_form/templates/not-eligible-postcode-returning-user.html
+++ b/vulnerable_people_form/templates/not-eligible-postcode-returning-user.html
@@ -1,0 +1,20 @@
+{%- from "govuk_frontend_jinja/components/summary-list/macro.html" import govukSummaryList -%}
+{%- from 'govuk_frontend_jinja/components/button/macro.html' import govukButton -%}
+
+{% extends "base.html" %}
+
+{% block centered_content %}
+  <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-8">
+    {{ title_text }}
+  </h1>
+  <p class="govuk-body">Your area is not currently in Tier 3 so you cannot get help through this service at the moment.</p>
+  <p class="govuk-body">If your area goes into Tier 3, you’ll be able to sign in to this service and update your support needs or personal details.</p>
+
+  <h2 class="govuk-heading-m">If you've changed your address</h2>
+  <p class="govuk-body">You'll be able to update your support needs or personal details if you've moved into an area that's in Tier 3.</p>
+
+  {{ govukButton({
+        "text": "I've changed my address",
+        "href": append_querystring_params("/postcode-lookup")
+      }) }}
+{% endblock %}

--- a/vulnerable_people_form/templates/not-eligible-postcode-tier.html
+++ b/vulnerable_people_form/templates/not-eligible-postcode-tier.html
@@ -7,9 +7,10 @@
   <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-8">
     {{ title_text }}
   </h1>
-  <p class="govuk-body">Your area is not at Local COVID Alert Level: very high, so you cannot get help through this service at the moment.</p>
-  <p class="govuk-body">If you area goes into Local COVID Alert Level: very high, go through the questions again: <a class="govuk-link" href="https://www.gov.uk/coronavirus-shielding-support">www.gov.uk/coronavirus-shielding-support</a>.</p>
-  <p class="govuk-body">Make sure you're up to date with the guidance on what you can and cannot do if you're clinically extremely vulnerable to coronavirus: <a class="govuk-link" href="https://www.gov.uk/coronavirus-extremely-vulnerable-guidance">https://www.gov.uk/coronavirus-extremely-vulnerable-guidance</a></p>
+  <p class="govuk-body">Your area is not in Tier 3 (Very High Alert), so you cannot get help through this service at the moment.</p>
+  <p class="govuk-body">If your area goes into Tier 3, go through the questions again: <a class="govuk-link" href="https://www.gov.uk/coronavirus-shielding-support">www.gov.uk/coronavirus-shielding-support</a>.</p>
+  <p class="govuk-body">Make sure you’re up to date with what you can and cannot do as someone who’s clinically extremely vulnerable to coronavirus: <a class="govuk-link" href="https://www.gov.uk/coronavirus-extremely-vulnerable-guidance">www.gov.uk/coronavirus-extremely-vulnerable-guidance</a>.</p>
+
   <p class="govuk-body">There’s also guidance if you live in:</p>
   <ul class="govuk-list govuk-list--bullet">
     <li><a class="govuk-link" href="https://www.health-ni.gov.uk/coronavirus">Northern Ireland</a></li>
@@ -18,4 +19,3 @@
   </ul>
   <p class="govuk-body">We won’t store the information you entered into this service.</p>
 {% endblock %}
-


### PR DESCRIPTION
When an NHS login returning user signs in the original
postcode they entered is now used to determine the tier.
The UI they will see is driven by the latest tier.