### PR TITLE
Smoke test submits form

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ concourse_e2e:
 	behave behave/features -k --stop --tags core,feature_postcode_tier
 
 smoke_test:
-	@echo "Executing smoke test without submission..."
-	behave behave/features/11.e2e_not_eligible_postcode_tier.feature --stop
+	@echo "Executing smoke test with submission..."
+	behave behave/features/12.e2e_journey_tier_3.feature --stop
 
 test_e2e_local:
 	@echo "Executing e2e automated tests against the local environment..."

--- a/Makefile
+++ b/Makefile
@@ -15,27 +15,15 @@ install:
 concourse_e2e:
 	@echo "Executing e2e automated tests against the staging environment..."
 	# execute all scenarios except no submission and backend submissions test ( the '-' character prefix means skip)
-ifeq (${TIERING_LOGIC},True)
 	behave behave/features -k --stop --tags core,feature_postcode_tier
-else
-	behave behave/features -k --stop --tags core,e2e_partial_journey_do_you_live_in_england
-endif
 
 smoke_test:
 	@echo "Executing smoke test without submission..."
-ifeq (${TIERING_LOGIC},True)
 	behave behave/features/11.e2e_not_eligible_postcode_tier.feature --stop
-else
-	behave behave/features/5.e2e_not_eligible_postcode.feature --stop
-endif
 
 test_e2e_local:
 	@echo "Executing e2e automated tests against the local environment..."
-ifeq (${TIERING_LOGIC},True)
 	docker-compose run --service-ports --rm chrome-driver bash -c "behave features -k --stop --tags core,feature_postcode_tier --stop"
-else
-	docker-compose run --service-ports --rm chrome-driver bash -c "behave features -k --stop --tags core,e2e_partial_journey_do_you_live_in_england --stop"
-endif
 
 concourse_e2e_with_pipeline_validation_webform_entry:
 	@echo "Executing web form entry for End to End with Pipeline Validation..."


### PR DESCRIPTION
Submit form when running smoke test

We now filter out the magical NHS number that is valid but will never be
assigned to a real person[1]. This means we can submit the form as part
of the smoke tests without worrying that it'll filter down to
LAs/supermarkets.

[1] https://github.com/alphagov/covid-engineering/pull/1086/files#diffd1cb3b92e44f12aca7c91698084340b13ebb56f9e6f7b70c128fd65fc970667fR49

