### PR TITLE
Add leading zeros to DOB on send_message for SPL check.

### DIFF
--- a/tests/form_pages/shared/test_form_utils.py
+++ b/tests/form_pages/shared/test_form_utils.py
@@ -3,6 +3,7 @@ import pytest
 from vulnerable_people_form.form_pages.shared.form_utils import (
     clean_nhs_number,
     sanitise_date,
+    format_date,
     strip_non_digits,
     sanitise_name,
     sanitise_support_address,
@@ -72,6 +73,32 @@ def test_sanitise_date_of_birth_should_raise_error_when_invalid_dict_supplied():
     test_date = {"day": "13", "month": "7", "invalid_field": "test"}
     with pytest.raises(ValueError) as exception_info:
         sanitise_date(test_date)
+    assert "Unexpected date_value encountered" in str(exception_info.value)
+
+
+def test_format_date_should_add_leading_zeros():
+    test_date = {"day": "1", "month": "7", "year": "1991"}
+    formatted_date = format_date(test_date)
+    assert formatted_date == "1991/07/01"
+
+
+def test_format_date_should_not_change_correct_day_month():
+    test_date = {"day": "11", "month": "12", "year": "1991"}
+    formatted_date = format_date(test_date)
+    assert formatted_date == "1991/12/11"
+
+
+def test_format_date_should_raise_error_when_invalid_length_dict_supplied():
+    test_date = {"day": "1", "month": "7", "year": "1991", "random_field": "test"}
+    with pytest.raises(ValueError) as exception_info:
+        format_date(test_date)
+    assert "Unexpected date_value encountered" in str(exception_info.value)
+
+
+def test_format_date_should_raise_error_when_invalid_dict_supplied():
+    test_date = {"day": "1", "month": "7", "invalid_field": "test"}
+    with pytest.raises(ValueError) as exception_info:
+        format_date(test_date)
     assert "Unexpected date_value encountered" in str(exception_info.value)
 
 

--- a/vulnerable_people_form/form_pages/shared/form_utils.py
+++ b/vulnerable_people_form/form_pages/shared/form_utils.py
@@ -25,6 +25,13 @@ def sanitise_date(date_value):
             date_value[k] = strip_non_digits(date_value[k])
 
 
+def format_date(date_value):
+    if len(date_value.keys()) != 3 or \
+      not all(k in date_value for k in ["day", "month", "year"]):
+        raise ValueError(f"Unexpected date_value encountered: {date_value}")
+    return f"{date_value['year']}/{date_value['month']:0>2}/{date_value['day']:0>2}"
+
+
 def sanitise_name(name_value):
     if name_value:
         if len(name_value.keys()) != 3 or \

--- a/vulnerable_people_form/integrations/notifications.py
+++ b/vulnerable_people_form/integrations/notifications.py
@@ -5,7 +5,7 @@ import boto3
 from botocore.config import Config
 from flask import current_app
 
-from vulnerable_people_form.form_pages.shared.form_utils import postcode_with_spaces
+from vulnerable_people_form.form_pages.shared.form_utils import postcode_with_spaces, format_date
 from vulnerable_people_form.form_pages.shared.session import form_answers
 from vulnerable_people_form.form_pages.shared.logger_utils import init_logger
 
@@ -37,12 +37,11 @@ def send_message(registration_number, app=current_app):
     client = get_sqs_client()
 
     spaced_postcode = postcode_with_spaces(form_answers()["support_address"]["postcode"])
-    date_of_birth = form_answers()["date_of_birth"]
 
     message = {
         "submission_id": registration_number,
         "nhs_number": form_answers()["nhs_number"],
-        "date_of_birth": f"{date_of_birth['year']}/{date_of_birth['month']}/{date_of_birth['day']}",
+        "date_of_birth": format_date(form_answers()["date_of_birth"]),
         "first_name": form_answers()["name"]["first_name"],
         "last_name": form_answers()["name"]["last_name"],
         "email": form_answers()["contact_details"].get("email"),


### PR DESCRIPTION
Fix the send_message function to add leading zeros to the day and month of the date_of_birth attribute

This is required by the MySQL stored procedure to check if the person is on the SPL

E.G. "1994/1/1" will throw an error on the spl proc, but "1994/01/01" will succeed

Added test for this scenario