### PR TITLE
Content update - Smart email check

### DIFF
--- a/tests/form_pages/shared/test_mailchecker.py
+++ b/tests/form_pages/shared/test_mailchecker.py
@@ -1,0 +1,302 @@
+"""
+The mailchecker takes it's original code from https://github.com/dbarlett/pymailcheck/ (MIT License)
+These test cases are adapted from it's original unittest versions
+"""
+
+import pytest
+
+from vulnerable_people_form.form_pages.shared import mailchecker
+
+DOMAINS = (
+    "google.com",
+    "gmail.com",
+    "emaildomain.com",
+    "comcast.net",
+    "facebook.com",
+    "msn.com",
+    "gmx.de",
+)
+
+SECOND_LEVEL_DOMAINS = (
+    "yahoo",
+    "hotmail",
+    "mail",
+    "live",
+    "outlook",
+    "gmx",
+)
+
+TOP_LEVEL_DOMAINS = (
+    "co.uk",
+    "com",
+    "org",
+    "info",
+    "fr",
+)
+
+
+def test_sift3_distance():
+    assert mailchecker.sift3_distance("boat", "boot") == 1
+    assert mailchecker.sift3_distance("boat", "bat") == 1.5
+    assert mailchecker.sift3_distance("ifno", "info") == 2
+    assert mailchecker.sift3_distance("hotmial", "hotmail") == 2
+
+
+def test_one_level_domain():
+    parts = mailchecker.split_email("postbox@com")
+    expected = {
+        "address": "postbox",
+        "domain": "com",
+        "top_level_domain": "com",
+        "second_level_domain": "",
+    }
+    assert parts == expected
+
+
+def test_two_level_domain():
+    parts = mailchecker.split_email("test@example.com")
+    expected = {
+        "address": "test",
+        "domain": "example.com",
+        "top_level_domain": "com",
+        "second_level_domain": "example",
+    }
+    assert parts == expected
+
+
+def test_three_level_domain():
+    parts = mailchecker.split_email("test@example.co.uk")
+    expected = {
+        "address": "test",
+        "domain": "example.co.uk",
+        "top_level_domain": "co.uk",
+        "second_level_domain": "example",
+    }
+    assert parts == expected
+
+
+def test_four_level_domain():
+    parts = mailchecker.split_email("test@mail.randomsmallcompany.co.uk")
+    expected = {
+        "address": "test",
+        "domain": "mail.randomsmallcompany.co.uk",
+        "top_level_domain": "randomsmallcompany.co.uk",
+        "second_level_domain": "mail",
+    }
+    assert parts == expected
+
+
+def test_rfc_compliant():
+    parts = mailchecker.split_email('"foo@bar"@example.com')
+    expected = {
+        "address": '"foo@bar"',
+        "domain": "example.com",
+        "top_level_domain": "com",
+        "second_level_domain": "example",
+    }
+    assert parts == expected
+
+
+def test_contains_numbers():
+    parts = mailchecker.split_email("containsnumbers1234567890@example.com")
+    expected = {
+        "address": "containsnumbers1234567890",
+        "domain": "example.com",
+        "top_level_domain": "com",
+        "second_level_domain": "example",
+    }
+    assert parts == expected
+
+
+def test_contains_plus():
+    parts = mailchecker.split_email("contains+symbol@example.com")
+    expected = {
+        "address": "contains+symbol",
+        "domain": "example.com",
+        "top_level_domain": "com",
+        "second_level_domain": "example",
+    }
+    assert parts == expected
+
+
+def test_contains_hyphen():
+    parts = mailchecker.split_email("contains-symbol@example.com")
+    expected = {
+        "address": "contains-symbol",
+        "domain": "example.com",
+        "top_level_domain": "com",
+        "second_level_domain": "example",
+    }
+    assert parts == expected
+
+
+def test_contains_periods():
+    parts = mailchecker.split_email("contains.symbol@domain.contains.symbol")
+    expected = {
+        "address": "contains.symbol",
+        "domain": "domain.contains.symbol",
+        "top_level_domain": "contains.symbol",
+        "second_level_domain": "domain",
+    }
+    assert parts == expected
+
+
+def test_contains_period_backslash():
+    parts = mailchecker.split_email('"contains.and\ symbols"@example.com')
+    expected = {
+        "address": '"contains.and\ symbols"',
+        "domain": "example.com",
+        "top_level_domain": "com",
+        "second_level_domain": "example",
+    }
+
+    assert parts == expected
+
+
+def test_contains_period_at_sign():
+    parts = mailchecker.split_email('"contains.and.@.symbols.com"@example.com')
+    expected = {
+        "address": '"contains.and.@.symbols.com"',
+        "domain": "example.com",
+        "top_level_domain": "com",
+        "second_level_domain": "example",
+    }
+
+    assert parts == expected
+
+
+def test_contains_all_symbols():
+    parts = mailchecker.split_email(
+        '"()<>[]:;@,\\\"!#$%&\'*+-/=?^_`{}|\ \ \ \ \ ~\ \ \ \ \ \ \ ?\ \ \ \ \ \ \ \ \ \ \ \ ^_`{}|~.a"@allthesymbols.com')
+    expected = {
+        "address": '"()<>[]:;@,\\\"!#$%&\'*+-/=?^_`{}|\ \ \ \ \ ~\ \ \ \ \ \ \ ?\ \ \ \ \ \ \ \ \ \ \ \ ^_`{}|~.a"',
+        "domain": "allthesymbols.com",
+        "top_level_domain": "com",
+        "second_level_domain": "allthesymbols",
+    }
+
+    assert parts == expected
+
+
+def test_not_rfc_compliant():
+    assert mailchecker.split_email("example.com") is False
+    assert mailchecker.split_email("abc.example.com") is False
+    assert mailchecker.split_email("@example.com") is False
+    assert mailchecker.split_email("test@") is False
+
+
+def test_trim_spaces():
+    parts = mailchecker.split_email(" postbox@com")
+    expected = {
+        "address": "postbox",
+        "domain": "com",
+        "top_level_domain": "com",
+        "second_level_domain": "",
+    }
+
+    assert parts == expected
+    parts = mailchecker.split_email("postbox@com ")
+
+    assert parts == expected
+
+
+def test_most_similar_domain():
+    assert mailchecker.find_closest_domain("google.com", DOMAINS) == "google.com"
+    assert mailchecker.find_closest_domain("gmail.com", DOMAINS) == "gmail.com"
+    assert mailchecker.find_closest_domain("emaildomain.com", DOMAINS) == "emaildomain.com"
+    assert mailchecker.find_closest_domain("gmsn.com", DOMAINS) == "msn.com"
+    assert mailchecker.find_closest_domain("gmaik.com", DOMAINS) == "gmail.com"
+
+
+def test_most_similar_second_level_domain():
+    assert mailchecker.find_closest_domain("hotmial", SECOND_LEVEL_DOMAINS) == "hotmail"
+    assert mailchecker.find_closest_domain("tahoo", SECOND_LEVEL_DOMAINS) == "yahoo"
+    assert mailchecker.find_closest_domain("livr", SECOND_LEVEL_DOMAINS) == "live"
+    assert mailchecker.find_closest_domain("outllok", SECOND_LEVEL_DOMAINS) == "outlook"
+
+
+def test_most_similar_top_level_domain():
+    assert mailchecker.find_closest_domain("cmo", TOP_LEVEL_DOMAINS) == "com"
+    assert mailchecker.find_closest_domain("ogr", TOP_LEVEL_DOMAINS) == "org"
+    assert mailchecker.find_closest_domain("ifno", TOP_LEVEL_DOMAINS) == "info"
+    assert mailchecker.find_closest_domain("com.uk", TOP_LEVEL_DOMAINS) == "co.uk"
+
+
+def test_returns_array():
+    expected = {
+        "address": "test",
+        "domain": "gmail.com",
+        "full": "test@gmail.com",
+    }
+    assert mailchecker.suggest("test@gmail.co", DOMAINS) == expected
+
+
+def test_no_suggestion_returns_false():
+        assert mailchecker.suggest("contact@kicksend.com", DOMAINS) is False
+
+
+def test_incomplete_email_returns_false():
+        assert mailchecker.suggest("", DOMAINS) is False
+        assert mailchecker.suggest("test@", DOMAINS) is False
+        assert mailchecker.suggest("test", DOMAINS) is False
+
+
+def test_returns_valid_suggestions():
+    assert mailchecker.suggest("test@gmailc.om", DOMAINS)["domain"] == "gmail.com"
+    assert mailchecker.suggest("test@emaildomain.co", DOMAINS)["domain"] == "emaildomain.com"
+    assert mailchecker.suggest("test@gmail.con", DOMAINS)["domain"] == "gmail.com"
+    assert mailchecker.suggest("test@gnail.con", DOMAINS)["domain"] == "gmail.com"
+    assert mailchecker.suggest("test@GNAIL.con", DOMAINS)["domain"] == "gmail.com"
+    assert mailchecker.suggest("test@#gmail.com", DOMAINS)["domain"] == "gmail.com"
+    assert mailchecker.suggest("test@comcast.nry", DOMAINS)["domain"] == "comcast.net"
+    assert mailchecker.suggest(
+            "test@homail.con",
+            DOMAINS,
+            SECOND_LEVEL_DOMAINS,
+            TOP_LEVEL_DOMAINS
+        )["domain"] == "hotmail.com"
+    assert mailchecker.suggest(
+            "test@hotmail.co",
+            DOMAINS,
+            SECOND_LEVEL_DOMAINS,
+            TOP_LEVEL_DOMAINS
+        )["domain"] == "hotmail.com"
+    assert mailchecker.suggest(
+            "test@yajoo.com",
+            DOMAINS,
+            SECOND_LEVEL_DOMAINS,
+            TOP_LEVEL_DOMAINS
+        )["domain"] == "yahoo.com"
+    assert mailchecker.suggest(
+            "test@randomsmallcompany.cmo",
+            DOMAINS,
+            SECOND_LEVEL_DOMAINS,
+            TOP_LEVEL_DOMAINS
+        )["domain"] == "randomsmallcompany.com"
+
+
+def test_idempotent_suggestions():
+    assert mailchecker.suggest(
+            "test@yahooo.cmo",
+            DOMAINS,
+            SECOND_LEVEL_DOMAINS,
+            TOP_LEVEL_DOMAINS
+        )["domain"] == "yahoo.com"
+
+
+def test_no_suggestions_valid_2ld_tld():
+    assert mailchecker.suggest(
+            "test@yahoo.co.uk",
+            DOMAINS,
+            SECOND_LEVEL_DOMAINS,
+            TOP_LEVEL_DOMAINS
+        ) is False
+
+
+def test_no_suggestions_valid_2ld_tld_close_domain():
+    assert mailchecker.suggest(
+            "test@gmx.fr",
+            DOMAINS,
+            SECOND_LEVEL_DOMAINS,
+            TOP_LEVEL_DOMAINS
+        ) is False

