### PR TITLE
Create helper functions for reading the csv file and assessing shielding advice

### DIFF
--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -3,6 +3,8 @@ import pytest
 from tests.integrations.lib.fake_os_places_api_entry import fake_os_places_api_entry as _fake_os_places_api_entry
 from tests.integrations.lib.fake_os_places_api_response import FakeOSPlacesAPIResponse
 
+from vulnerable_people_form.integrations.ladcode_shielding_advice_lookup import LocalAuthorityShielding
+
 
 @pytest.fixture()
 def fake_os_places_api_entry(faker):
@@ -19,5 +21,13 @@ def fake_os_places_api_response(faker):
             postcode=postcode or faker.postcode(),
             address_entries=entries,
         )
+
+    return func
+
+
+@pytest.fixture()
+def local_tier_lookup():
+    def func():
+        return LocalAuthorityShielding('tests/integrations/data/local-area-shielding-advice.csv')
 
     return func

--- a/tests/integrations/data/local-area-shielding-advice.csv
+++ b/tests/integrations/data/local-area-shielding-advice.csv
@@ -1,0 +1,12 @@
+ladcode,ladname,shielding_advice,start_datetime_utc
+E06000002,Middlesbrough Borough Council,YES,2020-12-02T00:00:01
+E06000002,Middlesbrough Borough Council,NO,2020-12-10T00:00:01
+E06000003,Dummy Council,NO,2020-12-02T00:00:01
+E06000003,Dummy Council,YES,2020-12-10T00:00:01
+E08000012,Liverpool City Council,YES,2020-08-20T00:00:01
+E08000015,Wirral Borough Council,YES,2020-12-02T00:00:01
+E08000015,Wirral Borough Council,NO,2021-12-02T00:00:01
+E06000018,Nottingham City Council,NO,2020-12-02T00:00:01
+E06000018,Nottingham City Council,YES,2020-12-10T00:00:01
+E0800021,Dummy Council,NO,2020-12-02T00:00:01
+E0800021,Dummy Council,YES,2022-12-02T00:00:01

--- a/tests/integrations/test_ladcode_shielding_advice_lookup.py
+++ b/tests/integrations/test_ladcode_shielding_advice_lookup.py
@@ -1,0 +1,20 @@
+def test_get_shielding_advice_from_ladcode_returns_correct_value_if_available(local_tier_lookup):
+    shielding_list = local_tier_lookup()
+    assert shielding_list.get_shielding_advice_by_ladcode("E08000012") == 'YES'
+
+
+def test_get_shielding_advice_from_ladcode_returns_default_value_if_not_available(local_tier_lookup):
+    shielding_list = local_tier_lookup()
+    assert shielding_list.get_shielding_advice_by_ladcode("NOTAVAILABLE001") == 'NO'
+
+
+def test_get_shielding_advice_from_ladcode_returns_latest_value_if_multiple_rows_available(local_tier_lookup):
+    shielding_list = local_tier_lookup()
+    assert shielding_list.get_shielding_advice_by_ladcode("E06000002") == 'NO'
+    assert shielding_list.get_shielding_advice_by_ladcode("E06000003") == 'YES'
+
+
+def test_get_shielding_advice_from_ladcode_returns_latest_value_and_ignore_future_values(local_tier_lookup):
+    shielding_list = local_tier_lookup()
+    assert shielding_list.get_shielding_advice_by_ladcode("E06000018") == 'YES'
+    assert shielding_list.get_shielding_advice_by_ladcode("E0800021") == 'NO'

--- a/tests/integrations/test_location_eligibility.py
+++ b/tests/integrations/test_location_eligibility.py
@@ -3,7 +3,9 @@ from unittest.mock import patch
 import pytest
 
 from vulnerable_people_form.integrations.location_eligibility import (is_postcode_in_england,
-                                                                      get_postcode_tier, get_uprn_tier)
+                                                                      get_postcode_tier, get_uprn_tier,
+                                                                      get_ladcode_from_postcode,
+                                                                      get_ladcode_from_uprn)
 
 from vulnerable_people_form.form_pages.shared.constants import PostcodeTier
 
@@ -50,3 +52,35 @@ def test_is_postcode_in_england_should_return_correct_eligibility_value(
                return_value={"records": [[{"stringValue": stored_proc_return_value}]]}):
         postcode_in_england = is_postcode_in_england("LS1 1BA")
     assert postcode_in_england == expected_output
+
+
+def test_get_ladcode_should_return_empty_result_set_if_postcode_not_found():
+    with patch("vulnerable_people_form.integrations.location_eligibility.execute_sql",
+               return_value={"records": []}):
+        lad_code = get_ladcode_from_postcode("BD3 1BA")
+        assert not lad_code
+
+
+@pytest.mark.parametrize("stored_proc_return_value, expected_output", [("E08000014", "E08000014")])
+def test_get_ladcode_should_return_valid_ladcode_if_postcode_found(
+        stored_proc_return_value, expected_output):
+    with patch("vulnerable_people_form.integrations.location_eligibility.execute_sql",
+               return_value={"records": [[{"stringValue": stored_proc_return_value}]]}):
+        ladcode = get_ladcode_from_postcode("B21 1BA")
+        assert ladcode == expected_output
+
+
+def test_get_ladcode_should_return_empty_result_set_if_uprn_not_found():
+    with patch("vulnerable_people_form.integrations.location_eligibility.execute_sql",
+               return_value={"records": []}):
+        lacode = get_ladcode_from_uprn("123456789")
+        assert not lacode
+
+
+@pytest.mark.parametrize("stored_proc_return_value, expected_output", [("E08000014", "E08000014")])
+def test_get_ladcode_should_return_valid_ladcode_if_uprn_found(
+        stored_proc_return_value, expected_output):
+    with patch("vulnerable_people_form.integrations.location_eligibility.execute_sql",
+               return_value={"records": [[{"stringValue": stored_proc_return_value}]]}):
+        ladcode = get_ladcode_from_uprn("123456789")
+        assert ladcode == expected_output

