### PR TITLE
Upgrade govuk-frontend-jinja

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 email-validator==1.1.1
 Flask==1.1.2
 Flask-WTF==0.14.3
-govuk-frontend-jinja==0.2.1
+govuk-frontend-jinja==1.1.0
 phonenumbers==8.12.6
 boto3==1.14.26
 python-stdnum==1.13


### PR DESCRIPTION
Hi there! 👋 

I'm the primary maintainer of the `govuk-frontend-jinja` package port of the `govuk-frontend` nunjucks macros. I noticed a while ago you're using the package which is fantastic. I also noticed that you're using an older pre-production release version too, which has had updates since.

I've recently [released v1.1.0](https://github.com/LandRegistry/govuk-frontend-jinja/releases), with support for `govuk-frontend` up to [v3.10.2](https://github.com/alphagov/govuk-frontend/releases/tag/v3.10.2). It'd be great if your project could upgrade, to take advantage of all the fixes, improvements and new components released since your current 3.7.0 implementation.

I was looking for how you're specifying the version of `govuk-frontend` copied into your static assets dir, but couldn't find it so I'm afraid I present this change untested. Otherwise I'd have bumped your `govuk-frontend` version from 3.7.0 to 3.10.2 as well. However in similar upgrades moving from v0.x.x to v1.x.x I haven't encountered any incompatibilities.

Happy to contribute and of course take any issues raised with `govuk-frontend-jinja` in return. Thanks again for using our code! 😊 