### PR TITLE
Reassure users going down a tier

### DIFF
--- a/vulnerable_people_form/templates/not-eligible-postcode-returning-user.html
+++ b/vulnerable_people_form/templates/not-eligible-postcode-returning-user.html
@@ -8,10 +8,11 @@
     {{ title_text }}
   </h1>
   <p class="govuk-body">Your area is not currently in Tier 3 so you cannot get help through this service at the moment.</p>
+  <p class="govuk-body">If you’ve already got priority access to supermarket deliveries, you’ll keep it.</p>
   <p class="govuk-body">If your area goes into Tier 3, you’ll be able to sign in to this service and update your support needs or personal details.</p>
 
   <h2 class="govuk-heading-m">If you've changed your address</h2>
-  <p class="govuk-body">You'll be able to update your support needs or personal details if you've moved into an area that's in Tier 3.</p>
+  <p class="govuk-body">You can update your support needs or personal details if you've moved into an area that's in Tier 3.</p>
 
   {{ govukButton({
         "text": "I've changed my address",


### PR DESCRIPTION
Content change to let users going down a tier that it doesn't mean they'll lose priority access to supermarket slots when they go down a tier.

Card: https://trello.com/c/aB2EIptp/78-reassure-users-going-down-a-tier-that-they-wont-lose-supermarket-slot