### PR TITLE
Validate phone number using formats from Notify codebase

### DIFF
--- a/tests/form_pages/shared/test_sms_validation.py
+++ b/tests/form_pages/shared/test_sms_validation.py
@@ -1,6 +1,7 @@
 import pytest
 
-from vulnerable_people_form.form_pages.shared.sms_validation import validate_uk_phone_number, InvalidPhoneError
+from vulnerable_people_form.form_pages.shared.sms_validation import validate_notify_compatible_uk_mobile_number, \
+    InvalidPhoneError
 
 valid_notify_uk_phone_numbers = [
     '7123456789',
@@ -53,10 +54,10 @@ invalid_notify_uk_phone_numbers = [
 
 @pytest.mark.parametrize("phone_number", valid_notify_uk_phone_numbers)
 def test_phone_number_is_valid_for_notify_returns_true_for_valid_notify_uk_test_cases(phone_number):
-    assert validate_uk_phone_number(phone_number)
+    assert validate_notify_compatible_uk_mobile_number(phone_number)
 
 
 @pytest.mark.parametrize("phone_number", invalid_notify_uk_phone_numbers)
 def test_phone_number_is_valid_for_notify_raises_exception_for_invalid_notify_uk_test_cases(phone_number):
     with pytest.raises(InvalidPhoneError):
-        validate_uk_phone_number(phone_number)
+        validate_notify_compatible_uk_mobile_number(phone_number)

--- a/tests/form_pages/shared/test_sms_validation.py
+++ b/tests/form_pages/shared/test_sms_validation.py
@@ -1,0 +1,62 @@
+import pytest
+
+from vulnerable_people_form.form_pages.shared.sms_validation import validate_uk_phone_number, InvalidPhoneError
+
+valid_notify_uk_phone_numbers = [
+    '7123456789',
+    '07123456789',
+    '07123 456789',
+    '07123-456-789',
+    '00447123456789',
+    '00 44 7123456789',
+    '+447123456789',
+    '+44 7123 456 789',
+    '+44 (0)7123 456 789',
+    '\u200B\t\t+44 (0)7123 \uFEFF 456 789 \r\n',
+]
+
+invalid_notify_uk_phone_numbers = [
+    '71234567890',  # International numbers
+    '1-202-555-0104',
+    '+12025550104',
+    '0012025550104',
+    '+0012025550104',
+    '23051234567',
+    '+682 12345',
+    '+3312345678',
+    '003312345678',
+    '1-2345-12345-12345',
+    '712345678910',  # Too many digits
+    '0712345678910',
+    '0044712345678910',
+    '0044712345678910',
+    '+44 ()7123 456 789 10',
+    '0712345678',  # Not enough digits
+    '004471234567',
+    '00447123456',
+    '+44 (0)7123 456 78',
+    '08081 570364',  # Not a UK mobile number
+    '+44 8081 570364',
+    '0117 496 0860',
+    '+44 117 496 0860',
+    '020 7946 0991',
+    '+44 20 7946 0991',
+    '07890x32109',  # Must not contain letters or symbols
+    '07123 456789...',
+    '07123 ☟☜⬇⬆☞☝',
+    '07123☟☜⬇⬆☞☝',
+    '07";DROP TABLE;"',
+    '+44 07ab cde fgh',
+    'ALPHANUM3R1C',
+]
+
+
+@pytest.mark.parametrize("phone_number", valid_notify_uk_phone_numbers)
+def test_phone_number_is_valid_for_notify_returns_true_for_valid_notify_uk_test_cases(phone_number):
+    assert validate_uk_phone_number(phone_number)
+
+
+@pytest.mark.parametrize("phone_number", invalid_notify_uk_phone_numbers)
+def test_phone_number_is_valid_for_notify_raises_exception_for_invalid_notify_uk_test_cases(phone_number):
+    with pytest.raises(InvalidPhoneError):
+        validate_uk_phone_number(phone_number)

--- a/tests/form_pages/shared/test_validation.py
+++ b/tests/form_pages/shared/test_validation.py
@@ -475,15 +475,9 @@ def test_validate_support_address_should_return_true_when_a_valid_address_is_pro
          "town_city": "town / city too long town / city too long town / city too long town / city too long town / city too long ", # noqa
          "postcode": "LS11BA"
      },
-     [{
-         "form_field": "building_and_street_line_1",
-         "expected_error_msg": "'Address line 1' cannot be longer than 110 characters"
-     },
-         {
-             "form_field": "building_and_street_line_2",
-             "expected_error_msg": "'Address line 2' cannot be longer than 210 characters"
-         },
-         {"form_field": "town_city", "expected_error_msg": "'Town or city' cannot be longer than 50 characters"}])
+     [{"form_field": "building_and_street_line_1", "expected_error_msg": "'Address line 1' cannot be longer than 110 characters"}, # noqa
+      {"form_field": "building_and_street_line_2", "expected_error_msg": "'Address line 2' cannot be longer than 210 characters"}, # noqa
+      {"form_field": "town_city", "expected_error_msg": "'Town or city' cannot be longer than 50 characters"}])
 ])
 def test_validate_support_address_should_return_false_when_an_invalid_address_is_provided(
         test_case_support_address, field_error_messages

--- a/tests/form_pages/shared/test_validation.py
+++ b/tests/form_pages/shared/test_validation.py
@@ -1,8 +1,9 @@
-import pytest
 from unittest.mock import patch
 
-from vulnerable_people_form.form_pages.shared import validation
+import pytest
 from flask import Flask
+
+from vulnerable_people_form.form_pages.shared import validation
 from vulnerable_people_form.form_pages.shared.answers_enums import (
     ApplyingOnOwnBehalfAnswers,
     MedicalConditionsAnswers,
@@ -31,7 +32,7 @@ def test_validate_name_should_return_true_when_first_name_and_surname_entered():
     with patch(
             _FORM_ANSWERS_FUNCTION_FULLY_QUALIFIED_NAME,
             create_form_answers_with_first_name_and_surname), \
-            _current_app.test_request_context() as test_request_ctx:
+         _current_app.test_request_context() as test_request_ctx:
         test_request_ctx.session["form_answers"] = create_form_answers_with_first_name_and_surname()
         is_valid = validation.validate_name()
         assert len(test_request_ctx.session) == 1
@@ -46,7 +47,7 @@ def test_validate_name_should_return_false_when_only_first_name_entered(first_na
     with patch(
             _FORM_ANSWERS_FUNCTION_FULLY_QUALIFIED_NAME,
             create_form_answers_with_first_name_only), \
-            _current_app.test_request_context() as test_request_ctx:
+         _current_app.test_request_context() as test_request_ctx:
         test_request_ctx.session["form_answers"] = create_form_answers_with_first_name_only()
         sanitise_name(test_request_ctx.session["form_answers"]["name"])
         is_valid = validation.validate_name()
@@ -63,7 +64,7 @@ def test_validate_name_should_return_false_when_only_last_name_entered():
     with patch(
             _FORM_ANSWERS_FUNCTION_FULLY_QUALIFIED_NAME,
             create_form_answers_with_last_name_only), \
-            _current_app.test_request_context() as test_request_ctx:
+         _current_app.test_request_context() as test_request_ctx:
         test_request_ctx.session["form_answers"] = create_form_answers_with_last_name_only()
         is_valid = validation.validate_name()
 
@@ -264,7 +265,7 @@ def test_validate_postcode_should_return_false_when_no_postcode_present(postcode
         assert is_valid is False
         assert len(test_request_ctx.session) == 1
         assert test_request_ctx.session["error_items"]["postcode"]["postcode"] \
-            == "What is the postcode where you need support?"
+               == "What is the postcode where you need support?"
 
 
 @pytest.mark.parametrize("postcode", ["invalid_post_code", "ssss 12345", "LS1 1AB ABC", "NE11", "NE11 1LBC"])
@@ -306,7 +307,8 @@ def test_validate_nhs_number_should_return_false_when_empty_or_invalid_length_nh
     )
 
 
-@pytest.mark.parametrize("form_field_value", ["1234567891", "abcd123456", "111~643245#5", "123 643245-5", "\t\t\t\b123 643245-5"]) # noqa
+@pytest.mark.parametrize("form_field_value",
+                         ["1234567891", "abcd123456", "111~643245#5", "123 643245-5", "\t\t\t\b123 643245-5"])  # noqa
 def test_validate_nhs_number_should_return_false_when_invalid_nhs_number_entered(form_field_value):
     _execute_input_validation_test_and_assert_validation_failed(
         validation.validate_nhs_number,
@@ -352,7 +354,7 @@ def test_validate_email_if_present_should_return_true_when_valid_email_entered()
     with patch(
             _FORM_ANSWERS_FUNCTION_FULLY_QUALIFIED_NAME,
             create_form_answers), \
-            _current_app.test_request_context() as test_request_ctx:
+         _current_app.test_request_context() as test_request_ctx:
         is_valid = validation.validate_email_if_present("contact_details", "email")
 
         assert is_valid is True
@@ -366,7 +368,7 @@ def test_validate_email_if_present_should_return_true_when_no_email_entered():
     with patch(
             _FORM_ANSWERS_FUNCTION_FULLY_QUALIFIED_NAME,
             create_form_answers), \
-            _current_app.test_request_context() as test_request_ctx:
+         _current_app.test_request_context() as test_request_ctx:
         is_valid = validation.validate_email_if_present("contact_details", "email")
 
         assert is_valid is True
@@ -459,32 +461,35 @@ def test_validate_support_address_should_return_true_when_a_valid_address_is_pro
 
 @pytest.mark.parametrize("test_case_support_address, field_error_messages", [
     ({
-        "building_and_street_line_1": "",
-        "building_and_street_line_2": "",
-        "town_city": "",
-        "postcode": ""
+         "building_and_street_line_1": "",
+         "building_and_street_line_2": "",
+         "town_city": "",
+         "postcode": ""
      },
      [{"form_field": "building_and_street_line_1", "expected_error_msg": "Enter a building and street"},
       {"form_field": "town_city", "expected_error_msg": "Enter a town or city"},
       {"form_field": "postcode", "expected_error_msg": "What is the postcode where you need support?"}]),
     ({
-        "building_and_street_line_1": "address line one too long address line one too long  address line one too long address line one too long address line one too long, address line one too long address line one too long  address line one too long address line one too long address line one too long,addr ",  # noqa
-        "building_and_street_line_2": "address line two too long address line two too long address line two too long address line two too long address line two too long address line one too long address line one too long  address line one too long address line one too long address line one too long ad",  # noqa
-        "town_city": "town / city too long town / city too long town / city too long town / city too long town / city too long ",  # noqa
-        "postcode": "LS11BA"
+         "building_and_street_line_1": "address line one too long address line one too long  address line one too long address line one too long address line one too long, address line one too long address line one too long  address line one too long address line one too long address line one too long,addr ",
+         # noqa
+         "building_and_street_line_2": "address line two too long address line two too long address line two too long address line two too long address line two too long address line one too long address line one too long  address line one too long address line one too long address line one too long ad",
+         # noqa
+         "town_city": "town / city too long town / city too long town / city too long town / city too long town / city too long ",
+         # noqa
+         "postcode": "LS11BA"
      },
      [{
          "form_field": "building_and_street_line_1",
          "expected_error_msg": "'Address line 1' cannot be longer than 110 characters"
-      },
-      {
-         "form_field": "building_and_street_line_2",
-         "expected_error_msg": "'Address line 2' cannot be longer than 210 characters"
-      },
-      {"form_field": "town_city", "expected_error_msg": "'Town or city' cannot be longer than 50 characters"}])
+     },
+         {
+             "form_field": "building_and_street_line_2",
+             "expected_error_msg": "'Address line 2' cannot be longer than 210 characters"
+         },
+         {"form_field": "town_city", "expected_error_msg": "'Town or city' cannot be longer than 50 characters"}])
 ])
 def test_validate_support_address_should_return_false_when_an_invalid_address_is_provided(
- test_case_support_address, field_error_messages
+        test_case_support_address, field_error_messages
 ):
     with _current_app.test_request_context() as test_request_ctx:
         test_request_ctx.session["form_answers"] = {
@@ -527,7 +532,7 @@ def _execute_input_validation_test_and_assert_validation_passed(validation_funct
     with patch(
             _FORM_ANSWERS_FUNCTION_FULLY_QUALIFIED_NAME,
             create_form_answers), \
-            _current_app.test_request_context() as test_request_ctx:
+         _current_app.test_request_context() as test_request_ctx:
         is_valid = validation_function()
 
         assert is_valid is True
@@ -542,7 +547,7 @@ def _execute_input_validation_test_and_assert_validation_failed(validation_funct
     with patch(
             _FORM_ANSWERS_FUNCTION_FULLY_QUALIFIED_NAME,
             create_form_answers), \
-            _current_app.test_request_context() as test_request_ctx:
+         _current_app.test_request_context() as test_request_ctx:
         is_valid = validation_function()
 
         _make_validation_failure_assertions(is_valid, test_request_ctx.session,

--- a/tests/form_pages/shared/test_validation.py
+++ b/tests/form_pages/shared/test_validation.py
@@ -470,12 +470,9 @@ def test_validate_support_address_should_return_true_when_a_valid_address_is_pro
       {"form_field": "town_city", "expected_error_msg": "Enter a town or city"},
       {"form_field": "postcode", "expected_error_msg": "What is the postcode where you need support?"}]),
     ({
-         "building_and_street_line_1": "address line one too long address line one too long  address line one too long address line one too long address line one too long, address line one too long address line one too long  address line one too long address line one too long address line one too long,addr ",
-         # noqa
-         "building_and_street_line_2": "address line two too long address line two too long address line two too long address line two too long address line two too long address line one too long address line one too long  address line one too long address line one too long address line one too long ad",
-         # noqa
-         "town_city": "town / city too long town / city too long town / city too long town / city too long town / city too long ",
-         # noqa
+         "building_and_street_line_1": "address line one too long address line one too long  address line one too long address line one too long address line one too long, address line one too long address line one too long  address line one too long address line one too long address line one too long,addr ", # noqa
+         "building_and_street_line_2": "address line two too long address line two too long address line two too long address line two too long address line two too long address line one too long address line one too long  address line one too long address line one too long address line one too long ad", # noqa
+         "town_city": "town / city too long town / city too long town / city too long town / city too long town / city too long ", # noqa
          "postcode": "LS11BA"
      },
      [{

--- a/vulnerable_people_form/form_pages/check_contact_details.py
+++ b/vulnerable_people_form/form_pages/check_contact_details.py
@@ -1,12 +1,19 @@
+import logging
+
 from flask import redirect, session
 
 from .blueprint import form
+from .shared.logger_utils import init_logger
 from .shared.mailchecker import suggest
 from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
 from .shared.session import form_answers, get_errors_from_session, request_form
 from .shared.validation import validate_contact_details
+
+
+logger = logging.getLogger(__name__)
+init_logger(logger)
 
 
 @form.route("/check-contact-details", methods=["GET"])
@@ -40,7 +47,7 @@ def post_check_contact_details():
         },
     }
     session["error_items"] = {}
-    if not validate_contact_details("check_contact_details"):
+    if not validate_contact_details("check_contact_details", logger=logger):
         return redirect("/check-contact-details")
 
     return route_to_next_form_page()

--- a/vulnerable_people_form/form_pages/contact_details.py
+++ b/vulnerable_people_form/form_pages/contact_details.py
@@ -51,6 +51,6 @@ def post_contact_details():
         },
     }
     session["error_items"] = {}
-    if not validate_contact_details("contact_details"):
+    if not validate_contact_details("contact_details", logger=logger):
         return redirect("/contact-details")
     return route_to_next_form_page()

--- a/vulnerable_people_form/form_pages/contact_details.py
+++ b/vulnerable_people_form/form_pages/contact_details.py
@@ -1,11 +1,18 @@
+import logging
+
 import phonenumbers
 from flask import redirect, session
 
 from .blueprint import form
+from .shared.logger_utils import init_logger
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page, get_back_url_for_contact_details
 from .shared.session import form_answers, get_errors_from_session, request_form
 from .shared.validation import validate_contact_details
+
+
+logger = logging.getLogger(__name__)
+init_logger(logger)
 
 
 def format_phone_number_if_valid(phone_number):
@@ -30,15 +37,17 @@ def get_contact_details():
 
 @form.route("/contact-details", methods=["POST"])
 def post_contact_details():
+    email = request_form().get("email")
+    phone_number_calls = request_form().get("phone_number_calls")
+    phone_number_texts = request_form().get("phone_number_texts")
+
     session["form_answers"] = {
         **session.setdefault("form_answers", {}),
         "contact_details": {
             **request_form(),
-            **{
-                phone_key: format_phone_number_if_valid(request_form().get(phone_key))
-                for phone_key in ("phone_number_calls", "phone_number_texts")
-            },
-            "email": request_form().get("email").strip() if request_form().get("email") else ""
+            "phone_number_calls": format_phone_number_if_valid(phone_number_calls) if phone_number_calls else '',
+            "phone_number_texts": format_phone_number_if_valid(phone_number_texts) if phone_number_texts else '',
+            "email": email.strip() if email else ""
         },
     }
     session["error_items"] = {}

--- a/vulnerable_people_form/form_pages/shared/logger_utils.py
+++ b/vulnerable_people_form/form_pages/shared/logger_utils.py
@@ -22,7 +22,8 @@ log_event_names = {
     "TOO_MANY_LADCODES_FOUND": "MoreThanOneLadcodeFoundInDb",
     "LADCODE_NOT_IN_FILE": "LadcodeNotMappedToTierNotFoundInRestrictionsFile",
     "LADCODE_SUCCESSFULLY_MAPPED_TO_TIER": "LadcodeSuccessfullyMappedToTier",
-    "LADCODE_HAS_NO_RELEVANT_RESTRICTION": "LadcodeNotMappedToTierNoRelevantRestriction"
+    "LADCODE_HAS_NO_RELEVANT_RESTRICTION": "LadcodeNotMappedToTierNoRelevantRestriction",
+    "NOT_VALID_PHONE_NUMBER_FOR_TEXTS_ENTERED": "NotValidPhoneNumberForTextsEntered"
 }
 
 

--- a/vulnerable_people_form/form_pages/shared/sms_validation.py
+++ b/vulnerable_people_form/form_pages/shared/sms_validation.py
@@ -1,0 +1,48 @@
+# NOTIFY CODE
+
+OBSCURE_WHITESPACE = (
+    '\u180E'  # Mongolian vowel separator
+    '\u200B'  # zero width space
+    '\u200C'  # zero width non-joiner
+    '\u200D'  # zero width joiner
+    '\u2060'  # word joiner
+    '\u00A0'  # non breaking space
+    '\uFEFF'  # zero width non-breaking space
+)
+
+uk_prefix = '44'
+
+
+class InvalidPhoneError(Exception):
+
+    def __init__(self, message=None):
+        super().__init__(message or 'Not a valid phone number')
+
+
+def validate_uk_phone_number(number):
+    number = normalise_phone_number(number).lstrip(uk_prefix).lstrip('0')
+
+    if not number.startswith('7'):
+        raise InvalidPhoneError('Not a UK mobile number')
+
+    if len(number) > 10:
+        raise InvalidPhoneError('Too many digits')
+
+    if len(number) < 10:
+        raise InvalidPhoneError('Not enough digits')
+
+    return '{}{}'.format(uk_prefix, number)
+
+
+def normalise_phone_number(number):
+    import string
+
+    for character in string.whitespace + OBSCURE_WHITESPACE + '()-+':
+        number = number.replace(character, '')
+
+    try:
+        list(map(int, number))
+    except ValueError:
+        raise InvalidPhoneError('Must not contain letters or symbols')
+
+    return number.lstrip('0')

--- a/vulnerable_people_form/form_pages/shared/sms_validation.py
+++ b/vulnerable_people_form/form_pages/shared/sms_validation.py
@@ -19,7 +19,7 @@ class InvalidPhoneError(Exception):
         super().__init__(message or 'Not a valid phone number')
 
 
-def validate_uk_phone_number(number):
+def validate_notify_compatible_uk_mobile_number(number):
     number = normalise_phone_number(number).lstrip(uk_prefix).lstrip('0')
 
     if not number.startswith('7'):

--- a/vulnerable_people_form/form_pages/shared/validation.py
+++ b/vulnerable_people_form/form_pages/shared/validation.py
@@ -317,7 +317,7 @@ def phone_number_is_valid_for_notify(phone_number, logger=None):
         return True
     except InvalidPhoneError as e:
         if logger:
-            logger.warning(create_log_message(log_event_names["NHS_LOGIN_USER_CONSENT_NOT_GIVEN"],
+            logger.warning(create_log_message(log_event_names["NOT_VALID_PHONE_NUMBER_FOR_TEXTS_ENTERED"],
                                               f"Invalid phone for receiving Notify SMS entered: {e.message}"))
         return False
 

--- a/vulnerable_people_form/form_pages/shared/validation.py
+++ b/vulnerable_people_form/form_pages/shared/validation.py
@@ -17,7 +17,7 @@ from .answers_enums import (
     BasicCareNeedsAnswers,
     LiveInEnglandAnswers)
 from .session import form_answers, get_answer_from_form, request_form
-from .sms_validation import validate_uk_phone_number, InvalidPhoneError
+from .sms_validation import validate_notify_compatible_uk_mobile_number, InvalidPhoneError
 
 
 def validate_mandatory_form_field(section_key, value_key, error_message):
@@ -312,7 +312,7 @@ def validate_sms_phone_number_if_present(section_key, phone_number_key):
 
 def phone_number_is_valid_for_notify(phone_number):
     try:
-        validate_uk_phone_number(phone_number)
+        validate_notify_compatible_uk_mobile_number(phone_number)
         return True
     except InvalidPhoneError:
         return False

--- a/vulnerable_people_form/form_pages/shared/validation.py
+++ b/vulnerable_people_form/form_pages/shared/validation.py
@@ -16,6 +16,7 @@ from .answers_enums import (
     ShoppingAssistanceAnswers,
     BasicCareNeedsAnswers,
     LiveInEnglandAnswers)
+from .logger_utils import create_log_message, log_event_names
 from .session import form_answers, get_answer_from_form, request_form
 from .sms_validation import validate_notify_compatible_uk_mobile_number, InvalidPhoneError
 
@@ -296,9 +297,9 @@ def validate_phone_number_if_present(section_key, phone_number_key):
     return True
 
 
-def validate_sms_phone_number_if_present(section_key, phone_number_key):
+def validate_sms_phone_number_if_present(section_key, phone_number_key, logger=None):
     phone_number = form_answers()["contact_details"].get(phone_number_key, "")
-    if phone_number and phone_number_is_valid_for_notify(phone_number):
+    if phone_number and phone_number_is_valid_for_notify(phone_number, logger=logger):
         return True
     else:
         error_message = "Enter a UK mobile number, like 07700 900000 or +44 7700 900000"
@@ -310,11 +311,14 @@ def validate_sms_phone_number_if_present(section_key, phone_number_key):
         return False
 
 
-def phone_number_is_valid_for_notify(phone_number):
+def phone_number_is_valid_for_notify(phone_number, logger=None):
     try:
         validate_notify_compatible_uk_mobile_number(phone_number)
         return True
-    except InvalidPhoneError:
+    except InvalidPhoneError as e:
+        if logger:
+            logger.warning(create_log_message(log_event_names["NHS_LOGIN_USER_CONSENT_NOT_GIVEN"],
+                                              f"Invalid phone for receiving Notify SMS entered: {e.message}"))
         return False
 
 
@@ -334,12 +338,12 @@ def validate_email_if_present(section_key, email_key):
     return True
 
 
-def validate_contact_details(section_key):
+def validate_contact_details(section_key, logger=None):
     value = all(
         [
             validate_email_if_present(section_key, "email"),
             validate_phone_number_if_present(section_key, "phone_number_calls"),
-            validate_sms_phone_number_if_present(section_key, "phone_number_texts"),
+            validate_sms_phone_number_if_present(section_key, "phone_number_texts", logger=logger),
         ]
     )
     return value


### PR DESCRIPTION
- add code to validate text contact phone numbers as Notify SMS compatible in the front end
- test against values from Notify test suite