### PR TITLE
Fixed logic for tier 4 prompting basic needs question

### DIFF
--- a/vulnerable_people_form/form_pages/check_your_answers.py
+++ b/vulnerable_people_form/form_pages/check_your_answers.py
@@ -6,7 +6,7 @@ from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page, dynamic_back_url
 from .shared.session import persist_answers_from_session, form_answers, get_summary_rows_from_form_answers, \
-    get_postcode_tier, is_returning_nhs_login_user_without_basic_care_needs_answer
+    get_postcode_tier, is_very_high_plus_shielding_without_basic_care_needs_answer
 from ..integrations import govuk_notify_client, spl_check
 
 
@@ -16,7 +16,7 @@ def get_check_your_answers():
     exclude_answers = None
 
     if current_app.is_tiering_logic_enabled:
-        if is_returning_nhs_login_user_without_basic_care_needs_answer():
+        if is_very_high_plus_shielding_without_basic_care_needs_answer():
             return redirect(append_querystring_params("/basic-care-needs"))
         if get_postcode_tier() == PostcodeTier.VERY_HIGH.value:
             exclude_answers = ['basic_care_needs']

--- a/vulnerable_people_form/form_pages/shared/session.py
+++ b/vulnerable_people_form/form_pages/shared/session.py
@@ -343,7 +343,11 @@ def _set_form_answer(answers_key_list, answer):
 def is_returning_nhs_login_user_without_basic_care_needs_answer():
     # Scenario: Where the postcode tier has increased to VERY_HIGH_PLUS_SHIELDING
     # and no answer is present for 'basic_care_needs'
-    return is_nhs_login_user() \
-           and accessing_saved_answers() \
-           and get_postcode_tier() == PostcodeTier.VERY_HIGH_PLUS_SHIELDING.value \
+    return is_nhs_login_user() and accessing_saved_answers() and is_very_high_plus_shielding_without_basic_care_needs_answer() # noqa
+
+
+def is_very_high_plus_shielding_without_basic_care_needs_answer():
+    # Scenario: Where the postcode tier has increased to VERY_HIGH_PLUS_SHIELDING
+    # and no answer is present for 'basic_care_needs'
+    return get_postcode_tier() == PostcodeTier.VERY_HIGH_PLUS_SHIELDING.value \
            and get_answer_from_form(["basic_care_needs"]) is None


### PR DESCRIPTION
When a user changes address from a tier 3 to a tier 4 if they haven't been been asked the basic care needs question they should be when redirected to the view answers page.