--- a/vulnerable_people_form/form_pages/shared/constants.py
+++ b/vulnerable_people_form/form_pages/shared/constants.py
@@ -75,6 +75,8 @@ SESSION_KEY_LIVES_IN_ENGLAND_REFERRER = "lives_in_england_referrer"
 SESSION_KEY_LOCATION_TIER = "postcode_tier"
 SESSION_KEY_IS_POSTCODE_IN_ENGLAND = "is_postcode_in_england"
 
+SESSION_KEY_SHIELDING_ADVICE = "shielding_advice"
+
 GOVUK_JOURNEY_START_PAGE_URL = "https://gov.uk/coronavirus-shielding-support"
 
 

--- a/vulnerable_people_form/form_pages/shared/logger_utils.py
+++ b/vulnerable_people_form/form_pages/shared/logger_utils.py
@@ -24,6 +24,12 @@ log_event_names = {
     "UPRN_TIER_NOT_FOUND": "UprnTierNotFound",
     "POSTCODE_IN_ENGLAND": "PostcodeInEngland",
     "POSTCODE_NOT_IN_ENGLAND": "PostcodeNotInEngland",
+    "POSTCODE_TO_LADCODE_SUCCESS": "PostcodeToLadcodeSucceeded",
+    "UPRN_TO_LADCODE_SUCCESS": "UPRNToLadcodeSucceeded",
+    "LADCODE_NOT_FOUND": "LadcodeNotFoundInDbForGivenPostcode",
+    "TOO_MANY_LADCODES_FOUND": "MoreThanOneLadcodeFoundInDb",
+    "LADCODE_NOT_IN_FILE": "LadcodeNotMappedToTierNotFoundInShieldingAdviceFile",
+    "SHIELDING_ADVICE_FOR_LADCODE_SUCCESS": "ShieldingAdviceFoundForLadcode"
 }
 
 

--- a/vulnerable_people_form/integrations/ladcode_shielding_advice_lookup.py
+++ b/vulnerable_people_form/integrations/ladcode_shielding_advice_lookup.py
@@ -1,0 +1,57 @@
+import csv
+from datetime import datetime
+import logging
+
+from vulnerable_people_form.form_pages.shared.logger_utils import create_log_message, log_event_names
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_NATIONAL_SHIELDING_ADVICE = 'NO'
+FIELDNAMES = [
+    'ladcode',
+    'ladname',
+    'shielding_advice',
+    'start_datetime_utc'
+]
+
+
+class LocalAuthorityShielding:
+    la_shielding_advice_data = {}
+
+    def __init__(self, shielding_advice_csv_file: str):
+        self.la_shielding_advice_data = {}
+        valid_applicable_records = []
+
+        with open(shielding_advice_csv_file, 'r') as f:
+            la_shielding_advice = csv.DictReader(f, delimiter=',')
+
+            # Find all non-future records
+            for la in la_shielding_advice:
+                now = datetime.utcnow()
+                if datetime.strptime(la['start_datetime_utc'], '%Y-%m-%dT%H:%M:%S') < now:
+                    valid_applicable_records.append(la)
+            # Sort by date for every ladcode in ascending order
+            sorted_advice = sorted(
+                valid_applicable_records,
+                key=lambda k: (k['ladcode'], k['start_datetime_utc']),
+                reverse=False)
+            # Keep the latest record only.
+            for record in sorted_advice:
+                ladcode = record['ladcode']
+                self.la_shielding_advice_data[ladcode] = record
+
+    def get_shielding_advice_by_ladcode(self, ladcode: str):
+        """
+        fetches the shielding advice status for supplied LAD Code
+        """
+        if ladcode not in self.la_shielding_advice_data:
+            logger.info(create_log_message(
+                log_event_names["LADCODE_NOT_IN_FILE"],
+                f"{ladcode} not in shielding advice file. Using default: {DEFAULT_NATIONAL_SHIELDING_ADVICE}"))
+            return DEFAULT_NATIONAL_SHIELDING_ADVICE
+
+        shielding_advice = self.la_shielding_advice_data[ladcode]["shielding_advice"]
+        logger.info(create_log_message(
+            log_event_names["SHIELDING_ADVICE_FOR_LADCODE_SUCCESS"],
+            f"{ladcode} has Shielding Advice {shielding_advice}"))
+        return shielding_advice


### PR DESCRIPTION
Create helper functions for reading the csv file and assessing shielding advice

This commit assumes that there will be a csv file available with shielding advice.
It creates functions for
- convert uprn/postcode to ladcode
- get shielding advice for ladcode from csv file with columns
 `ladcode,ladname,shielding_advice,start_date,start_time`

It also creates test cases for same.