### PR TITLE
Track change answer links and shopping assistance in GA

### DIFF
--- a/vulnerable_people_form/form_pages/shared/session.py
+++ b/vulnerable_people_form/form_pages/shared/session.py
@@ -179,6 +179,7 @@ def _get_summary_row(change_answer_url, question, value):
             "items": [
                 {
                     "href": change_answer_url,
+                    "classes": "change-link",
                     "text": "Change",
                     "visuallyHiddenText": question,
                 }

--- a/vulnerable_people_form/static/js/svp-analytics.js
+++ b/vulnerable_people_form/static/js/svp-analytics.js
@@ -16,6 +16,43 @@ window.GOVUK = window.GOVUK || {};
         return '';
     };
 
+    function trackRadioItemsAnswers(inputSelector, eventCategory, eventLabel) {
+        document.querySelectorAll(inputSelector).forEach(item => {
+            item.addEventListener('click', event => {
+                var eventAction = event.target.value === "1" ? "Yes" : "No";
+                ga('send', 'event', eventCategory, eventAction, eventLabel);
+            })
+        })
+    }
+
+    function trackChangeAnswerLinks() {
+        document.querySelectorAll(".change-link").forEach((item) => {
+            item.addEventListener("click", (event) => {
+                event.preventDefault();
+                setTimeout(redirect, 1000);
+
+                var hasRedirected = false;
+                var changeLinkAction =
+                    event.target.baseURI.indexOf("view-answers") !== -1 ?
+                    "change link - view answers NHS login user" :
+                    "change link - check your answers";
+
+                function redirect() {
+                    if (!hasRedirected) {
+                        hasRedirected = true;
+                        document.location = event.target.href;
+                    }
+                }
+
+                ga("send", "event", "on-page links", changeLinkAction, event.target.href, {
+                    hitCallback: function() {
+                        redirect();
+                    },
+                });
+            });
+        });
+    }
+
     function Analytics() {}
     Analytics.prototype.init = function(gaTrackingId, gaCrossDomainTrackingId) {
         this.gaTrackingId = gaTrackingId;
@@ -44,6 +81,9 @@ window.GOVUK = window.GOVUK || {};
                 } else {
                     ga('send', 'pageview');
                 }
+
+                trackRadioItemsAnswers('input[name="do_you_have_someone_to_go_shopping_for_you"]', 'page interaction', window.location);
+                trackChangeAnswerLinks();
             }
 
             if (this.gaCrossDomainTrackingId) {


### PR DESCRIPTION
A requirement from MI to track when a user changes their answers to allow a better understanding of how the user is using the service. In addition, the do-you-have-someone-to-go-shopping-for-you question answers have also been tracked and sent to GA to help understand how people answer this question.