### PR TITLE
Default postcode tier to very high plus shielding without tiering logic

### DIFF
--- a/tests/form_pages/shared/test_postcode_tier.py
+++ b/tests/form_pages/shared/test_postcode_tier.py
@@ -18,7 +18,7 @@ def test_update_postcode_tier_should_not_update_when_tiering_logic_disabled():
          patch("vulnerable_people_form.form_pages.shared.postcode_tier.set_postcode_tier") as mock_set_postcode_tier:
         update_postcode_tier("LS11BA", _current_app)
         mock_get_postcode_tier.assert_not_called()
-        mock_set_postcode_tier.assert_not_called()
+        mock_set_postcode_tier.assert_called_once_with(PostcodeTier.VERY_HIGH_PLUS_SHIELDING.value)
 
 
 def test_update_postcode_tier_should_update_session_when_tiering_logic_enabled():

--- a/vulnerable_people_form/form_pages/shared/postcode_tier.py
+++ b/vulnerable_people_form/form_pages/shared/postcode_tier.py
@@ -7,6 +7,8 @@ def update_postcode_tier(postcode, app):
     if app.is_tiering_logic_enabled:
         postcode_tier = get_postcode_tier(postcode)
         set_postcode_tier(postcode_tier)
+    else:
+        set_postcode_tier(PostcodeTier.VERY_HIGH_PLUS_SHIELDING.value)
 
 
 def is_tier_very_high_or_above(postcode_tier):


### PR DESCRIPTION
As we need to know what questions to ask someone when they return we
need an appropriate postcode tier level to give them, even under
national lockdown.

This sets the value to VERY_HIGH_PLUS_SHIELDING as the questions
currently asked match this level.