### PR TITLE
994 Catch Glue Failures as part of the gatling test

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -389,23 +389,38 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: registry-image
+            type: docker-image
             source:
-              repository: governmentpaas/awscli
+              repository: ubuntu
               tag: latest
-              username: ((docker_hub_username))
-              password: ((docker_hub_password))
           inputs:
+            - name: git-master
             - name: aws-credentials
+          params:
+            ENVIRONMENT: "staging"
+            REGION: "eu-west-2"
           run:
-            path: ash
+            path: bash
             args:
               - -c
               - |
                 set -euo pipefail
-                source aws-credentials/.env
-                aws glue start-workflow-run \
-                  --name "cv-vulnerable-people-daily-wave-two-pipeline-staging"
+                echo "Installing system dependencies:"
+                apt-get update
+                apt-get upgrade -y
+                apt-get install -y jq curl unzip git make python3 python3-pip
+
+                echo "Installing libraries required for test:"
+                source ../aws-credentials/.env
+                make install
+
+                echo "Running Python script to trigger workflow:"
+                python3 scripts/trigger_glue_workflow_and_check_outcome.py
+                         --workflow_to_trigger cv-vulnerable-people-daily-wave-two-pipeline-staging \
+                         --workflows_to_check cv-vulnerable-people-daily-wave-two-pipeline-staging,dw-etl-daily-pipeline-staging \
+                         --timeout 10800 \
+                         --wait_time 30
+            dir: git-master
 
   - name: run-e2e-test-with-pipeline-validation-in-staging
     serial: true

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -421,6 +421,7 @@ jobs:
                          --timeout 10800 \
                          --wait_time 30
             dir: git-master
+          on_failure: *slack_alert_on_failure
 
   - name: run-e2e-test-with-pipeline-validation-in-staging
     serial: true

--- a/scripts/trigger_glue_workflow_and_check_outcome.py
+++ b/scripts/trigger_glue_workflow_and_check_outcome.py
@@ -1,0 +1,105 @@
+import boto3
+import json
+import time
+from datetime import datetime, timezone
+import logging
+import os
+import argparse
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--workflow_to_trigger", help="workflow to trigger")
+parser.add_argument("--workflows_to_check", help="comma separted list of workflows to check")
+parser.add_argument("--timeout", help="timeout, in seconds", type=int)
+parser.add_argument("--wait_time", help="time to wait before checking the status again in seconds", type=int)
+args = parser.parse_args()
+
+if (
+    args.workflow_to_trigger is None or
+    args.workflows_to_check is None or
+    args.timeout is None or
+    args.wait_time is None
+   ):
+    raise Exception('''Please supply arguments for:
+                         --workflow_to_trigger
+                         --workflows_to_check
+                         --timeout
+                         --wait_time''')
+
+
+workflow_to_trigger = args.workflow_to_trigger
+workflows_to_check = args.workflows_to_check.split(',')
+running_statuses = ['RUNNING', 'STOPPING']
+completed_statues = ['COMPLETED', 'STOPPED', 'ERROR']
+timeout = args.timeout
+wait_time = args.wait_time
+
+client = boto3.client('glue')
+logger = logging.getLogger()
+logging.basicConfig(level=logging.INFO)
+
+started_date = datetime.now(timezone.utc)
+
+
+def check_work_flow_compeleted(work_flow_name):
+
+    while True:
+        work_flow_dict = client.get_workflow(Name=work_flow_name)
+        if work_flow_dict['Workflow']['LastRun']['StartedOn'] > started_date:
+            logger.info(f'WorkFlow: {work_flow_name}, Started')
+            break
+
+        if (datetime.now(timezone.utc) - started_date).total_seconds() > timeout:
+            logger.error(f'Error Timeout Workflow: {work_flow_name}')
+            raise Exception(f'Timeout. Workflow {work_flow_name}, ran for longer than expected')
+        logger.info(f'WorkFlow: {work_flow_name}, Waiting for workflow to start')
+        time.sleep(5)
+
+    while True:
+        work_flow_dict = client.get_workflow(Name=work_flow_name)
+        status = work_flow_dict['Workflow']['LastRun']['Status']
+
+        if status in completed_statues:
+            if(status == 'COMPLETED'):
+                logger.info(
+                    f'Workflow:{work_flow_name}, Status:{status}')
+            else:
+                logger.error(
+                    f'Workflow:{work_flow_name}, Status:{status}')
+            break
+
+        if (datetime.now(timezone.utc) - started_date).total_seconds() > timeout:
+            logger.error('Error Timeout Workflow: ' + work_flow_name)
+            raise Exception('Timeout. Workflow ran for longer than expected')
+        logger.info(f'WorkFlow: {work_flow_name}, Status: {status}, Waiting for workflow to complete')
+        time.sleep(5)
+
+    work_stats = work_flow_dict['Workflow']['LastRun']['Statistics']
+
+    if (
+        int(work_stats['TimeoutActions']) > 0 or
+        int(work_stats['FailedActions']) > 0 or
+        int(work_stats['StoppedActions']) > 0 or
+        int(work_stats['RunningActions']) > 0 or
+        int(work_stats['TotalActions']) != int(work_stats['SucceededActions'])
+    ):
+        error_message = 'Error not all jobs completed successfully, WorkFlow:'
+        error_message += work_flow_name + os.linesep + \
+            json.dumps(work_stats, indent=4, sort_keys=True)
+        logger.error(error_message)
+        raise Exception(error_message)
+    else:
+        logger.info(f'Workflow:{work_flow_name}, all jobs completed successfully')
+
+
+def main():
+    logger.info(f'Triggering Workflow:{workflow_to_trigger}')
+    client.start_workflow_run(Name=workflow_to_trigger)
+
+    for workflow in workflows_to_check:
+        check_work_flow_compeleted(workflow)
+
+    logger.info('All workflows completed successfully')
+
+
+main()

--- a/scripts/trigger_glue_workflow_and_check_outcome.py
+++ b/scripts/trigger_glue_workflow_and_check_outcome.py
@@ -53,7 +53,7 @@ def check_work_flow_compeleted(work_flow_name):
             logger.error(f'Error Timeout Workflow: {work_flow_name}')
             raise Exception(f'Timeout. Workflow {work_flow_name}, ran for longer than expected')
         logger.info(f'WorkFlow: {work_flow_name}, Waiting for workflow to start')
-        time.sleep(5)
+        time.sleep(wait_time)
 
     while True:
         work_flow_dict = client.get_workflow(Name=work_flow_name)
@@ -72,7 +72,7 @@ def check_work_flow_compeleted(work_flow_name):
             logger.error('Error Timeout Workflow: ' + work_flow_name)
             raise Exception('Timeout. Workflow ran for longer than expected')
         logger.info(f'WorkFlow: {work_flow_name}, Status: {status}, Waiting for workflow to complete')
-        time.sleep(5)
+        time.sleep(wait_time)
 
     work_stats = work_flow_dict['Workflow']['LastRun']['Statistics']
 


### PR DESCRIPTION
Change from aws CLI call to a python script that triggers the glue workflow and verify's the jobs have completed
This requires this pull request to be merged 1st https://github.com/alphagov/covid-engineering/pull/1089
