### PR TITLE
Modify web submission/retrieval sprocs to point to strategic resources

### DIFF
--- a/tests/integrations/test_persistence.py
+++ b/tests/integrations/test_persistence.py
@@ -132,7 +132,7 @@ def test_persist_answers_should_map_parameters_correctly():
 
         assert submission_reference == submission_ref
         mock_execute_sql.assert_called_once_with(
-            sql="CALL cv_staging.create_web_submission_with_shielding("
+            sql="CALL cv_staging.create_web_submission("
                 ":nhs_number,"
                 ":first_name,"
                 ":middle_name,"

--- a/vulnerable_people_form/integrations/persistence.py
+++ b/vulnerable_people_form/integrations/persistence.py
@@ -208,7 +208,7 @@ def persist_answers(
     shielding_advice,
 ):
     result = execute_sql(
-        sql="CALL cv_staging.create_web_submission_with_shielding("
+        sql="CALL cv_staging.create_web_submission("
         ":nhs_number,"
         ":first_name,"
         ":middle_name,"
@@ -281,7 +281,7 @@ def persist_answers(
 
 def load_answers(nhs_uid):
     records = execute_sql(
-        "CALL cv_base.retrieve_latest_web_submission_for_nhs_login_with_shielding(" "    :uid_nhs_login" ")",
+        "CALL cv_base.retrieve_latest_web_submission_for_nhs_login(" "    :uid_nhs_login" ")",
         (generate_string_parameter("uid_nhs_login", nhs_uid),),
     )["records"]
 


### PR DESCRIPTION
This commit modifies the web submission `create_web_submission` and web retrieval
sprocs `retrieve_latest_web_submission_for_nhs_login` back to strategic resources.
The modfication is extension of PR
https://github.com/alphagov/govuk-shielded-vulnerable-people-service/pull/246.