### PR TITLE
Fix routing after form has been filled in for address_lookup

### DIFF
--- a/vulnerable_people_form/form_pages/shared/routing.py
+++ b/vulnerable_people_form/form_pages/shared/routing.py
@@ -189,7 +189,7 @@ def route_to_next_form_page():
 
     if current_form == "address-lookup":
         if _is_tiering_logic_enabled():
-            return _get_next_form_url_based_on_location_tier("/nhs-letter")
+            return _get_next_form_url_based_on_location_tier("/nhs-letter", True)
         return return_redirect_if_postcode_valid(redirect("/nhs-letter"))
     elif current_form == "applying-on-own-behalf":
         if ApplyingOnOwnBehalfAnswers(answer) is ApplyingOnOwnBehalfAnswers.YES:


### PR DESCRIPTION
We want to redirect to a terminal page if the details have already been
filled in, so the flag should be set in the routing function for finding
the next form page.