### PR TITLE
Version smoke and e2e tests based on what has been tested for that env

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -264,6 +264,7 @@ jobs:
       - get: every-2m
         trigger: true
       - get: git-master
+        passed: [e2e-test-staging]
       - task: smoke-test
         file: git-master/concourse/tasks/smoke-test.yml
         params:
@@ -283,6 +284,7 @@ jobs:
       - get: every-2m
         trigger: true
       - get: git-master
+        passed: [deploy-to-prod]
       - task: smoke-test
         file: git-master/concourse/tasks/smoke-test.yml
         params:
@@ -307,6 +309,7 @@ jobs:
   - name: gatling-workflow-load-test-in-staging
     plan:
       - get: git-master
+        passed: [e2e-test-staging]
       - get: trigger-at-1am
         trigger: true
       - task: gatling
@@ -372,6 +375,7 @@ jobs:
   - name: run-daily-and-mi-workflows-in-staging
     plan:
       - get: git-master
+        passed: [e2e-test-staging]
       - get: trigger-at-1am
         trigger: true
       - task: get-aws-credentials
@@ -407,6 +411,7 @@ jobs:
     serial: true
     plan:
       - get: git-master
+        passed: [e2e-test-staging]
       - get: trigger-at-6am
         trigger: true
       - task: webform-entry


### PR DESCRIPTION
We are about to change the journey quite significantly, putting the
address picker before any other questions.

This means that the behave tests will be out of sync for staging and
production, while the code is being deployed.

In order to make sure the right tests are run against the right
environment, rely on the e2e tests having [passed] for staging and the
code having been deployed for prod tests [passed].