### PR TITLE
Modify web submissions to use new sproc for RDS

### DIFF
--- a/tests/form_pages/shared/test_session.py
+++ b/tests/form_pages/shared/test_session.py
@@ -252,6 +252,7 @@ def test_persist_answers_from_session():
             "medical_conditions": MedicalConditionsAnswers.YES.value,
             "do_you_live_in_england": LiveInEnglandAnswers.YES.value,
             "tier_at_submission": PostcodeTier.VERY_HIGH.value,
+            "shielding_at_submission": None,
         }
 
         test_request_ctx.session["nhs_sub"] = nhs_sub_value
@@ -284,6 +285,7 @@ def test_persist_answers_from_session():
             data_to_persist["medical_conditions"],
             data_to_persist["do_you_live_in_england"],
             data_to_persist["tier_at_submission"],
+            data_to_persist["shielding_at_submission"],
         )
 
         assert test_request_ctx.session["form_uid"] == submission_ref

--- a/tests/integrations/test_persistence.py
+++ b/tests/integrations/test_persistence.py
@@ -127,11 +127,12 @@ def test_persist_answers_should_map_parameters_correctly():
             test_answers["do_you_have_someone_to_go_shopping_for_you"],
             test_answers["do_you_have_one_of_the_listed_medical_conditions"],
             test_answers["do_you_live_in_england"],
-            test_answers["postcode_tier"])
+            test_answers["postcode_tier"],
+            test_answers["shielding_advice"])
 
         assert submission_reference == submission_ref
         mock_execute_sql.assert_called_once_with(
-            sql="CALL cv_staging.create_web_submission("
+            sql="CALL cv_staging.create_web_submission_with_shielding("
                 ":nhs_number,"
                 ":first_name,"
                 ":middle_name,"
@@ -153,7 +154,8 @@ def test_persist_answers_should_map_parameters_correctly():
                 ":do_you_have_someone_to_go_shopping_for_you,"
                 ":do_you_have_one_of_the_listed_medical_conditions,"
                 ":do_you_live_in_england,"
-                ":tier_at_submission"
+                ":tier_at_submission,"
+                ":shielding_at_submission"
                 ")",
             parameters=(
                 {"name": "nhs_number", "value": {"stringValue": test_answers["nhs_number"]}},
@@ -205,6 +207,10 @@ def test_persist_answers_should_map_parameters_correctly():
                 {
                     "name": "tier_at_submission",
                     "value": {"doubleValue": PostcodeTier.MEDIUM.value},
+                },
+                {
+                    "name": "shielding_at_submission",
+                    "value": {"doubleValue": test_answers["shielding_advice"]},
                 }
             )
         )
@@ -257,5 +263,6 @@ def _create_dummy_answers():
         "do_you_have_someone_to_go_shopping_for_you":  1,
         "do_you_have_one_of_the_listed_medical_conditions":  0,
         "do_you_live_in_england":  1,
-        "postcode_tier": PostcodeTier.MEDIUM.value
+        "postcode_tier": PostcodeTier.MEDIUM.value,
+        "shielding_advice": 1
     }

--- a/vulnerable_people_form/form_pages/shared/session.py
+++ b/vulnerable_people_form/form_pages/shared/session.py
@@ -230,6 +230,7 @@ def persist_answers_from_session():
         form_answers().get("medical_conditions"),
         lives_in_england,
         get_location_tier(),
+        None,
     )
     session["form_uid"] = submission_reference
 
@@ -271,6 +272,7 @@ def load_answers_into_session_if_available():
             do_you_have_one_of_the_listed_medical_conditions,
             do_you_live_in_england,
             tier_at_submission,
+            shielding_at_submission,
         ) = stored_answers
 
         date_of_birth = datetime.date.fromisoformat(date_of_birth["stringValue"])
@@ -309,7 +311,8 @@ def load_answers_into_session_if_available():
             "nhs_letter": have_you_received_an_nhs_letter["longValue"],
             "basic_care_needs": do_you_need_help_meeting_your_basic_care_needs.get("longValue"),
             "do_you_have_someone_to_go_shopping_for_you": do_you_have_someone_to_go_shopping_for_you["longValue"],
-            "do_you_live_in_england": do_you_live_in_england.get("longValue")
+            "do_you_live_in_england": do_you_live_in_england.get("longValue"),
+            "shielding_at_submission": shielding_at_submission.get("longValue")
         }
         priority_supermarket_deliveries = do_you_want_supermarket_deliveries.get("longValue")
         if priority_supermarket_deliveries is not None:

--- a/vulnerable_people_form/integrations/persistence.py
+++ b/vulnerable_people_form/integrations/persistence.py
@@ -205,9 +205,10 @@ def persist_answers(
     do_you_have_one_of_the_listed_medical_conditions,
     do_you_live_in_england,
     postcode_tier,
+    shielding_advice,
 ):
     result = execute_sql(
-        sql="CALL cv_staging.create_web_submission("
+        sql="CALL cv_staging.create_web_submission_with_shielding("
         ":nhs_number,"
         ":first_name,"
         ":middle_name,"
@@ -229,7 +230,8 @@ def persist_answers(
         ":do_you_have_someone_to_go_shopping_for_you,"
         ":do_you_have_one_of_the_listed_medical_conditions,"
         ":do_you_live_in_england,"
-        ":tier_at_submission"
+        ":tier_at_submission,"
+        ":shielding_at_submission"
         ")",
         parameters=(
             generate_string_parameter("nhs_number", nhs_number),
@@ -268,7 +270,8 @@ def persist_answers(
                 "do_you_live_in_england",
                 do_you_live_in_england,
             ),
-            generate_int_parameter("tier_at_submission", postcode_tier)
+            generate_int_parameter("tier_at_submission", postcode_tier),
+            generate_int_parameter("shielding_at_submission", shielding_advice)
         ),
     )
 
@@ -278,7 +281,7 @@ def persist_answers(
 
 def load_answers(nhs_uid):
     records = execute_sql(
-        "CALL cv_base.retrieve_latest_web_submission_for_nhs_login(" "    :uid_nhs_login" ")",
+        "CALL cv_base.retrieve_latest_web_submission_for_nhs_login_with_shielding(" "    :uid_nhs_login" ")",
         (generate_string_parameter("uid_nhs_login", nhs_uid),),
     )["records"]
 


### PR DESCRIPTION
This commit modifies web submissions to use new stored procedure `create_web_submission_with_shielding`
instead of `create_web_submission`. This will allow new field `shielding_at_submission` to be
populated as NULL.

Similarly, sproc `retrieve_latest_web_submission_for_nhs_login` is changed to
`retrieve_latest_web_submission_for_nhs_login_with_shielding`.