--- a/tests/form_pages/shared/test_mailchecker.py
+++ b/tests/form_pages/shared/test_mailchecker.py
@@ -3,8 +3,6 @@ The mailchecker takes it's original code from https://github.com/dbarlett/pymail
 These test cases are adapted from it's original unittest versions
 """
 
-import pytest
-
 from vulnerable_people_form.form_pages.shared import mailchecker
 
 DOMAINS = (
@@ -142,9 +140,9 @@ def test_contains_periods():
 
 
 def test_contains_period_backslash():
-    parts = mailchecker.split_email('"contains.and\ symbols"@example.com')
+    parts = mailchecker.split_email('"contains.and\ symbols"@example.com')  # noqa: W605
     expected = {
-        "address": '"contains.and\ symbols"',
+        "address": '"contains.and\ symbols"',  # noqa: W605
         "domain": "example.com",
         "top_level_domain": "com",
         "second_level_domain": "example",
@@ -167,9 +165,11 @@ def test_contains_period_at_sign():
 
 def test_contains_all_symbols():
     parts = mailchecker.split_email(
-        '"()<>[]:;@,\\\"!#$%&\'*+-/=?^_`{}|\ \ \ \ \ ~\ \ \ \ \ \ \ ?\ \ \ \ \ \ \ \ \ \ \ \ ^_`{}|~.a"@allthesymbols.com')
+        '"()<>[]:;@,\\\"!#$%&\'*+-/=?^_`{}|\ \ \ \ \ ~\ \ \ \ \ \ \ ?\ \ \ \ \ \ \ \ \ \ \ \ ^_`{}|~.a"'  # noqa: W605
+        '@allthesymbols.com')
     expected = {
-        "address": '"()<>[]:;@,\\\"!#$%&\'*+-/=?^_`{}|\ \ \ \ \ ~\ \ \ \ \ \ \ ?\ \ \ \ \ \ \ \ \ \ \ \ ^_`{}|~.a"',
+        "address": '"()<>[]:;@,\\\"!#$%&\'*+-/=?^_`{}|\ \ \ \ \ ~\ \ \ \ \ \ \ ?\ \ \ \ \ \ \ '  # noqa: W605
+                   '\ \ \ \ \ ^_`{}|~.a"',  # noqa: W605
         "domain": "allthesymbols.com",
         "top_level_domain": "com",
         "second_level_domain": "allthesymbols",
@@ -232,13 +232,13 @@ def test_returns_array():
 
 
 def test_no_suggestion_returns_false():
-        assert mailchecker.suggest("contact@kicksend.com", DOMAINS) is False
+    assert mailchecker.suggest("contact@kicksend.com", DOMAINS) is False
 
 
 def test_incomplete_email_returns_false():
-        assert mailchecker.suggest("", DOMAINS) is False
-        assert mailchecker.suggest("test@", DOMAINS) is False
-        assert mailchecker.suggest("test", DOMAINS) is False
+    assert mailchecker.suggest("", DOMAINS) is False
+    assert mailchecker.suggest("test@", DOMAINS) is False
+    assert mailchecker.suggest("test", DOMAINS) is False
 
 
 def test_returns_valid_suggestions():
@@ -250,53 +250,53 @@ def test_returns_valid_suggestions():
     assert mailchecker.suggest("test@#gmail.com", DOMAINS)["domain"] == "gmail.com"
     assert mailchecker.suggest("test@comcast.nry", DOMAINS)["domain"] == "comcast.net"
     assert mailchecker.suggest(
-            "test@homail.con",
-            DOMAINS,
-            SECOND_LEVEL_DOMAINS,
-            TOP_LEVEL_DOMAINS
-        )["domain"] == "hotmail.com"
+        "test@homail.con",
+        DOMAINS,
+        SECOND_LEVEL_DOMAINS,
+        TOP_LEVEL_DOMAINS
+    )["domain"] == "hotmail.com"
     assert mailchecker.suggest(
-            "test@hotmail.co",
-            DOMAINS,
-            SECOND_LEVEL_DOMAINS,
-            TOP_LEVEL_DOMAINS
-        )["domain"] == "hotmail.com"
+        "test@hotmail.co",
+        DOMAINS,
+        SECOND_LEVEL_DOMAINS,
+        TOP_LEVEL_DOMAINS
+    )["domain"] == "hotmail.com"
     assert mailchecker.suggest(
-            "test@yajoo.com",
-            DOMAINS,
-            SECOND_LEVEL_DOMAINS,
-            TOP_LEVEL_DOMAINS
-        )["domain"] == "yahoo.com"
+        "test@yajoo.com",
+        DOMAINS,
+        SECOND_LEVEL_DOMAINS,
+        TOP_LEVEL_DOMAINS
+    )["domain"] == "yahoo.com"
     assert mailchecker.suggest(
-            "test@randomsmallcompany.cmo",
-            DOMAINS,
-            SECOND_LEVEL_DOMAINS,
-            TOP_LEVEL_DOMAINS
-        )["domain"] == "randomsmallcompany.com"
+        "test@randomsmallcompany.cmo",
+        DOMAINS,
+        SECOND_LEVEL_DOMAINS,
+        TOP_LEVEL_DOMAINS
+    )["domain"] == "randomsmallcompany.com"
 
 
 def test_idempotent_suggestions():
     assert mailchecker.suggest(
-            "test@yahooo.cmo",
-            DOMAINS,
-            SECOND_LEVEL_DOMAINS,
-            TOP_LEVEL_DOMAINS
-        )["domain"] == "yahoo.com"
+        "test@yahooo.cmo",
+        DOMAINS,
+        SECOND_LEVEL_DOMAINS,
+        TOP_LEVEL_DOMAINS
+    )["domain"] == "yahoo.com"
 
 
 def test_no_suggestions_valid_2ld_tld():
     assert mailchecker.suggest(
-            "test@yahoo.co.uk",
-            DOMAINS,
-            SECOND_LEVEL_DOMAINS,
-            TOP_LEVEL_DOMAINS
-        ) is False
+        "test@yahoo.co.uk",
+        DOMAINS,
+        SECOND_LEVEL_DOMAINS,
+        TOP_LEVEL_DOMAINS
+    ) is False
 
 
 def test_no_suggestions_valid_2ld_tld_close_domain():
     assert mailchecker.suggest(
-            "test@gmx.fr",
-            DOMAINS,
-            SECOND_LEVEL_DOMAINS,
-            TOP_LEVEL_DOMAINS
-        ) is False
+        "test@gmx.fr",
+        DOMAINS,
+        SECOND_LEVEL_DOMAINS,
+        TOP_LEVEL_DOMAINS
+    ) is False

--- a/vulnerable_people_form/form_pages/check_contact_details.py
+++ b/vulnerable_people_form/form_pages/check_contact_details.py
@@ -1,6 +1,7 @@
 from flask import redirect, session
 
 from .blueprint import form
+from .shared.mailchecker import suggest
 from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
@@ -10,13 +11,22 @@ from .shared.validation import validate_contact_details
 
 @form.route("/check-contact-details", methods=["GET"])
 def get_check_contact_details():
+    alt_email_suggestion = _get_email_suggestion()
+
     return render_template_with_title(
         "check-contact-details.html",
         previous_path=append_querystring_params("/contact-details"),
         values=form_answers().get("contact_details", {}),
         button_text="This is correct",
+        alt_email_suggestion=alt_email_suggestion,
         **get_errors_from_session("check_contact_details"),
     )
+
+
+def _get_email_suggestion():
+    email = form_answers().get("contact_details", {}).get('email')
+    suggestion = suggest(email)
+    return suggestion.get('full') if suggestion else None
 
 
 @form.route("/check-contact-details", methods=["POST"])

--- a/vulnerable_people_form/form_pages/shared/mailchecker.py
+++ b/vulnerable_people_form/form_pages/shared/mailchecker.py
@@ -1,0 +1,285 @@
+"""
+This mailchecker takes it's original code from https://github.com/dbarlett/pymailcheck/ (MIT License)
+To avoid extra dependencies and to allow us to customise it has been added as a new file
+
+https://github.com/mailcheck/pymailcheck/blob/master/LICENSE
+"""
+
+DOMAIN_THRESHOLD = 2
+SECOND_LEVEL_THRESHOLD = 2
+TOP_LEVEL_THRESHOLD = 2
+DOMAINS = frozenset([
+    "aol.com", "att.net", "comcast.net", "facebook.com", "gmail.com", "gmx.com", "googlemail.com",
+    "google.com", "hotmail.com", "hotmail.co.uk", "mac.com", "me.com", "mail.com", "msn.com",
+    "live.com", "sbcglobal.net", "verizon.net", "yahoo.com", "yahoo.co.uk",
+    "btinternet.com", "virginmedia.com", "blueyonder.co.uk", "freeserve.co.uk", "live.co.uk",
+    "ntlworld.com", "o2.co.uk", "orange.net", "sky.com", "talktalk.co.uk", "tiscali.co.uk",
+    "virgin.net", "wanadoo.co.uk", "bt.com",
+])
+SECOND_LEVEL_DOMAINS = frozenset([
+    "gmx"
+    "hotmail",
+    "live",
+    "mail",
+    "outlook",
+    "yahoo",
+])
+TOP_LEVEL_DOMAINS = frozenset([
+    "at",
+    "be",
+    "biz",
+    "ca",
+    "ch",
+    "co.il",
+    "co.jp",
+    "co.nz",
+    "co.uk",
+    "com",
+    "com.au",
+    "com.tw",
+    "cz",
+    "de",
+    "dk",
+    "edu",
+    "es",
+    "eu",
+    "fr",
+    "gov",
+    "gov.uk",
+    "gr",
+    "hk",
+    "hu"
+    "ie",
+    "in",
+    "info",
+    "it",
+    "jp",
+    "kr",
+    "mil",
+    "net",
+    "net",
+    "net.au",
+    "nl",
+    "no",
+    "org",
+    "ru",
+    "se",
+    "sg",
+    "us",
+])
+
+
+def sift3_distance(s_1, s_2, max_offset=5):
+    """Calculate string distance
+    See http://siderite.blogspot.com/2007/04/super-fast-and-accurate-string-\
+distance.html for background. This is a port of sift3Distance from mailcheck.js
+    rather than the Python code from https://gist.github.com/fjorgemota/3067867
+    because the latter produces different results.
+    :param s_1: first string
+    :param s_2: second string
+    :param max_offset: maximum offset, default: 5
+    :type s_1: str
+    :type s_2: str
+    :type max_offset: int
+    :returns: string distance
+    :rtype: int
+    """
+    len_s_1 = len(s_1)
+    len_s_2 = len(s_2)
+
+    if len_s_1 == 0:
+        if len_s_2 == 0:
+            return 0
+        else:
+            return len_s_2
+
+    if len_s_2 == 0:
+        return len_s_1
+
+    c = 0
+    offset_1 = 0
+    offset_2 = 0
+    lcs = 0
+
+    while (c + offset_1 < len_s_1) and (c + offset_2 < len_s_2):
+        if s_1[c + offset_1] == s_2[c + offset_2]:
+            lcs += 1
+        else:
+            offset_1 = 0
+            offset_2 = 0
+            for i in range(0, max_offset):
+                if (c + i < len_s_1) and (s_1[c + i] == s_2[c]):
+                    offset_1 = i
+                    break
+                if (c + i < len_s_2) and (s_1[c] == s_2[c + i]):
+                    offset_2 = i
+                    break
+        c += 1
+    return (len_s_1 + len_s_2) / 2.0 - lcs
+
+
+def split_email(email):
+    """Split an email address
+    :param email: email address
+    :type email: str
+    :returns: email address parts, or False if not an email address
+    :rtype: dict, bool
+    """
+    parts = email.strip().split("@")
+    if len(parts) < 2:
+        return False
+    for i in parts:
+        if i == "":
+            return False
+
+    domain = parts.pop()
+    domain_parts = domain.split(".")
+    sld = ""
+    tld = ""
+
+    if len(domain_parts) == 0:
+        # The address does not have a top-level domain
+        return False
+    elif len(domain_parts) == 1:
+        # The address has only a top-level domain (valid under RFC)
+        tld = domain_parts[0]
+    else:
+        sld = domain_parts[0]
+        for i in domain_parts[1:]:
+            tld += (i + ".")
+        tld = tld[0:-1]
+
+    return {
+        "address": "@".join(parts),
+        "top_level_domain": tld,
+        "second_level_domain": sld,
+        "domain": domain,
+    }
+
+
+def find_closest_domain(
+        domain,
+        domains,
+        threshold=DOMAIN_THRESHOLD
+):
+    """Find closest domain
+    :param domain: domain
+    :param domains: domains to compare to
+    :param threshold: distance threshold
+    :returns: closest domain, or False if none is less than or equal to
+    threshold
+    :rtype: str, bool
+    """
+    min_dist = 99
+    closest_domain = None
+
+    for i in domains:
+        if domain == i:
+            return domain
+        dist = sift3_distance(domain, i)
+        if dist < min_dist:
+            min_dist = dist
+            closest_domain = i
+
+    if min_dist <= threshold and closest_domain is not None:
+        return closest_domain
+    else:
+        return False
+
+
+def suggest(
+        email,
+        domains=DOMAINS,
+        second_level_domains=SECOND_LEVEL_DOMAINS,
+        top_level_domains=TOP_LEVEL_DOMAINS
+):
+    """Suggest a corrected email address
+    :param email: email address
+    :param domains: domains to match against, default DOMAINS
+    :param second_level_domains: second-level domains to match against,
+     default SECOND_LEVEL DOMAINS
+    :param top_level_domains: top-level domains to matcha against,
+     default TOP_LEVEL_DOMAINS
+    :type email: str
+    :type domains: list
+    :type second_level_domains: iterable
+    :type top_level_domains: iterable
+    :returns: email suggestion, or False
+    :rtype: dict, bool
+    """
+    email = email.lower()
+    email_parts = split_email(email)
+
+    # If the email is invalid, or a valid 2nd-level + top-level, do not suggest
+    # anything.
+    if not email_parts or (
+            email_parts["second_level_domain"] in second_level_domains and
+            email_parts["top_level_domain"] in top_level_domains
+    ):
+        return False
+
+    closest_domain = find_closest_domain(
+        email_parts["domain"],
+        domains
+    )
+    if closest_domain:
+        if closest_domain == email_parts["domain"]:
+            # The email address exactly matches one of the supplied domains; do
+            # not return a suggestion.
+            return False
+        else:
+            # The email address closely matches one of the supplied domains;
+            # return a suggestion
+            return {
+                "address": email_parts["address"],
+                "domain": closest_domain,
+                "full": "{0}@{1}".format(
+                    email_parts["address"],
+                    closest_domain
+                )
+            }
+
+    closest_sld = find_closest_domain(
+        email_parts["second_level_domain"],
+        second_level_domains
+    )
+    closest_tld = find_closest_domain(
+        email_parts["top_level_domain"],
+        top_level_domains
+    )
+    if email_parts["domain"]:
+        closest_domain = email_parts["domain"]
+        ret = False
+
+        if closest_sld and closest_sld != email_parts["second_level_domain"]:
+            # The email address may have a misspelled second-level domain;
+            # return a suggestion.
+            closest_domain = closest_domain.replace(
+                email_parts["second_level_domain"],
+                closest_sld
+            )
+            ret = True
+
+        if closest_tld and closest_tld != email_parts["top_level_domain"]:
+            # The email address may have a misspelled top-level domain;
+            # return a suggestion.
+            closest_domain = closest_domain.replace(
+                email_parts["top_level_domain"],
+                closest_tld
+            )
+            ret = True
+
+        if ret:
+            return {
+                "address": email_parts["address"],
+                "domain": closest_domain,
+                "full": "{0}@{1}".format(
+                    email_parts["address"],
+                    closest_domain
+                )
+            }
+    # The email address exactly matches one of the supplied domains, does not
+    # closely match any domain and does not appear to simply have a mispelled
+    # top-level domain, or is an invalid email address; do not return a
+    # suggestion.
+    return False

--- a/vulnerable_people_form/templates/check-contact-details.html
+++ b/vulnerable_people_form/templates/check-contact-details.html
@@ -8,7 +8,7 @@
     {{title_text}}
     </h1>
     {% if alt_email_suggestion %}
-    <p class="govuk-body">Did you mean <strong>{{ alt_email_suggestion }}</strong></p>
+    <p class="govuk-body">Did you mean <strong>{{ alt_email_suggestion }}?</strong></p>
     {% endif %}
 {{
   govukInput({

--- a/vulnerable_people_form/templates/check-contact-details.html
+++ b/vulnerable_people_form/templates/check-contact-details.html
@@ -7,6 +7,9 @@
   <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
     {{title_text}}
     </h1>
+    {% if alt_email_suggestion %}
+    <p class="govuk-body">Did you mean <strong>{{ alt_email_suggestion }}</strong></p>
+    {% endif %}
 {{
   govukInput({
     "label": {


### PR DESCRIPTION
### What
Add message on check-content-details to pick up on simple email address typos

### How
- Use code ported from https://github.com/mailcheck/mailcheck/ to check based on word-distance 
- Use settings for most common UK and international domains
- Integrate into templates
