### PR TITLE
Add shielding advice CSV

### DIFF
--- a/scripts/prepopulate.sql
+++ b/scripts/prepopulate.sql
@@ -4,12 +4,13 @@ truncate table cv_ref.ref_ONSUD_uprn_to_lad_code_mapping;
 
 insert into cv_ref.ref_NSPL_postcode_to_lad_code_mapping (pcd, laua, ctry, provisioned_datetime) values 
 ("BB11TA","E06000008","E92000001" , NOW()), 
-("LE674AY", "E07000134","E92000001" , NOW()), 
+("BD37DB", "E07000134","E92000001" , NOW()), 
 ("L244AD","E06000006" ,"E92000001" , NOW()),
-("LU11AA","E06000032" ,"E92000001" , NOW());
+("LU11AA","E06000032" ,"E92000001" , NOW()),
+("LS287TQ","E06000008","E92000001" , NOW());
 
 insert into cv_base.clean_local_area_restrictions (lad_code, lad_name, alert_level, start_datetime) values
-("E06000008", "Blackburn", "4", NOW()),
+("E06000008", "Blackburn", "3", NOW()),
 ("E06000032", "Luton", "4", NOW()),
 ("E07000134", "Leighton", "3", NOW()),
 ("E06000006", "Lowestoft", "2", NOW());
@@ -19,4 +20,5 @@ insert into cv_ref.ref_ONSUD_uprn_to_lad_code_mapping (uprn, lad19cd, ctry, prov
 (2000, "E06000006", "E92000001", NOW() ),
 (3000, "E09000134", "M83000003", NOW() ),
 (10000000, "E06000008", "E92000001", NOW() ),
+(1000000, "E06000008", "E92000001", NOW() ),
 (10000001, "E06000032", "E92000001", NOW() );

--- a/tests/form_pages/shared/test_location_tier.py
+++ b/tests/form_pages/shared/test_location_tier.py
@@ -1,8 +1,9 @@
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 from flask import Flask
 import pytest
 
 from vulnerable_people_form.form_pages.shared.constants import PostcodeTier, PostcodeTierStatus
+from vulnerable_people_form.form_pages.shared.answers_enums import YesNoAnswers
 from vulnerable_people_form.form_pages.shared.location_tier import (
     update_location_tier_by_postcode,
     update_location_tier_by_uprn,
@@ -27,16 +28,26 @@ def test_update_location_tier_by_uprn_should_not_update_when_tiering_logic_disab
 def test_update_location_tier_by_uprn_should_update_session_when_tiering_logic_enabled():
     try:
         uprn = 110000
+        la = "E06000008"
         location_tier = PostcodeTier.MEDIUM.value
+        shielding_advice = YesNoAnswers.YES.value
         _current_app.is_tiering_logic_enabled = True
+        _current_app.shielding_advice = Mock()
+        _current_app.shielding_advice.is_la_shielding = lambda ladcode: shielding_advice
         with _current_app.app_context(), \
-            patch("vulnerable_people_form.form_pages.shared.location_tier.get_uprn_tier",
-                  return_value=location_tier) as mock_get_location_tier, \
-            patch("vulnerable_people_form.form_pages.shared.location_tier.set_location_tier") \
-                as mock_set_location_tier:
+             patch("vulnerable_people_form.form_pages.shared.location_tier.get_uprn_tier",
+                   return_value=location_tier) as mock_get_location_tier, \
+             patch("vulnerable_people_form.form_pages.shared.location_tier.get_ladcode_from_uprn",
+                   return_value=la) as mock_get_ladcode_from_uprn, \
+             patch("vulnerable_people_form.form_pages.shared.location_tier.set_location_tier") \
+                as mock_set_location_tier,  \
+             patch("vulnerable_people_form.form_pages.shared.location_tier.set_shielding_advice") \
+                as mock_set_shielding_advice:
             update_location_tier_by_uprn(uprn, _current_app)
+            mock_get_ladcode_from_uprn.assert_called_once()
             mock_get_location_tier.assert_called_once_with(uprn)
             mock_set_location_tier.assert_called_once_with(location_tier)
+            mock_set_shielding_advice.assert_called_once_with(shielding_advice)
     finally:
         _current_app.is_tiering_logic_enabled = False
 
@@ -52,16 +63,27 @@ def test_update_location_tier_by_postcode_should_not_update_when_tiering_logic_d
 def test_update_location_tier_by_postcode_should_update_session_when_tiering_logic_enabled():
     try:
         postcode = "LS11BA"
+        la = "E06000008"
         location_tier = PostcodeTier.MEDIUM.value
+        shielding_advice = YesNoAnswers.YES.value
         _current_app.is_tiering_logic_enabled = True
+        _current_app.shielding_advice = Mock()
+        _current_app.shielding_advice.is_la_shielding = lambda ladcode: shielding_advice
         with _current_app.app_context(), \
-            patch("vulnerable_people_form.form_pages.shared.location_tier.get_postcode_tier",
-                  return_value=location_tier) as mock_get_location_tier, \
-            patch("vulnerable_people_form.form_pages.shared.location_tier.set_location_tier") \
-                as mock_set_location_tier:
+             patch("vulnerable_people_form.form_pages.shared.location_tier.get_postcode_tier",
+                   return_value=location_tier) as mock_get_location_tier, \
+             patch("vulnerable_people_form.form_pages.shared.location_tier.get_ladcode_from_postcode",
+                   return_value=la) as mock_get_ladcode_from_postcode, \
+             patch("vulnerable_people_form.form_pages.shared.location_tier.set_location_tier") \
+                as mock_set_location_tier, \
+             patch("vulnerable_people_form.form_pages.shared.location_tier.set_shielding_advice") \
+                as mock_set_shielding_advice:
+
             update_location_tier_by_postcode(postcode, _current_app)
+            mock_get_ladcode_from_postcode.assert_called_once()
             mock_get_location_tier.assert_called_once_with(postcode)
             mock_set_location_tier.assert_called_once_with(location_tier)
+            mock_set_shielding_advice.assert_called_once_with(shielding_advice)
     finally:
         _current_app.is_tiering_logic_enabled = False
 

--- a/tests/form_pages/shared/test_session.py
+++ b/tests/form_pages/shared/test_session.py
@@ -227,6 +227,7 @@ def test_persist_answers_from_session():
         submission_ref = "submission-reference"
         nhs_sub_value = "nhs-sub-value"
         test_request_ctx.session["postcode_tier"] = PostcodeTier.VERY_HIGH.value
+        test_request_ctx.session["shielding_advice"] = YesNoAnswers.NO.value
         data_to_persist = {
             "nhs_number": "1234567891",
             "name": {"first_name": "Jon", "middle_name": "", "last_name": "Smith"},
@@ -252,7 +253,7 @@ def test_persist_answers_from_session():
             "medical_conditions": MedicalConditionsAnswers.YES.value,
             "do_you_live_in_england": LiveInEnglandAnswers.YES.value,
             "tier_at_submission": PostcodeTier.VERY_HIGH.value,
-            "shielding_at_submission": None,
+            "shielding_at_submission": YesNoAnswers.NO.value,
         }
 
         test_request_ctx.session["nhs_sub"] = nhs_sub_value

--- a/tests/integrations/test_ladcode_shielding_advice_lookup.py
+++ b/tests/integrations/test_ladcode_shielding_advice_lookup.py
@@ -1,20 +1,20 @@
 def test_get_shielding_advice_from_ladcode_returns_correct_value_if_available(local_tier_lookup):
     shielding_list = local_tier_lookup()
-    assert shielding_list.get_shielding_advice_by_ladcode("E08000012") == 'YES'
+    assert shielding_list.is_la_shielding("E08000012") is True
 
 
 def test_get_shielding_advice_from_ladcode_returns_default_value_if_not_available(local_tier_lookup):
     shielding_list = local_tier_lookup()
-    assert shielding_list.get_shielding_advice_by_ladcode("NOTAVAILABLE001") == 'NO'
+    assert shielding_list.is_la_shielding("NOTAVAILABLE001") is False
 
 
 def test_get_shielding_advice_from_ladcode_returns_latest_value_if_multiple_rows_available(local_tier_lookup):
     shielding_list = local_tier_lookup()
-    assert shielding_list.get_shielding_advice_by_ladcode("E06000002") == 'NO'
-    assert shielding_list.get_shielding_advice_by_ladcode("E06000003") == 'YES'
+    assert shielding_list.is_la_shielding("E06000002") is False
+    assert shielding_list.is_la_shielding("E06000003") is True
 
 
 def test_get_shielding_advice_from_ladcode_returns_latest_value_and_ignore_future_values(local_tier_lookup):
     shielding_list = local_tier_lookup()
-    assert shielding_list.get_shielding_advice_by_ladcode("E06000018") == 'YES'
-    assert shielding_list.get_shielding_advice_by_ladcode("E0800021") == 'NO'
+    assert shielding_list.is_la_shielding("E06000018") is True
+    assert shielding_list.is_la_shielding("E0800021") is False

--- a/tests/ons-mock/server.py
+++ b/tests/ons-mock/server.py
@@ -4,7 +4,8 @@ import json
 import re
 from fake_os_places_api_entry import FakeOSPlacesAPIEntry
 
-_postcode_to_uprn = {"BB11TA": 10000000,
+_postcode_to_uprn = {"LS287TQ": 10000000,
+                     "BB11TA": 1000000,
                      "LE674AY": 1000,
                      "L244AD":  2000,
                      "LU11AA":  10000001,

--- a/vulnerable_people_form/__init__.py
+++ b/vulnerable_people_form/__init__.py
@@ -11,9 +11,10 @@ from sentry_sdk.integrations.flask import FlaskIntegration
 from vulnerable_people_form.form_pages.shared.querystring_utils import append_querystring_params
 from . import form_pages
 from .form_pages.shared.form_utils import postcode_with_spaces
-from .integrations import nhs_openconnect_id, persistence
+from .integrations import nhs_openconnect_id, persistence, ladcode_shielding_advice_lookup
 
 _ENV_DEVELOPMENT = "DEVELOPMENT"
+_DEFAULT_SHIELDING_ADVICE_FILE_PREFIX = "vulnerable_people_form/integrations/data/local-area-shielding-advice-"
 
 
 def _handle_error(e):
@@ -80,6 +81,9 @@ def create_app(scriptinfo):
 
     app.is_tiering_logic_enabled = "TIERING_LOGIC" in app.config and app.config["TIERING_LOGIC"] == "True"
 
+    app.shielding_advice = ladcode_shielding_advice_lookup.LocalAuthorityShielding(
+            _get_shielding_advice_data_path(app.config['ENVIRONMENT']))
+
     app.register_error_handler(HTTPStatus.NOT_FOUND.value, _handle_error)
     app.register_error_handler(HTTPStatus.INTERNAL_SERVER_ERROR.value, _handle_error)
     app.context_processor(utility_processor)
@@ -121,6 +125,10 @@ def _init_security(app):
         content_security_policy=csp,
         content_security_policy_nonce_in=['script-src']
     )
+
+
+def _get_shielding_advice_data_path(env: str):
+    return _DEFAULT_SHIELDING_ADVICE_FILE_PREFIX + env.lower() + ".csv"
 
 
 def utility_processor():

--- a/vulnerable_people_form/form_pages/shared/location_tier.py
+++ b/vulnerable_people_form/form_pages/shared/location_tier.py
@@ -1,7 +1,16 @@
 from vulnerable_people_form.form_pages.shared.constants import PostcodeTier, PostcodeTierStatus
-from vulnerable_people_form.form_pages.shared.session import set_location_tier, set_is_postcode_in_england
-from vulnerable_people_form.integrations.location_eligibility import get_uprn_tier, get_postcode_tier, \
-                                                                     is_postcode_in_england
+from vulnerable_people_form.form_pages.shared.session import (
+        set_location_tier,
+        set_is_postcode_in_england,
+        set_shielding_advice
+        )
+from vulnerable_people_form.integrations.location_eligibility import (
+        get_uprn_tier,
+        get_postcode_tier,
+        is_postcode_in_england,
+        get_ladcode_from_postcode,
+        get_ladcode_from_uprn
+        )
 
 
 def update_is_postcode_in_england(postcode, app):
@@ -13,6 +22,8 @@ def update_location_tier_by_uprn(uprn, app):
     if app.is_tiering_logic_enabled:
         location_tier = get_uprn_tier(uprn)
         set_location_tier(location_tier)
+        lad_code = get_ladcode_from_uprn(uprn)
+        set_shielding_advice(app.shielding_advice.is_la_shielding(lad_code))
     else:
         set_location_tier(PostcodeTier.VERY_HIGH_PLUS_SHIELDING.value)
 
@@ -21,6 +32,8 @@ def update_location_tier_by_postcode(postcode, app):
     if app.is_tiering_logic_enabled:
         location_tier = get_postcode_tier(postcode)
         set_location_tier(location_tier)
+        lad_code = get_ladcode_from_postcode(postcode)
+        set_shielding_advice(app.shielding_advice.is_la_shielding(lad_code))
     else:
         set_location_tier(PostcodeTier.VERY_HIGH_PLUS_SHIELDING.value)
 

--- a/vulnerable_people_form/form_pages/shared/session.py
+++ b/vulnerable_people_form/form_pages/shared/session.py
@@ -12,6 +12,7 @@ from .constants import (
     PAGE_TITLES,
     NHS_USER_INFO_TO_FORM_ANSWERS,
     SESSION_KEY_LOCATION_TIER,
+    SESSION_KEY_SHIELDING_ADVICE,
     SESSION_KEY_IS_POSTCODE_IN_ENGLAND,
     PostcodeTier
 )
@@ -230,7 +231,7 @@ def persist_answers_from_session():
         form_answers().get("medical_conditions"),
         lives_in_england,
         get_location_tier(),
-        None,
+        get_shielding_advice(),
     )
     session["form_uid"] = submission_reference
 
@@ -323,6 +324,7 @@ def load_answers_into_session_if_available():
             session["medical_conditions"] = medical_conditions
         session["accessing_saved_answers"] = True
         set_location_tier(tier_at_submission.get("longValue"))
+        set_shielding_advice(shielding_at_submission.get("longValue"))
         return True
     return False
 
@@ -349,6 +351,14 @@ def set_location_tier(location_tier):
 
 def get_location_tier():
     return session.get(SESSION_KEY_LOCATION_TIER, None)
+
+
+def set_shielding_advice(shielding_advice):
+    session[SESSION_KEY_SHIELDING_ADVICE] = shielding_advice
+
+
+def get_shielding_advice():
+    return session.get(SESSION_KEY_SHIELDING_ADVICE, None)
 
 
 def set_is_postcode_in_england(is_postcode_in_england):

--- a/vulnerable_people_form/integrations/data/local-area-shielding-advice-development.csv
+++ b/vulnerable_people_form/integrations/data/local-area-shielding-advice-development.csv
@@ -1,0 +1,2 @@
+ladcode,ladname,shielding_advice,start_datetime_utc
+E06000008,Blackburn with Darwen Borough Council,YES,2020-12-20T00:01:00

--- a/vulnerable_people_form/integrations/data/local-area-shielding-advice-prod.csv
+++ b/vulnerable_people_form/integrations/data/local-area-shielding-advice-prod.csv
@@ -1,0 +1,145 @@
+ladcode,ladname,shielding_advice,start_datetime_utc
+E06000031,Peterborough City Council,YES,2020-12-20T00:01:00
+E06000032,Luton Borough Council,YES,2020-12-20T00:01:00
+E06000033,Southend-on-Sea Borough Council,YES,2020-12-20T00:01:00
+E06000034,Thurrock Council,YES,2020-12-20T00:01:00
+E06000035,Medway Council,YES,2020-12-20T00:01:00
+E06000036,Bracknell Forest Council,YES,2020-12-20T00:01:00
+E06000037,West Berkshire Council,YES,2020-12-20T00:01:00
+E06000038,Reading Borough Council,YES,2020-12-20T00:01:00
+E06000039,Slough Borough Council,YES,2020-12-20T00:01:00
+E06000040,Royal Borough of Windsor and Maidenhead,YES,2020-12-20T00:01:00
+E06000041,Wokingham Borough Council,YES,2020-12-20T00:01:00
+E06000042,Milton Keynes Council,YES,2020-12-20T00:01:00
+E06000043,Brighton and Hove City Council,YES,2020-12-26T00:01:00
+E06000044,Portsmouth City Council,YES,2020-12-20T00:01:00
+E06000045,Southampton City Council,YES,2020-12-26T00:01:00
+E06000055,Bedford Borough Council,YES,2020-12-20T00:01:00
+E06000056,Central Bedfordshire Council,YES,2020-12-20T00:01:00
+E09000023,London Borough of Lewisham,YES,2020-12-20T00:01:00
+E09000001,City of London Corporation,YES,2020-12-20T00:01:00
+E09000002,London Borough of Barking and Dagenham,YES,2020-12-20T00:01:00
+E09000003,London Borough of Barnet,YES,2020-12-20T00:01:00
+E09000004,London Borough of Bexley,YES,2020-12-20T00:01:00
+E09000005,London Borough of Brent,YES,2020-12-20T00:01:00
+E09000006,London Borough of Bromley,YES,2020-12-20T00:01:00
+E09000007,London Borough of Camden,YES,2020-12-20T00:01:00
+E09000008,London Borough of Croydon,YES,2020-12-20T00:01:00
+E09000009,London Borough of Ealing,YES,2020-12-20T00:01:00
+E09000010,London Borough of Enfield,YES,2020-12-20T00:01:00
+E09000011,Royal Borough of Greenwich,YES,2020-12-20T00:01:00
+E09000012,London Borough of Hackney,YES,2020-12-20T00:01:00
+E09000013,London Borough of Hammersmith & Fulham,YES,2020-12-20T00:01:00
+E09000014,London Borough of Haringey,YES,2020-12-20T00:01:00
+E09000015,London Borough of Harrow,YES,2020-12-20T00:01:00
+E09000016,London Borough of Havering,YES,2020-12-20T00:01:00
+E09000017,London Borough of Hillingdon,YES,2020-12-20T00:01:00
+E09000018,London Borough of Hounslow,YES,2020-12-20T00:01:00
+E09000019,London Borough of Islington,YES,2020-12-20T00:01:00
+E09000020,Royal Borough of Kensington and Chelsea,YES,2020-12-20T00:01:00
+E09000021,Royal Borough of Kingston upon Thames,YES,2020-12-20T00:01:00
+E09000022,London Borough of Lambeth,YES,2020-12-20T00:01:00
+E09000024,London Borough of Merton,YES,2020-12-20T00:01:00
+E09000025,London Borough of Newham,YES,2020-12-20T00:01:00
+E09000026,London Borough of Redbridge,YES,2020-12-20T00:01:00
+E09000027,London Borough of Richmond upon Thames,YES,2020-12-20T00:01:00
+E09000028,London Borough of Southwark,YES,2020-12-20T00:01:00
+E09000029,London Borough of Sutton,YES,2020-12-20T00:01:00
+E09000030,London Borough of Tower Hamlets,YES,2020-12-20T00:01:00
+E09000031,London Borough of Waltham Forest,YES,2020-12-20T00:01:00
+E09000032,London Borough of Wandsworth,YES,2020-12-20T00:01:00
+E09000033,City of Westminster,YES,2020-12-20T00:01:00
+E07000004,Buckinghamshire Council,YES,2020-12-20T00:01:00
+E07000005,Buckinghamshire Council,YES,2020-12-20T00:01:00
+E07000006,Buckinghamshire Council,YES,2020-12-20T00:01:00
+E07000007,Buckinghamshire Council,YES,2020-12-20T00:01:00
+E06000060,Buckinghamshire Council,YES,2020-12-20T00:01:00
+E07000008,Cambridge City Council,YES,2020-12-26T00:01:00
+E07000009,East Cambridgeshire District Council,YES,2020-12-26T00:01:00
+E07000010,Fenland District Council,YES,2020-12-26T00:01:00
+E07000011,Huntingdonshire District Council,YES,2020-12-26T00:01:00
+E07000012,South Cambridgeshire District Council,YES,2020-12-26T00:01:00
+E07000061,Eastbourne Borough Council,YES,2020-12-26T00:01:00
+E07000062,Hastings Borough Council,YES,2020-12-20T00:01:00
+E07000063,Lewes District Council,YES,2020-12-26T00:01:00
+E07000064,Rother District Council,YES,2020-12-20T00:01:00
+E07000065,Wealden District Council,YES,2020-12-26T00:01:00
+E07000066,Basildon Borough Council,YES,2020-12-20T00:01:00
+E07000067,Braintree District Council,YES,2020-12-20T00:01:00
+E07000068,Brentwood Borough Council,YES,2020-12-20T00:01:00
+E07000069,Castle Point Borough Council,YES,2020-12-20T00:01:00
+E07000070,Chelmsford City Council,YES,2020-12-20T00:01:00
+E07000071,Colchester Borough Council,YES,2020-12-26T00:01:00
+E07000072,Epping Forest District Council,YES,2020-12-20T00:01:00
+E07000073,Harlow Council,YES,2020-12-20T00:01:00
+E07000074,Maldon District Council,YES,2020-12-20T00:01:00
+E07000075,Rochford District Council,YES,2020-12-20T00:01:00
+E07000203,Mid Suffolk District Council,YES,2020-12-26T00:01:00
+E07000244,East Suffolk District Council,YES,2020-12-26T00:01:00
+E07000245,West Suffolk District Council,YES,2020-12-26T00:01:00
+E07000207,Elmbridge Borough Council,YES,2020-12-20T00:01:00
+E07000208,Epsom and Ewell Borough Council,YES,2020-12-20T00:01:00
+E07000209,Guildford Borough Council,YES,2020-12-20T00:01:00
+E07000210,Mole Valley District Council,YES,2020-12-20T00:01:00
+E07000211,Reigate and Banstead Borough Council,YES,2020-12-20T00:01:00
+E07000212,Runnymede Borough Council,YES,2020-12-20T00:01:00
+E07000213,Spelthorne Borough Council,YES,2020-12-20T00:01:00
+E07000214,Surrey Heath Borough Council,YES,2020-12-20T00:01:00
+E07000215,Tandridge District Council,YES,2020-12-20T00:01:00
+E07000216,Waverley Borough Council,YES,2020-12-26T00:01:00
+E07000217,Woking Borough Council,YES,2020-12-20T00:01:00
+E07000223,Adur District Council,YES,2020-12-26T00:01:00
+E07000224,Arun District Council,YES,2020-12-26T00:01:00
+E07000225,Chichester District Council,YES,2020-12-26T00:01:00
+E07000226,Crawley Borough Council,YES,2020-12-26T00:01:00
+E07000227,Horsham District Council,YES,2020-12-26T00:01:00
+E07000228,Mid Sussex District Council,YES,2020-12-26T00:01:00
+E07000229,Worthing Borough Council,YES,2020-12-26T00:01:00
+E07000076,Tendring District Council,YES,2020-12-26T00:01:00
+E07000077,Uttlesford District Council,YES,2020-12-26T00:01:00
+E07000084,Basingstoke and Deane Borough Council,YES,2020-12-26T00:01:00
+E07000085,East Hampshire District Council,YES,2020-12-26T00:01:00
+E07000086,Eastleigh Borough Council,YES,2020-12-26T00:01:00
+E07000087,Fareham Borough Council,YES,2020-12-26T00:01:00
+E07000088,Gosport Borough Council,YES,2020-12-20T00:01:00
+E07000089,Hart District Council,YES,2020-12-26T00:01:00
+E07000090,Havant Borough Council,YES,2020-12-20T00:01:00
+E07000092,Rushmoor Borough Council,YES,2020-12-26T00:01:00
+E07000093,Test Valley Borough Council,YES,2020-12-26T00:01:00
+E07000094,Winchester City Council,YES,2020-12-26T00:01:00
+E07000095,Borough of Broxbourne,YES,2020-12-20T00:01:00
+E07000096,Dacorum Borough Council,YES,2020-12-20T00:01:00
+E07000098,Hertsmere Borough Council,YES,2020-12-20T00:01:00
+E07000099,North Hertfordshire District Council,YES,2020-12-20T00:01:00
+E07000102,Three Rivers District Council,YES,2020-12-20T00:01:00
+E07000103,Watford Borough Council,YES,2020-12-20T00:01:00
+E07000240,St Albans City and District Council,YES,2020-12-20T00:01:00
+E07000241,Welwyn Hatfield Council,YES,2020-12-20T00:01:00
+E07000242,East Hertfordshire District Council,YES,2020-12-20T00:01:00
+E07000243,Stevenage Borough Council,YES,2020-12-20T00:01:00
+E07000105,Ashford Borough Council,YES,2020-12-20T00:01:00
+E07000106,Canterbury City Council,YES,2020-12-20T00:01:00
+E07000107,Dartford Borough Council,YES,2020-12-20T00:01:00
+E07000108,Dover District Council,YES,2020-12-20T00:01:00
+E07000109,Gravesham Borough Council,YES,2020-12-20T00:01:00
+E07000110,Maidstone Borough Council,YES,2020-12-20T00:01:00
+E07000111,Sevenoaks District Council,YES,2020-12-20T00:01:00
+E07000112,Folkestone and Hythe,YES,2020-12-20T00:01:00
+E07000113,Swale Borough Council,YES,2020-12-20T00:01:00
+E07000114,Thanet District Council,YES,2020-12-20T00:01:00
+E07000115,Tonbridge and Malling Borough Council,YES,2020-12-20T00:01:00
+E07000116,Tunbridge Wells Borough Council,YES,2020-12-20T00:01:00
+E07000143,Breckland Council,YES,2020-12-26T00:01:00
+E07000144,Broadland District Council,YES,2020-12-26T00:01:00
+E07000145,Great Yarmouth Borough Council,YES,2020-12-26T00:01:00
+E07000146,Borough Council of Kings Lynn and West Norfolk,YES,2020-12-26T00:01:00
+E07000147,North Norfolk District Council,YES,2020-12-26T00:01:00
+E07000148,Norwich City Council,YES,2020-12-26T00:01:00
+E07000149,South Norfolk District Council,YES,2020-12-26T00:01:00
+E07000177,Cherwell District Council,YES,2020-12-26T00:01:00
+E07000178,Oxford City Council,YES,2020-12-26T00:01:00
+E07000179,South Oxfordshire District Council,YES,2020-12-26T00:01:00
+E07000180,Vale of White Horse District Council,YES,2020-12-26T00:01:00
+E07000181,West Oxfordshire District Council,YES,2020-12-26T00:01:00
+E07000200,Babergh District Council,YES,2020-12-26T00:01:00
+E07000202,Ipswich Borough Council,YES,2020-12-26T00:01:00

--- a/vulnerable_people_form/integrations/data/local-area-shielding-advice-prod.csv
+++ b/vulnerable_people_form/integrations/data/local-area-shielding-advice-prod.csv
@@ -1,4 +1,17 @@
 ladcode,ladname,shielding_advice,start_datetime_utc
+E06000001,Hartlepool Borough Council,YES,2020-12-31T00:01:00
+E06000002,Middlesbrough Borough Council,YES,2020-12-31T00:01:00
+E06000003,Redcar and Cleveland Borough Council,YES,2020-12-31T00:01:00
+E06000004,Stockton-on-Tees Borough Council,YES,2020-12-31T00:01:00
+E06000005,Darlington Borough Council,YES,2020-12-31T00:01:00
+E06000007,Warrington Borough Council,YES,2020-12-31T00:01:00
+E06000008,Blackburn with Darwen Borough Council,YES,2020-12-31T00:01:00
+E06000009,Blackpool Borough Council,YES,2020-12-31T00:01:00
+E06000015,Derby City,YES,2020-12-31T00:01:00
+E06000016,Leicester City Council,YES,2020-12-31T00:01:00
+E06000018,Nottingham City Council,YES,2020-12-31T00:01:00
+E06000021,Stoke-on-Trent City Council,YES,2020-12-31T00:01:00
+E06000030,Swindon Borough Council,YES,2020-12-31T00:01:00
 E06000031,Peterborough City Council,YES,2020-12-20T00:01:00
 E06000032,Luton Borough Council,YES,2020-12-20T00:01:00
 E06000033,Southend-on-Sea Borough Council,YES,2020-12-20T00:01:00
@@ -14,9 +27,36 @@ E06000042,Milton Keynes Council,YES,2020-12-20T00:01:00
 E06000043,Brighton and Hove City Council,YES,2020-12-26T00:01:00
 E06000044,Portsmouth City Council,YES,2020-12-20T00:01:00
 E06000045,Southampton City Council,YES,2020-12-26T00:01:00
+E06000047,Durham County Council,YES,2020-12-31T00:01:00
+E06000049,Cheshire East Council,YES,2020-12-31T00:01:00
+E06000050,Cheshire West and Chester Council,YES,2020-12-31T00:01:00
 E06000055,Bedford Borough Council,YES,2020-12-20T00:01:00
 E06000056,Central Bedfordshire Council,YES,2020-12-20T00:01:00
+E06000057,Northumberland County Council,YES,2020-12-31T00:01:00
+E06000058,"Bournemouth, Christchurch and Poole Council",YES,2020-12-31T00:01:00
+E08000001,Bolton Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000002,Bury Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000003,Manchester City Council,YES,2020-12-31T00:01:00
+E08000004,Oldham Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000005,Rochdale Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000006,Salford City Council,YES,2020-12-31T00:01:00
+E08000007,Stockport Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000008,Tameside Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000009,Trafford Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000010,Wigan Metropolitan Borough Council,YES,2020-12-31T00:01:00
 E09000023,London Borough of Lewisham,YES,2020-12-20T00:01:00
+E08000021,Newcastle City Council,YES,2020-12-31T00:01:00
+E08000022,North Tyneside Council,YES,2020-12-31T00:01:00
+E08000023,South Tyneside Council,YES,2020-12-31T00:01:00
+E08000024,Sunderland City Council,YES,2020-12-31T00:01:00
+E08000025,Birmingham City Council,YES,2020-12-31T00:01:00
+E08000026,Coventry City Council,YES,2020-12-31T00:01:00
+E08000027,Dudley Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000028,Sandwell Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000029,Solihull Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000030,Walsall Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000031,City of Wolverhampton Council,YES,2020-12-31T00:01:00
+E08000037,Gateshead Metropolitan Borough Council,YES,2020-12-31T00:01:00
 E09000001,City of London Corporation,YES,2020-12-20T00:01:00
 E09000002,London Borough of Barking and Dagenham,YES,2020-12-20T00:01:00
 E09000003,London Borough of Barnet,YES,2020-12-20T00:01:00
@@ -59,6 +99,20 @@ E07000009,East Cambridgeshire District Council,YES,2020-12-26T00:01:00
 E07000010,Fenland District Council,YES,2020-12-26T00:01:00
 E07000011,Huntingdonshire District Council,YES,2020-12-26T00:01:00
 E07000012,South Cambridgeshire District Council,YES,2020-12-26T00:01:00
+E07000026,Allerdale Borough Council,YES,2020-12-31T00:01:00
+E07000027,Borough of Barrow-in-Furness,YES,2020-12-31T00:01:00
+E07000028,Carlisle City Council,YES,2020-12-31T00:01:00
+E07000029,Copeland Borough Council,YES,2020-12-31T00:01:00
+E07000030,Eden District Council,YES,2020-12-31T00:01:00
+E07000031,South Lakeland District Council,YES,2020-12-31T00:01:00
+E07000032,Amber Valley Borough Council,YES,2020-12-31T00:01:00
+E07000033,Bolsover District Council,YES,2020-12-31T00:01:00
+E07000034,Chesterfield Borough Council,YES,2020-12-31T00:01:00
+E07000035,Derbyshire Dales District Council,YES,2020-12-31T00:01:00
+E07000036,Erewash Borough Council,YES,2020-12-31T00:01:00
+E07000037,High Peak Borough Council,YES,2020-12-31T00:01:00
+E07000038,North East Derbyshire District Council,YES,2020-12-31T00:01:00
+E07000039,South Derbyshire District Council,YES,2020-12-31T00:01:00
 E07000061,Eastbourne Borough Council,YES,2020-12-26T00:01:00
 E07000062,Hastings Borough Council,YES,2020-12-20T00:01:00
 E07000063,Lewes District Council,YES,2020-12-26T00:01:00
@@ -88,6 +142,11 @@ E07000214,Surrey Heath Borough Council,YES,2020-12-20T00:01:00
 E07000215,Tandridge District Council,YES,2020-12-20T00:01:00
 E07000216,Waverley Borough Council,YES,2020-12-26T00:01:00
 E07000217,Woking Borough Council,YES,2020-12-20T00:01:00
+E07000218,North Warwickshire Borough Council,YES,2020-12-31T00:01:00
+E07000219,Nuneaton and Bedworth Borough Council,YES,2020-12-31T00:01:00
+E07000220,Rugby Borough Council,YES,2020-12-31T00:01:00
+E07000221,Stratford-on-Avon District Council,YES,2020-12-31T00:01:00
+E07000222,Warwick District Council,YES,2020-12-31T00:01:00
 E07000223,Adur District Council,YES,2020-12-26T00:01:00
 E07000224,Arun District Council,YES,2020-12-26T00:01:00
 E07000225,Chichester District Council,YES,2020-12-26T00:01:00
@@ -97,6 +156,12 @@ E07000228,Mid Sussex District Council,YES,2020-12-26T00:01:00
 E07000229,Worthing Borough Council,YES,2020-12-26T00:01:00
 E07000076,Tendring District Council,YES,2020-12-26T00:01:00
 E07000077,Uttlesford District Council,YES,2020-12-26T00:01:00
+E07000078,Cheltenham Borough Council,YES,2020-12-31T00:01:00
+E07000079,Cotswold District Council,YES,2020-12-31T00:01:00
+E07000080,Forest of Dean District Council,YES,2020-12-31T00:01:00
+E07000081,Gloucester City Council,YES,2020-12-31T00:01:00
+E07000082,Stroud District Council,YES,2020-12-31T00:01:00
+E07000083,Tewkesbury Borough Council,YES,2020-12-31T00:01:00
 E07000084,Basingstoke and Deane Borough Council,YES,2020-12-26T00:01:00
 E07000085,East Hampshire District Council,YES,2020-12-26T00:01:00
 E07000086,Eastleigh Borough Council,YES,2020-12-26T00:01:00
@@ -104,6 +169,7 @@ E07000087,Fareham Borough Council,YES,2020-12-26T00:01:00
 E07000088,Gosport Borough Council,YES,2020-12-20T00:01:00
 E07000089,Hart District Council,YES,2020-12-26T00:01:00
 E07000090,Havant Borough Council,YES,2020-12-20T00:01:00
+E07000091,New Forest District Council,YES,2020-12-31T00:01:00
 E07000092,Rushmoor Borough Council,YES,2020-12-26T00:01:00
 E07000093,Test Valley Borough Council,YES,2020-12-26T00:01:00
 E07000094,Winchester City Council,YES,2020-12-26T00:01:00
@@ -129,6 +195,32 @@ E07000113,Swale Borough Council,YES,2020-12-20T00:01:00
 E07000114,Thanet District Council,YES,2020-12-20T00:01:00
 E07000115,Tonbridge and Malling Borough Council,YES,2020-12-20T00:01:00
 E07000116,Tunbridge Wells Borough Council,YES,2020-12-20T00:01:00
+E07000117,Burnley Borough Council,YES,2020-12-31T00:01:00
+E07000118,Chorley Council,YES,2020-12-31T00:01:00
+E07000119,Fylde Borough Council,YES,2020-12-31T00:01:00
+E07000120,Hyndburn Borough Council,YES,2020-12-31T00:01:00
+E07000121,Lancaster City Council,YES,2020-12-31T00:01:00
+E07000122,Pendle Borough Council,YES,2020-12-31T00:01:00
+E07000123,Preston City Council,YES,2020-12-31T00:01:00
+E07000124,Ribble Valley Borough Council,YES,2020-12-31T00:01:00
+E07000125,Rossendale Borough Council,YES,2020-12-31T00:01:00
+E07000126,South Ribble Borough Council,YES,2020-12-31T00:01:00
+E07000127,West Lancashire Borough Council,YES,2020-12-31T00:01:00
+E07000128,Wyre Council,YES,2020-12-31T00:01:00
+E07000129,Blaby District Council,YES,2020-12-31T00:01:00
+E07000130,Charnwood Borough Council,YES,2020-12-31T00:01:00
+E07000131,Harborough District Council,YES,2020-12-31T00:01:00
+E07000132,Hinckley and Bosworth Borough Council,YES,2020-12-31T00:01:00
+E07000133,Melton Borough Council,YES,2020-12-31T00:01:00
+E07000134,North West Leicestershire District Council,YES,2020-12-31T00:01:00
+E07000135,Oadby and Wigston District Council,YES,2020-12-31T00:01:00
+E07000136,Boston Borough Council,YES,2020-12-31T00:01:00
+E07000137,East Lindsey District Council,YES,2020-12-31T00:01:00
+E07000138,City of Lincoln Council,YES,2020-12-31T00:01:00
+E07000139,North Kesteven District Council,YES,2020-12-31T00:01:00
+E07000140,South Holland District Council,YES,2020-12-31T00:01:00
+E07000141,South Kesteven District Council,YES,2020-12-31T00:01:00
+E07000142,West Lindsey District Council,YES,2020-12-31T00:01:00
 E07000143,Breckland Council,YES,2020-12-26T00:01:00
 E07000144,Broadland District Council,YES,2020-12-26T00:01:00
 E07000145,Great Yarmouth Borough Council,YES,2020-12-26T00:01:00
@@ -136,10 +228,37 @@ E07000146,Borough Council of Kings Lynn and West Norfolk,YES,2020-12-26T00:01:00
 E07000147,North Norfolk District Council,YES,2020-12-26T00:01:00
 E07000148,Norwich City Council,YES,2020-12-26T00:01:00
 E07000149,South Norfolk District Council,YES,2020-12-26T00:01:00
+E07000150,Corby Borough Council,YES,2020-12-31T00:01:00
+E07000151,Daventry District Council,YES,2020-12-31T00:01:00
+E07000152,East Northamptonshire Council,YES,2020-12-31T00:01:00
+E07000153,Kettering Borough Council,YES,2020-12-31T00:01:00
+E07000154,Northampton Borough Council,YES,2020-12-31T00:01:00
+E07000155,South Northamptonshire Council,YES,2020-12-31T00:01:00
+E07000156,Wellingborough Borough Council,YES,2020-12-31T00:01:00
+E07000170,Ashfield District Council,YES,2020-12-31T00:01:00
+E07000171,Bassetlaw District Council,YES,2020-12-31T00:01:00
+E07000172,Broxtowe Borough Council,YES,2020-12-31T00:01:00
+E07000173,Gedling Borough Council,YES,2020-12-31T00:01:00
+E07000174,Mansfield District Council,YES,2020-12-31T00:01:00
+E07000175,Newark and Sherwood District Council,YES,2020-12-31T00:01:00
+E07000176,Rushcliffe Borough Council,YES,2020-12-31T00:01:00
 E07000177,Cherwell District Council,YES,2020-12-26T00:01:00
 E07000178,Oxford City Council,YES,2020-12-26T00:01:00
 E07000179,South Oxfordshire District Council,YES,2020-12-26T00:01:00
 E07000180,Vale of White Horse District Council,YES,2020-12-26T00:01:00
 E07000181,West Oxfordshire District Council,YES,2020-12-26T00:01:00
+E07000187,Mendip District Council,YES,2020-12-31T00:01:00
+E07000188,Sedgemoor District Council,YES,2020-12-31T00:01:00
+E07000189,South Somerset District Council,YES,2020-12-31T00:01:00
+E07000246,Somerset West and Taunton District Council,YES,2020-12-31T00:01:00
+E07000192,Cannock Chase District Council,YES,2020-12-31T00:01:00
+E07000193,East Staffordshire Borough Council,YES,2020-12-31T00:01:00
+E07000194,Lichfield District Council,YES,2020-12-31T00:01:00
+E07000195,Newcastle-under-Lyme District Council,YES,2020-12-31T00:01:00
+E07000196,South Staffordshire Council,YES,2020-12-31T00:01:00
+E07000197,Stafford Borough Council,YES,2020-12-31T00:01:00
+E07000198,Staffordshire Moorlands District Council,YES,2020-12-31T00:01:00
+E07000199,Tamworth Borough Council,YES,2020-12-31T00:01:00
 E07000200,Babergh District Council,YES,2020-12-26T00:01:00
 E07000202,Ipswich Borough Council,YES,2020-12-26T00:01:00
+E06000046,Isle of Wight Council,YES,2020-12-31T00:01:00

--- a/vulnerable_people_form/integrations/data/local-area-shielding-advice-prod.csv
+++ b/vulnerable_people_form/integrations/data/local-area-shielding-advice-prod.csv
@@ -1,264 +1,582 @@
 ladcode,ladname,shielding_advice,start_datetime_utc
 E06000001,Hartlepool Borough Council,YES,2020-12-31T00:01:00
+E06000001,Hartlepool Borough Council,YES,2021-01-04T00:01:00
 E06000002,Middlesbrough Borough Council,YES,2020-12-31T00:01:00
+E06000002,Middlesbrough Borough Council,YES,2021-01-04T00:01:00
 E06000003,Redcar and Cleveland Borough Council,YES,2020-12-31T00:01:00
+E06000003,Redcar and Cleveland Borough Council,YES,2021-01-04T00:01:00
 E06000004,Stockton-on-Tees Borough Council,YES,2020-12-31T00:01:00
+E06000004,Stockton-on-Tees Borough Council,YES,2021-01-04T00:01:00
 E06000005,Darlington Borough Council,YES,2020-12-31T00:01:00
+E06000005,Darlington Borough Council,YES,2021-01-04T00:01:00
+E06000006,Halton Borough Council,YES,2021-01-04T00:01:00
 E06000007,Warrington Borough Council,YES,2020-12-31T00:01:00
+E06000007,Warrington Borough Council,YES,2021-01-04T00:01:00
 E06000008,Blackburn with Darwen Borough Council,YES,2020-12-31T00:01:00
+E06000008,Blackburn with Darwen Borough Council,YES,2021-01-04T00:01:00
 E06000009,Blackpool Borough Council,YES,2020-12-31T00:01:00
+E06000009,Blackpool Borough Council,YES,2021-01-04T00:01:00
+E06000010,Hull City Council,YES,2021-01-04T00:01:00
+E06000011,East Riding of Yorkshire Council,YES,2021-01-04T00:01:00
+E06000012,North East Lincolnshire Council,YES,2021-01-04T00:01:00
+E06000013,North Lincolnshire Council,YES,2021-01-04T00:01:00
+E06000014,City of York Council,YES,2021-01-04T00:01:00
 E06000015,Derby City,YES,2020-12-31T00:01:00
+E06000015,Derby City,YES,2021-01-04T00:01:00
 E06000016,Leicester City Council,YES,2020-12-31T00:01:00
+E06000016,Leicester City Council,YES,2021-01-04T00:01:00
+E06000017,Rutland County Council,YES,2021-01-04T00:01:00
 E06000018,Nottingham City Council,YES,2020-12-31T00:01:00
+E06000018,Nottingham City Council,YES,2021-01-04T00:01:00
+E06000019,Herefordshire Council,YES,2021-01-04T00:01:00
+E06000020,Telford & Wrekin Council,YES,2021-01-04T00:01:00
 E06000021,Stoke-on-Trent City Council,YES,2020-12-31T00:01:00
+E06000021,Stoke-on-Trent City Council,YES,2021-01-04T00:01:00
+E06000022,Bath and North East Somerset Council,YES,2021-01-04T00:01:00
+E06000023,Bristol City Council,YES,2021-01-04T00:01:00
+E06000024,North Somerset Council,YES,2021-01-04T00:01:00
+E06000025,South Gloucestershire Council,YES,2021-01-04T00:01:00
+E06000026,Plymouth City Council,YES,2021-01-04T00:01:00
+E06000027,Torbay Council,YES,2021-01-04T00:01:00
 E06000030,Swindon Borough Council,YES,2020-12-31T00:01:00
+E06000030,Swindon Borough Council,YES,2021-01-04T00:01:00
 E06000031,Peterborough City Council,YES,2020-12-20T00:01:00
+E06000031,Peterborough City Council,YES,2021-01-04T00:01:00
 E06000032,Luton Borough Council,YES,2020-12-20T00:01:00
+E06000032,Luton Borough Council,YES,2021-01-04T00:01:00
 E06000033,Southend-on-Sea Borough Council,YES,2020-12-20T00:01:00
+E06000033,Southend-on-Sea Borough Council,YES,2021-01-04T00:01:00
 E06000034,Thurrock Council,YES,2020-12-20T00:01:00
+E06000034,Thurrock Council,YES,2021-01-04T00:01:00
 E06000035,Medway Council,YES,2020-12-20T00:01:00
+E06000035,Medway Council,YES,2021-01-04T00:01:00
 E06000036,Bracknell Forest Council,YES,2020-12-20T00:01:00
+E06000036,Bracknell Forest Council,YES,2021-01-04T00:01:00
 E06000037,West Berkshire Council,YES,2020-12-20T00:01:00
+E06000037,West Berkshire Council,YES,2021-01-04T00:01:00
 E06000038,Reading Borough Council,YES,2020-12-20T00:01:00
+E06000038,Reading Borough Council,YES,2021-01-04T00:01:00
 E06000039,Slough Borough Council,YES,2020-12-20T00:01:00
+E06000039,Slough Borough Council,YES,2021-01-04T00:01:00
 E06000040,Royal Borough of Windsor and Maidenhead,YES,2020-12-20T00:01:00
+E06000040,Royal Borough of Windsor and Maidenhead,YES,2021-01-04T00:01:00
 E06000041,Wokingham Borough Council,YES,2020-12-20T00:01:00
+E06000041,Wokingham Borough Council,YES,2021-01-04T00:01:00
 E06000042,Milton Keynes Council,YES,2020-12-20T00:01:00
+E06000042,Milton Keynes Council,YES,2021-01-04T00:01:00
 E06000043,Brighton and Hove City Council,YES,2020-12-26T00:01:00
+E06000043,Brighton and Hove City Council,YES,2021-01-04T00:01:00
 E06000044,Portsmouth City Council,YES,2020-12-20T00:01:00
+E06000044,Portsmouth City Council,YES,2021-01-04T00:01:00
 E06000045,Southampton City Council,YES,2020-12-26T00:01:00
-E06000047,Durham County Council,YES,2020-12-31T00:01:00
-E06000049,Cheshire East Council,YES,2020-12-31T00:01:00
-E06000050,Cheshire West and Chester Council,YES,2020-12-31T00:01:00
-E06000055,Bedford Borough Council,YES,2020-12-20T00:01:00
-E06000056,Central Bedfordshire Council,YES,2020-12-20T00:01:00
-E06000057,Northumberland County Council,YES,2020-12-31T00:01:00
-E06000058,"Bournemouth, Christchurch and Poole Council",YES,2020-12-31T00:01:00
-E08000001,Bolton Metropolitan Borough Council,YES,2020-12-31T00:01:00
-E08000002,Bury Metropolitan Borough Council,YES,2020-12-31T00:01:00
-E08000003,Manchester City Council,YES,2020-12-31T00:01:00
-E08000004,Oldham Metropolitan Borough Council,YES,2020-12-31T00:01:00
-E08000005,Rochdale Metropolitan Borough Council,YES,2020-12-31T00:01:00
-E08000006,Salford City Council,YES,2020-12-31T00:01:00
-E08000007,Stockport Metropolitan Borough Council,YES,2020-12-31T00:01:00
-E08000008,Tameside Metropolitan Borough Council,YES,2020-12-31T00:01:00
-E08000009,Trafford Metropolitan Borough Council,YES,2020-12-31T00:01:00
-E08000010,Wigan Metropolitan Borough Council,YES,2020-12-31T00:01:00
-E09000023,London Borough of Lewisham,YES,2020-12-20T00:01:00
-E08000021,Newcastle City Council,YES,2020-12-31T00:01:00
-E08000022,North Tyneside Council,YES,2020-12-31T00:01:00
-E08000023,South Tyneside Council,YES,2020-12-31T00:01:00
-E08000024,Sunderland City Council,YES,2020-12-31T00:01:00
-E08000025,Birmingham City Council,YES,2020-12-31T00:01:00
-E08000026,Coventry City Council,YES,2020-12-31T00:01:00
-E08000027,Dudley Metropolitan Borough Council,YES,2020-12-31T00:01:00
-E08000028,Sandwell Metropolitan Borough Council,YES,2020-12-31T00:01:00
-E08000029,Solihull Metropolitan Borough Council,YES,2020-12-31T00:01:00
-E08000030,Walsall Metropolitan Borough Council,YES,2020-12-31T00:01:00
-E08000031,City of Wolverhampton Council,YES,2020-12-31T00:01:00
-E08000037,Gateshead Metropolitan Borough Council,YES,2020-12-31T00:01:00
-E09000001,City of London Corporation,YES,2020-12-20T00:01:00
-E09000002,London Borough of Barking and Dagenham,YES,2020-12-20T00:01:00
-E09000003,London Borough of Barnet,YES,2020-12-20T00:01:00
-E09000004,London Borough of Bexley,YES,2020-12-20T00:01:00
-E09000005,London Borough of Brent,YES,2020-12-20T00:01:00
-E09000006,London Borough of Bromley,YES,2020-12-20T00:01:00
-E09000007,London Borough of Camden,YES,2020-12-20T00:01:00
-E09000008,London Borough of Croydon,YES,2020-12-20T00:01:00
-E09000009,London Borough of Ealing,YES,2020-12-20T00:01:00
-E09000010,London Borough of Enfield,YES,2020-12-20T00:01:00
-E09000011,Royal Borough of Greenwich,YES,2020-12-20T00:01:00
-E09000012,London Borough of Hackney,YES,2020-12-20T00:01:00
-E09000013,London Borough of Hammersmith & Fulham,YES,2020-12-20T00:01:00
-E09000014,London Borough of Haringey,YES,2020-12-20T00:01:00
-E09000015,London Borough of Harrow,YES,2020-12-20T00:01:00
-E09000016,London Borough of Havering,YES,2020-12-20T00:01:00
-E09000017,London Borough of Hillingdon,YES,2020-12-20T00:01:00
-E09000018,London Borough of Hounslow,YES,2020-12-20T00:01:00
-E09000019,London Borough of Islington,YES,2020-12-20T00:01:00
-E09000020,Royal Borough of Kensington and Chelsea,YES,2020-12-20T00:01:00
-E09000021,Royal Borough of Kingston upon Thames,YES,2020-12-20T00:01:00
-E09000022,London Borough of Lambeth,YES,2020-12-20T00:01:00
-E09000024,London Borough of Merton,YES,2020-12-20T00:01:00
-E09000025,London Borough of Newham,YES,2020-12-20T00:01:00
-E09000026,London Borough of Redbridge,YES,2020-12-20T00:01:00
-E09000027,London Borough of Richmond upon Thames,YES,2020-12-20T00:01:00
-E09000028,London Borough of Southwark,YES,2020-12-20T00:01:00
-E09000029,London Borough of Sutton,YES,2020-12-20T00:01:00
-E09000030,London Borough of Tower Hamlets,YES,2020-12-20T00:01:00
-E09000031,London Borough of Waltham Forest,YES,2020-12-20T00:01:00
-E09000032,London Borough of Wandsworth,YES,2020-12-20T00:01:00
-E09000033,City of Westminster,YES,2020-12-20T00:01:00
-E07000004,Buckinghamshire Council,YES,2020-12-20T00:01:00
-E07000005,Buckinghamshire Council,YES,2020-12-20T00:01:00
-E07000006,Buckinghamshire Council,YES,2020-12-20T00:01:00
-E07000007,Buckinghamshire Council,YES,2020-12-20T00:01:00
-E06000060,Buckinghamshire Council,YES,2020-12-20T00:01:00
-E07000008,Cambridge City Council,YES,2020-12-26T00:01:00
-E07000009,East Cambridgeshire District Council,YES,2020-12-26T00:01:00
-E07000010,Fenland District Council,YES,2020-12-26T00:01:00
-E07000011,Huntingdonshire District Council,YES,2020-12-26T00:01:00
-E07000012,South Cambridgeshire District Council,YES,2020-12-26T00:01:00
-E07000026,Allerdale Borough Council,YES,2020-12-31T00:01:00
-E07000027,Borough of Barrow-in-Furness,YES,2020-12-31T00:01:00
-E07000028,Carlisle City Council,YES,2020-12-31T00:01:00
-E07000029,Copeland Borough Council,YES,2020-12-31T00:01:00
-E07000030,Eden District Council,YES,2020-12-31T00:01:00
-E07000031,South Lakeland District Council,YES,2020-12-31T00:01:00
-E07000032,Amber Valley Borough Council,YES,2020-12-31T00:01:00
-E07000033,Bolsover District Council,YES,2020-12-31T00:01:00
-E07000034,Chesterfield Borough Council,YES,2020-12-31T00:01:00
-E07000035,Derbyshire Dales District Council,YES,2020-12-31T00:01:00
-E07000036,Erewash Borough Council,YES,2020-12-31T00:01:00
-E07000037,High Peak Borough Council,YES,2020-12-31T00:01:00
-E07000038,North East Derbyshire District Council,YES,2020-12-31T00:01:00
-E07000039,South Derbyshire District Council,YES,2020-12-31T00:01:00
-E07000061,Eastbourne Borough Council,YES,2020-12-26T00:01:00
-E07000062,Hastings Borough Council,YES,2020-12-20T00:01:00
-E07000063,Lewes District Council,YES,2020-12-26T00:01:00
-E07000064,Rother District Council,YES,2020-12-20T00:01:00
-E07000065,Wealden District Council,YES,2020-12-26T00:01:00
-E07000066,Basildon Borough Council,YES,2020-12-20T00:01:00
-E07000067,Braintree District Council,YES,2020-12-20T00:01:00
-E07000068,Brentwood Borough Council,YES,2020-12-20T00:01:00
-E07000069,Castle Point Borough Council,YES,2020-12-20T00:01:00
-E07000070,Chelmsford City Council,YES,2020-12-20T00:01:00
-E07000071,Colchester Borough Council,YES,2020-12-26T00:01:00
-E07000072,Epping Forest District Council,YES,2020-12-20T00:01:00
-E07000073,Harlow Council,YES,2020-12-20T00:01:00
-E07000074,Maldon District Council,YES,2020-12-20T00:01:00
-E07000075,Rochford District Council,YES,2020-12-20T00:01:00
-E07000203,Mid Suffolk District Council,YES,2020-12-26T00:01:00
-E07000244,East Suffolk District Council,YES,2020-12-26T00:01:00
-E07000245,West Suffolk District Council,YES,2020-12-26T00:01:00
-E07000207,Elmbridge Borough Council,YES,2020-12-20T00:01:00
-E07000208,Epsom and Ewell Borough Council,YES,2020-12-20T00:01:00
-E07000209,Guildford Borough Council,YES,2020-12-20T00:01:00
-E07000210,Mole Valley District Council,YES,2020-12-20T00:01:00
-E07000211,Reigate and Banstead Borough Council,YES,2020-12-20T00:01:00
-E07000212,Runnymede Borough Council,YES,2020-12-20T00:01:00
-E07000213,Spelthorne Borough Council,YES,2020-12-20T00:01:00
-E07000214,Surrey Heath Borough Council,YES,2020-12-20T00:01:00
-E07000215,Tandridge District Council,YES,2020-12-20T00:01:00
-E07000216,Waverley Borough Council,YES,2020-12-26T00:01:00
-E07000217,Woking Borough Council,YES,2020-12-20T00:01:00
-E07000218,North Warwickshire Borough Council,YES,2020-12-31T00:01:00
-E07000219,Nuneaton and Bedworth Borough Council,YES,2020-12-31T00:01:00
-E07000220,Rugby Borough Council,YES,2020-12-31T00:01:00
-E07000221,Stratford-on-Avon District Council,YES,2020-12-31T00:01:00
-E07000222,Warwick District Council,YES,2020-12-31T00:01:00
-E07000223,Adur District Council,YES,2020-12-26T00:01:00
-E07000224,Arun District Council,YES,2020-12-26T00:01:00
-E07000225,Chichester District Council,YES,2020-12-26T00:01:00
-E07000226,Crawley Borough Council,YES,2020-12-26T00:01:00
-E07000227,Horsham District Council,YES,2020-12-26T00:01:00
-E07000228,Mid Sussex District Council,YES,2020-12-26T00:01:00
-E07000229,Worthing Borough Council,YES,2020-12-26T00:01:00
-E07000076,Tendring District Council,YES,2020-12-26T00:01:00
-E07000077,Uttlesford District Council,YES,2020-12-26T00:01:00
-E07000078,Cheltenham Borough Council,YES,2020-12-31T00:01:00
-E07000079,Cotswold District Council,YES,2020-12-31T00:01:00
-E07000080,Forest of Dean District Council,YES,2020-12-31T00:01:00
-E07000081,Gloucester City Council,YES,2020-12-31T00:01:00
-E07000082,Stroud District Council,YES,2020-12-31T00:01:00
-E07000083,Tewkesbury Borough Council,YES,2020-12-31T00:01:00
-E07000084,Basingstoke and Deane Borough Council,YES,2020-12-26T00:01:00
-E07000085,East Hampshire District Council,YES,2020-12-26T00:01:00
-E07000086,Eastleigh Borough Council,YES,2020-12-26T00:01:00
-E07000087,Fareham Borough Council,YES,2020-12-26T00:01:00
-E07000088,Gosport Borough Council,YES,2020-12-20T00:01:00
-E07000089,Hart District Council,YES,2020-12-26T00:01:00
-E07000090,Havant Borough Council,YES,2020-12-20T00:01:00
-E07000091,New Forest District Council,YES,2020-12-31T00:01:00
-E07000092,Rushmoor Borough Council,YES,2020-12-26T00:01:00
-E07000093,Test Valley Borough Council,YES,2020-12-26T00:01:00
-E07000094,Winchester City Council,YES,2020-12-26T00:01:00
-E07000095,Borough of Broxbourne,YES,2020-12-20T00:01:00
-E07000096,Dacorum Borough Council,YES,2020-12-20T00:01:00
-E07000098,Hertsmere Borough Council,YES,2020-12-20T00:01:00
-E07000099,North Hertfordshire District Council,YES,2020-12-20T00:01:00
-E07000102,Three Rivers District Council,YES,2020-12-20T00:01:00
-E07000103,Watford Borough Council,YES,2020-12-20T00:01:00
-E07000240,St Albans City and District Council,YES,2020-12-20T00:01:00
-E07000241,Welwyn Hatfield Council,YES,2020-12-20T00:01:00
-E07000242,East Hertfordshire District Council,YES,2020-12-20T00:01:00
-E07000243,Stevenage Borough Council,YES,2020-12-20T00:01:00
-E07000105,Ashford Borough Council,YES,2020-12-20T00:01:00
-E07000106,Canterbury City Council,YES,2020-12-20T00:01:00
-E07000107,Dartford Borough Council,YES,2020-12-20T00:01:00
-E07000108,Dover District Council,YES,2020-12-20T00:01:00
-E07000109,Gravesham Borough Council,YES,2020-12-20T00:01:00
-E07000110,Maidstone Borough Council,YES,2020-12-20T00:01:00
-E07000111,Sevenoaks District Council,YES,2020-12-20T00:01:00
-E07000112,Folkestone and Hythe,YES,2020-12-20T00:01:00
-E07000113,Swale Borough Council,YES,2020-12-20T00:01:00
-E07000114,Thanet District Council,YES,2020-12-20T00:01:00
-E07000115,Tonbridge and Malling Borough Council,YES,2020-12-20T00:01:00
-E07000116,Tunbridge Wells Borough Council,YES,2020-12-20T00:01:00
-E07000117,Burnley Borough Council,YES,2020-12-31T00:01:00
-E07000118,Chorley Council,YES,2020-12-31T00:01:00
-E07000119,Fylde Borough Council,YES,2020-12-31T00:01:00
-E07000120,Hyndburn Borough Council,YES,2020-12-31T00:01:00
-E07000121,Lancaster City Council,YES,2020-12-31T00:01:00
-E07000122,Pendle Borough Council,YES,2020-12-31T00:01:00
-E07000123,Preston City Council,YES,2020-12-31T00:01:00
-E07000124,Ribble Valley Borough Council,YES,2020-12-31T00:01:00
-E07000125,Rossendale Borough Council,YES,2020-12-31T00:01:00
-E07000126,South Ribble Borough Council,YES,2020-12-31T00:01:00
-E07000127,West Lancashire Borough Council,YES,2020-12-31T00:01:00
-E07000128,Wyre Council,YES,2020-12-31T00:01:00
-E07000129,Blaby District Council,YES,2020-12-31T00:01:00
-E07000130,Charnwood Borough Council,YES,2020-12-31T00:01:00
-E07000131,Harborough District Council,YES,2020-12-31T00:01:00
-E07000132,Hinckley and Bosworth Borough Council,YES,2020-12-31T00:01:00
-E07000133,Melton Borough Council,YES,2020-12-31T00:01:00
-E07000134,North West Leicestershire District Council,YES,2020-12-31T00:01:00
-E07000135,Oadby and Wigston District Council,YES,2020-12-31T00:01:00
-E07000136,Boston Borough Council,YES,2020-12-31T00:01:00
-E07000137,East Lindsey District Council,YES,2020-12-31T00:01:00
-E07000138,City of Lincoln Council,YES,2020-12-31T00:01:00
-E07000139,North Kesteven District Council,YES,2020-12-31T00:01:00
-E07000140,South Holland District Council,YES,2020-12-31T00:01:00
-E07000141,South Kesteven District Council,YES,2020-12-31T00:01:00
-E07000142,West Lindsey District Council,YES,2020-12-31T00:01:00
-E07000143,Breckland Council,YES,2020-12-26T00:01:00
-E07000144,Broadland District Council,YES,2020-12-26T00:01:00
-E07000145,Great Yarmouth Borough Council,YES,2020-12-26T00:01:00
-E07000146,Borough Council of Kings Lynn and West Norfolk,YES,2020-12-26T00:01:00
-E07000147,North Norfolk District Council,YES,2020-12-26T00:01:00
-E07000148,Norwich City Council,YES,2020-12-26T00:01:00
-E07000149,South Norfolk District Council,YES,2020-12-26T00:01:00
-E07000150,Corby Borough Council,YES,2020-12-31T00:01:00
-E07000151,Daventry District Council,YES,2020-12-31T00:01:00
-E07000152,East Northamptonshire Council,YES,2020-12-31T00:01:00
-E07000153,Kettering Borough Council,YES,2020-12-31T00:01:00
-E07000154,Northampton Borough Council,YES,2020-12-31T00:01:00
-E07000155,South Northamptonshire Council,YES,2020-12-31T00:01:00
-E07000156,Wellingborough Borough Council,YES,2020-12-31T00:01:00
-E07000170,Ashfield District Council,YES,2020-12-31T00:01:00
-E07000171,Bassetlaw District Council,YES,2020-12-31T00:01:00
-E07000172,Broxtowe Borough Council,YES,2020-12-31T00:01:00
-E07000173,Gedling Borough Council,YES,2020-12-31T00:01:00
-E07000174,Mansfield District Council,YES,2020-12-31T00:01:00
-E07000175,Newark and Sherwood District Council,YES,2020-12-31T00:01:00
-E07000176,Rushcliffe Borough Council,YES,2020-12-31T00:01:00
-E07000177,Cherwell District Council,YES,2020-12-26T00:01:00
-E07000178,Oxford City Council,YES,2020-12-26T00:01:00
-E07000179,South Oxfordshire District Council,YES,2020-12-26T00:01:00
-E07000180,Vale of White Horse District Council,YES,2020-12-26T00:01:00
-E07000181,West Oxfordshire District Council,YES,2020-12-26T00:01:00
-E07000187,Mendip District Council,YES,2020-12-31T00:01:00
-E07000188,Sedgemoor District Council,YES,2020-12-31T00:01:00
-E07000189,South Somerset District Council,YES,2020-12-31T00:01:00
-E07000246,Somerset West and Taunton District Council,YES,2020-12-31T00:01:00
-E07000192,Cannock Chase District Council,YES,2020-12-31T00:01:00
-E07000193,East Staffordshire Borough Council,YES,2020-12-31T00:01:00
-E07000194,Lichfield District Council,YES,2020-12-31T00:01:00
-E07000195,Newcastle-under-Lyme District Council,YES,2020-12-31T00:01:00
-E07000196,South Staffordshire Council,YES,2020-12-31T00:01:00
-E07000197,Stafford Borough Council,YES,2020-12-31T00:01:00
-E07000198,Staffordshire Moorlands District Council,YES,2020-12-31T00:01:00
-E07000199,Tamworth Borough Council,YES,2020-12-31T00:01:00
-E07000200,Babergh District Council,YES,2020-12-26T00:01:00
-E07000202,Ipswich Borough Council,YES,2020-12-26T00:01:00
+E06000045,Southampton City Council,YES,2021-01-04T00:01:00
 E06000046,Isle of Wight Council,YES,2020-12-31T00:01:00
+E06000046,Isle of Wight Council,YES,2021-01-04T00:01:00
+E06000047,Durham County Council,YES,2020-12-31T00:01:00
+E06000047,Durham County Council,YES,2021-01-04T00:01:00
+E06000049,Cheshire East Council,YES,2020-12-31T00:01:00
+E06000049,Cheshire East Council,YES,2021-01-04T00:01:00
+E06000050,Cheshire West and Chester Council,YES,2020-12-31T00:01:00
+E06000050,Cheshire West and Chester Council,YES,2021-01-04T00:01:00
+E06000051,Shropshire Council,YES,2021-01-04T00:01:00
+E06000052,Cornwall Council,YES,2021-01-04T00:01:00
+E06000053,Council of the Isles of Scilly,YES,2021-01-04T00:01:00
+E06000054,Wiltshire Council,YES,2021-01-04T00:01:00
+E06000055,Bedford Borough Council,YES,2020-12-20T00:01:00
+E06000055,Bedford Borough Council,YES,2021-01-04T00:01:00
+E06000056,Central Bedfordshire Council,YES,2020-12-20T00:01:00
+E06000056,Central Bedfordshire Council,YES,2021-01-04T00:01:00
+E06000057,Northumberland County Council,YES,2020-12-31T00:01:00
+E06000057,Northumberland County Council,YES,2021-01-04T00:01:00
+E06000058,"Bournemouth, Christchurch and Poole Council",YES,2020-12-31T00:01:00
+E06000058,"Bournemouth, Christchurch and Poole Council",YES,2021-01-04T00:01:00
+E06000059,Dorset Council,YES,2021-01-04T00:01:00
+E06000060,Buckinghamshire Council,YES,2020-12-20T00:01:00
+E06000060,Buckinghamshire Council,YES,2021-01-04T00:01:00
+E07000004,Buckinghamshire Council,YES,2020-12-20T00:01:00
+E07000004,Buckinghamshire Council,YES,2021-01-04T00:01:00
+E07000005,Buckinghamshire Council,YES,2020-12-20T00:01:00
+E07000005,Buckinghamshire Council,YES,2021-01-04T00:01:00
+E07000006,Buckinghamshire Council,YES,2020-12-20T00:01:00
+E07000006,Buckinghamshire Council,YES,2021-01-04T00:01:00
+E07000007,Buckinghamshire Council,YES,2020-12-20T00:01:00
+E07000007,Buckinghamshire Council,YES,2021-01-04T00:01:00
+E07000008,Cambridge City Council,YES,2020-12-26T00:01:00
+E07000008,Cambridge City Council,YES,2021-01-04T00:01:00
+E07000009,East Cambridgeshire District Council,YES,2020-12-26T00:01:00
+E07000009,East Cambridgeshire District Council,YES,2021-01-04T00:01:00
+E07000010,Fenland District Council,YES,2020-12-26T00:01:00
+E07000010,Fenland District Council,YES,2021-01-04T00:01:00
+E07000011,Huntingdonshire District Council,YES,2020-12-26T00:01:00
+E07000011,Huntingdonshire District Council,YES,2021-01-04T00:01:00
+E07000012,South Cambridgeshire District Council,YES,2020-12-26T00:01:00
+E07000012,South Cambridgeshire District Council,YES,2021-01-04T00:01:00
+E07000026,Allerdale Borough Council,YES,2020-12-31T00:01:00
+E07000026,Allerdale Borough Council,YES,2021-01-04T00:01:00
+E07000027,Borough of Barrow-in-Furness,YES,2020-12-31T00:01:00
+E07000027,Borough of Barrow-in-Furness,YES,2021-01-04T00:01:00
+E07000028,Carlisle City Council,YES,2020-12-31T00:01:00
+E07000028,Carlisle City Council,YES,2021-01-04T00:01:00
+E07000029,Copeland Borough Council,YES,2020-12-31T00:01:00
+E07000029,Copeland Borough Council,YES,2021-01-04T00:01:00
+E07000030,Eden District Council,YES,2020-12-31T00:01:00
+E07000030,Eden District Council,YES,2021-01-04T00:01:00
+E07000031,South Lakeland District Council,YES,2020-12-31T00:01:00
+E07000031,South Lakeland District Council,YES,2021-01-04T00:01:00
+E07000032,Amber Valley Borough Council,YES,2020-12-31T00:01:00
+E07000032,Amber Valley Borough Council,YES,2021-01-04T00:01:00
+E07000033,Bolsover District Council,YES,2020-12-31T00:01:00
+E07000033,Bolsover District Council,YES,2021-01-04T00:01:00
+E07000034,Chesterfield Borough Council,YES,2020-12-31T00:01:00
+E07000034,Chesterfield Borough Council,YES,2021-01-04T00:01:00
+E07000035,Derbyshire Dales District Council,YES,2020-12-31T00:01:00
+E07000035,Derbyshire Dales District Council,YES,2021-01-04T00:01:00
+E07000036,Erewash Borough Council,YES,2020-12-31T00:01:00
+E07000036,Erewash Borough Council,YES,2021-01-04T00:01:00
+E07000037,High Peak Borough Council,YES,2020-12-31T00:01:00
+E07000037,High Peak Borough Council,YES,2021-01-04T00:01:00
+E07000038,North East Derbyshire District Council,YES,2020-12-31T00:01:00
+E07000038,North East Derbyshire District Council,YES,2021-01-04T00:01:00
+E07000039,South Derbyshire District Council,YES,2020-12-31T00:01:00
+E07000039,South Derbyshire District Council,YES,2021-01-04T00:01:00
+E07000040,East Devon District Council,YES,2021-01-04T00:01:00
+E07000041,Exeter City Council,YES,2021-01-04T00:01:00
+E07000042,Mid Devon District Council,YES,2021-01-04T00:01:00
+E07000043,North Devon Council,YES,2021-01-04T00:01:00
+E07000044,South Hams District Council,YES,2021-01-04T00:01:00
+E07000045,Teignbridge District Council,YES,2021-01-04T00:01:00
+E07000046,Torridge District Council,YES,2021-01-04T00:01:00
+E07000047,West Devon Borough Council,YES,2021-01-04T00:01:00
+E07000061,Eastbourne Borough Council,YES,2020-12-26T00:01:00
+E07000061,Eastbourne Borough Council,YES,2021-01-04T00:01:00
+E07000062,Hastings Borough Council,YES,2020-12-20T00:01:00
+E07000062,Hastings Borough Council,YES,2021-01-04T00:01:00
+E07000063,Lewes District Council,YES,2020-12-26T00:01:00
+E07000063,Lewes District Council,YES,2021-01-04T00:01:00
+E07000064,Rother District Council,YES,2020-12-20T00:01:00
+E07000064,Rother District Council,YES,2021-01-04T00:01:00
+E07000065,Wealden District Council,YES,2020-12-26T00:01:00
+E07000065,Wealden District Council,YES,2021-01-04T00:01:00
+E07000066,Basildon Borough Council,YES,2020-12-20T00:01:00
+E07000066,Basildon Borough Council,YES,2021-01-04T00:01:00
+E07000067,Braintree District Council,YES,2020-12-20T00:01:00
+E07000067,Braintree District Council,YES,2021-01-04T00:01:00
+E07000068,Brentwood Borough Council,YES,2020-12-20T00:01:00
+E07000068,Brentwood Borough Council,YES,2021-01-04T00:01:00
+E07000069,Castle Point Borough Council,YES,2020-12-20T00:01:00
+E07000069,Castle Point Borough Council,YES,2021-01-04T00:01:00
+E07000070,Chelmsford City Council,YES,2020-12-20T00:01:00
+E07000070,Chelmsford City Council,YES,2021-01-04T00:01:00
+E07000071,Colchester Borough Council,YES,2020-12-26T00:01:00
+E07000071,Colchester Borough Council,YES,2021-01-04T00:01:00
+E07000072,Epping Forest District Council,YES,2020-12-20T00:01:00
+E07000072,Epping Forest District Council,YES,2021-01-04T00:01:00
+E07000073,Harlow Council,YES,2020-12-20T00:01:00
+E07000073,Harlow Council,YES,2021-01-04T00:01:00
+E07000074,Maldon District Council,YES,2020-12-20T00:01:00
+E07000074,Maldon District Council,YES,2021-01-04T00:01:00
+E07000075,Rochford District Council,YES,2020-12-20T00:01:00
+E07000075,Rochford District Council,YES,2021-01-04T00:01:00
+E07000076,Tendring District Council,YES,2020-12-26T00:01:00
+E07000076,Tendring District Council,YES,2021-01-04T00:01:00
+E07000077,Uttlesford District Council,YES,2020-12-26T00:01:00
+E07000077,Uttlesford District Council,YES,2021-01-04T00:01:00
+E07000078,Cheltenham Borough Council,YES,2020-12-31T00:01:00
+E07000078,Cheltenham Borough Council,YES,2021-01-04T00:01:00
+E07000079,Cotswold District Council,YES,2020-12-31T00:01:00
+E07000079,Cotswold District Council,YES,2021-01-04T00:01:00
+E07000080,Forest of Dean District Council,YES,2020-12-31T00:01:00
+E07000080,Forest of Dean District Council,YES,2021-01-04T00:01:00
+E07000081,Gloucester City Council,YES,2020-12-31T00:01:00
+E07000081,Gloucester City Council,YES,2021-01-04T00:01:00
+E07000082,Stroud District Council,YES,2020-12-31T00:01:00
+E07000082,Stroud District Council,YES,2021-01-04T00:01:00
+E07000083,Tewkesbury Borough Council,YES,2020-12-31T00:01:00
+E07000083,Tewkesbury Borough Council,YES,2021-01-04T00:01:00
+E07000084,Basingstoke and Deane Borough Council,YES,2020-12-26T00:01:00
+E07000084,Basingstoke and Deane Borough Council,YES,2021-01-04T00:01:00
+E07000085,East Hampshire District Council,YES,2020-12-26T00:01:00
+E07000085,East Hampshire District Council,YES,2021-01-04T00:01:00
+E07000086,Eastleigh Borough Council,YES,2020-12-26T00:01:00
+E07000086,Eastleigh Borough Council,YES,2021-01-04T00:01:00
+E07000087,Fareham Borough Council,YES,2020-12-26T00:01:00
+E07000087,Fareham Borough Council,YES,2021-01-04T00:01:00
+E07000088,Gosport Borough Council,YES,2020-12-20T00:01:00
+E07000088,Gosport Borough Council,YES,2021-01-04T00:01:00
+E07000089,Hart District Council,YES,2020-12-26T00:01:00
+E07000089,Hart District Council,YES,2021-01-04T00:01:00
+E07000090,Havant Borough Council,YES,2020-12-20T00:01:00
+E07000090,Havant Borough Council,YES,2021-01-04T00:01:00
+E07000091,New Forest District Council,YES,2020-12-31T00:01:00
+E07000091,New Forest District Council,YES,2021-01-04T00:01:00
+E07000092,Rushmoor Borough Council,YES,2020-12-26T00:01:00
+E07000092,Rushmoor Borough Council,YES,2021-01-04T00:01:00
+E07000093,Test Valley Borough Council,YES,2020-12-26T00:01:00
+E07000093,Test Valley Borough Council,YES,2021-01-04T00:01:00
+E07000094,Winchester City Council,YES,2020-12-26T00:01:00
+E07000094,Winchester City Council,YES,2021-01-04T00:01:00
+E07000095,Borough of Broxbourne,YES,2020-12-20T00:01:00
+E07000095,Borough of Broxbourne,YES,2021-01-04T00:01:00
+E07000096,Dacorum Borough Council,YES,2020-12-20T00:01:00
+E07000096,Dacorum Borough Council,YES,2021-01-04T00:01:00
+E07000098,Hertsmere Borough Council,YES,2020-12-20T00:01:00
+E07000098,Hertsmere Borough Council,YES,2021-01-04T00:01:00
+E07000099,North Hertfordshire District Council,YES,2020-12-20T00:01:00
+E07000099,North Hertfordshire District Council,YES,2021-01-04T00:01:00
+E07000102,Three Rivers District Council,YES,2020-12-20T00:01:00
+E07000102,Three Rivers District Council,YES,2021-01-04T00:01:00
+E07000103,Watford Borough Council,YES,2020-12-20T00:01:00
+E07000103,Watford Borough Council,YES,2021-01-04T00:01:00
+E07000105,Ashford Borough Council,YES,2020-12-20T00:01:00
+E07000105,Ashford Borough Council,YES,2021-01-04T00:01:00
+E07000106,Canterbury City Council,YES,2020-12-20T00:01:00
+E07000106,Canterbury City Council,YES,2021-01-04T00:01:00
+E07000107,Dartford Borough Council,YES,2020-12-20T00:01:00
+E07000107,Dartford Borough Council,YES,2021-01-04T00:01:00
+E07000108,Dover District Council,YES,2020-12-20T00:01:00
+E07000108,Dover District Council,YES,2021-01-04T00:01:00
+E07000109,Gravesham Borough Council,YES,2020-12-20T00:01:00
+E07000109,Gravesham Borough Council,YES,2021-01-04T00:01:00
+E07000110,Maidstone Borough Council,YES,2020-12-20T00:01:00
+E07000110,Maidstone Borough Council,YES,2021-01-04T00:01:00
+E07000111,Sevenoaks District Council,YES,2020-12-20T00:01:00
+E07000111,Sevenoaks District Council,YES,2021-01-04T00:01:00
+E07000112,Folkestone and Hythe,YES,2020-12-20T00:01:00
+E07000112,Folkestone and Hythe,YES,2021-01-04T00:01:00
+E07000113,Swale Borough Council,YES,2020-12-20T00:01:00
+E07000113,Swale Borough Council,YES,2021-01-04T00:01:00
+E07000114,Thanet District Council,YES,2020-12-20T00:01:00
+E07000114,Thanet District Council,YES,2021-01-04T00:01:00
+E07000115,Tonbridge and Malling Borough Council,YES,2020-12-20T00:01:00
+E07000115,Tonbridge and Malling Borough Council,YES,2021-01-04T00:01:00
+E07000116,Tunbridge Wells Borough Council,YES,2020-12-20T00:01:00
+E07000116,Tunbridge Wells Borough Council,YES,2021-01-04T00:01:00
+E07000117,Burnley Borough Council,YES,2020-12-31T00:01:00
+E07000117,Burnley Borough Council,YES,2021-01-04T00:01:00
+E07000118,Chorley Council,YES,2020-12-31T00:01:00
+E07000118,Chorley Council,YES,2021-01-04T00:01:00
+E07000119,Fylde Borough Council,YES,2020-12-31T00:01:00
+E07000119,Fylde Borough Council,YES,2021-01-04T00:01:00
+E07000120,Hyndburn Borough Council,YES,2020-12-31T00:01:00
+E07000120,Hyndburn Borough Council,YES,2021-01-04T00:01:00
+E07000121,Lancaster City Council,YES,2020-12-31T00:01:00
+E07000121,Lancaster City Council,YES,2021-01-04T00:01:00
+E07000122,Pendle Borough Council,YES,2020-12-31T00:01:00
+E07000122,Pendle Borough Council,YES,2021-01-04T00:01:00
+E07000123,Preston City Council,YES,2020-12-31T00:01:00
+E07000123,Preston City Council,YES,2021-01-04T00:01:00
+E07000124,Ribble Valley Borough Council,YES,2020-12-31T00:01:00
+E07000124,Ribble Valley Borough Council,YES,2021-01-04T00:01:00
+E07000125,Rossendale Borough Council,YES,2020-12-31T00:01:00
+E07000125,Rossendale Borough Council,YES,2021-01-04T00:01:00
+E07000126,South Ribble Borough Council,YES,2020-12-31T00:01:00
+E07000126,South Ribble Borough Council,YES,2021-01-04T00:01:00
+E07000127,West Lancashire Borough Council,YES,2020-12-31T00:01:00
+E07000127,West Lancashire Borough Council,YES,2021-01-04T00:01:00
+E07000128,Wyre Council,YES,2020-12-31T00:01:00
+E07000128,Wyre Council,YES,2021-01-04T00:01:00
+E07000129,Blaby District Council,YES,2020-12-31T00:01:00
+E07000129,Blaby District Council,YES,2021-01-04T00:01:00
+E07000130,Charnwood Borough Council,YES,2020-12-31T00:01:00
+E07000130,Charnwood Borough Council,YES,2021-01-04T00:01:00
+E07000131,Harborough District Council,YES,2020-12-31T00:01:00
+E07000131,Harborough District Council,YES,2021-01-04T00:01:00
+E07000132,Hinckley and Bosworth Borough Council,YES,2020-12-31T00:01:00
+E07000132,Hinckley and Bosworth Borough Council,YES,2021-01-04T00:01:00
+E07000133,Melton Borough Council,YES,2020-12-31T00:01:00
+E07000133,Melton Borough Council,YES,2021-01-04T00:01:00
+E07000134,North West Leicestershire District Council,YES,2020-12-31T00:01:00
+E07000134,North West Leicestershire District Council,YES,2021-01-04T00:01:00
+E07000135,Oadby and Wigston District Council,YES,2020-12-31T00:01:00
+E07000135,Oadby and Wigston District Council,YES,2021-01-04T00:01:00
+E07000136,Boston Borough Council,YES,2020-12-31T00:01:00
+E07000136,Boston Borough Council,YES,2021-01-04T00:01:00
+E07000137,East Lindsey District Council,YES,2020-12-31T00:01:00
+E07000137,East Lindsey District Council,YES,2021-01-04T00:01:00
+E07000138,City of Lincoln Council,YES,2020-12-31T00:01:00
+E07000138,City of Lincoln Council,YES,2021-01-04T00:01:00
+E07000139,North Kesteven District Council,YES,2020-12-31T00:01:00
+E07000139,North Kesteven District Council,YES,2021-01-04T00:01:00
+E07000140,South Holland District Council,YES,2020-12-31T00:01:00
+E07000140,South Holland District Council,YES,2021-01-04T00:01:00
+E07000141,South Kesteven District Council,YES,2020-12-31T00:01:00
+E07000141,South Kesteven District Council,YES,2021-01-04T00:01:00
+E07000142,West Lindsey District Council,YES,2020-12-31T00:01:00
+E07000142,West Lindsey District Council,YES,2021-01-04T00:01:00
+E07000143,Breckland Council,YES,2020-12-26T00:01:00
+E07000143,Breckland Council,YES,2021-01-04T00:01:00
+E07000144,Broadland District Council,YES,2020-12-26T00:01:00
+E07000144,Broadland District Council,YES,2021-01-04T00:01:00
+E07000145,Great Yarmouth Borough Council,YES,2020-12-26T00:01:00
+E07000145,Great Yarmouth Borough Council,YES,2021-01-04T00:01:00
+E07000146,Borough Council of Kings Lynn and West Norfolk,YES,2020-12-26T00:01:00
+E07000146,Borough Council of Kings Lynn and West Norfolk,YES,2021-01-04T00:01:00
+E07000147,North Norfolk District Council,YES,2020-12-26T00:01:00
+E07000147,North Norfolk District Council,YES,2021-01-04T00:01:00
+E07000148,Norwich City Council,YES,2020-12-26T00:01:00
+E07000148,Norwich City Council,YES,2021-01-04T00:01:00
+E07000149,South Norfolk District Council,YES,2020-12-26T00:01:00
+E07000149,South Norfolk District Council,YES,2021-01-04T00:01:00
+E07000150,Corby Borough Council,YES,2020-12-31T00:01:00
+E07000150,Corby Borough Council,YES,2021-01-04T00:01:00
+E07000151,Daventry District Council,YES,2020-12-31T00:01:00
+E07000151,Daventry District Council,YES,2021-01-04T00:01:00
+E07000152,East Northamptonshire Council,YES,2020-12-31T00:01:00
+E07000152,East Northamptonshire Council,YES,2021-01-04T00:01:00
+E07000153,Kettering Borough Council,YES,2020-12-31T00:01:00
+E07000153,Kettering Borough Council,YES,2021-01-04T00:01:00
+E07000154,Northampton Borough Council,YES,2020-12-31T00:01:00
+E07000154,Northampton Borough Council,YES,2021-01-04T00:01:00
+E07000155,South Northamptonshire Council,YES,2020-12-31T00:01:00
+E07000155,South Northamptonshire Council,YES,2021-01-04T00:01:00
+E07000156,Wellingborough Borough Council,YES,2020-12-31T00:01:00
+E07000156,Wellingborough Borough Council,YES,2021-01-04T00:01:00
+E07000163,Craven District Council,YES,2021-01-04T00:01:00
+E07000164,Hambleton District Council,YES,2021-01-04T00:01:00
+E07000165,Harrogate Borough Council,YES,2021-01-04T00:01:00
+E07000166,Richmondshire District Council,YES,2021-01-04T00:01:00
+E07000167,Ryedale District Council,YES,2021-01-04T00:01:00
+E07000168,Scarborough Borough Council,YES,2021-01-04T00:01:00
+E07000169,Selby District Council,YES,2021-01-04T00:01:00
+E07000170,Ashfield District Council,YES,2020-12-31T00:01:00
+E07000170,Ashfield District Council,YES,2021-01-04T00:01:00
+E07000171,Bassetlaw District Council,YES,2020-12-31T00:01:00
+E07000171,Bassetlaw District Council,YES,2021-01-04T00:01:00
+E07000172,Broxtowe Borough Council,YES,2020-12-31T00:01:00
+E07000172,Broxtowe Borough Council,YES,2021-01-04T00:01:00
+E07000173,Gedling Borough Council,YES,2020-12-31T00:01:00
+E07000173,Gedling Borough Council,YES,2021-01-04T00:01:00
+E07000174,Mansfield District Council,YES,2020-12-31T00:01:00
+E07000174,Mansfield District Council,YES,2021-01-04T00:01:00
+E07000175,Newark and Sherwood District Council,YES,2020-12-31T00:01:00
+E07000175,Newark and Sherwood District Council,YES,2021-01-04T00:01:00
+E07000176,Rushcliffe Borough Council,YES,2020-12-31T00:01:00
+E07000176,Rushcliffe Borough Council,YES,2021-01-04T00:01:00
+E07000177,Cherwell District Council,YES,2020-12-26T00:01:00
+E07000177,Cherwell District Council,YES,2021-01-04T00:01:00
+E07000178,Oxford City Council,YES,2020-12-26T00:01:00
+E07000178,Oxford City Council,YES,2021-01-04T00:01:00
+E07000179,South Oxfordshire District Council,YES,2020-12-26T00:01:00
+E07000179,South Oxfordshire District Council,YES,2021-01-04T00:01:00
+E07000180,Vale of White Horse District Council,YES,2020-12-26T00:01:00
+E07000180,Vale of White Horse District Council,YES,2021-01-04T00:01:00
+E07000181,West Oxfordshire District Council,YES,2020-12-26T00:01:00
+E07000181,West Oxfordshire District Council,YES,2021-01-04T00:01:00
+E07000187,Mendip District Council,YES,2020-12-31T00:01:00
+E07000187,Mendip District Council,YES,2021-01-04T00:01:00
+E07000188,Sedgemoor District Council,YES,2020-12-31T00:01:00
+E07000188,Sedgemoor District Council,YES,2021-01-04T00:01:00
+E07000189,South Somerset District Council,YES,2020-12-31T00:01:00
+E07000189,South Somerset District Council,YES,2021-01-04T00:01:00
+E07000192,Cannock Chase District Council,YES,2020-12-31T00:01:00
+E07000192,Cannock Chase District Council,YES,2021-01-04T00:01:00
+E07000193,East Staffordshire Borough Council,YES,2020-12-31T00:01:00
+E07000193,East Staffordshire Borough Council,YES,2021-01-04T00:01:00
+E07000194,Lichfield District Council,YES,2020-12-31T00:01:00
+E07000194,Lichfield District Council,YES,2021-01-04T00:01:00
+E07000195,Newcastle-under-Lyme District Council,YES,2020-12-31T00:01:00
+E07000195,Newcastle-under-Lyme District Council,YES,2021-01-04T00:01:00
+E07000196,South Staffordshire Council,YES,2020-12-31T00:01:00
+E07000196,South Staffordshire Council,YES,2021-01-04T00:01:00
+E07000197,Stafford Borough Council,YES,2020-12-31T00:01:00
+E07000197,Stafford Borough Council,YES,2021-01-04T00:01:00
+E07000198,Staffordshire Moorlands District Council,YES,2020-12-31T00:01:00
+E07000198,Staffordshire Moorlands District Council,YES,2021-01-04T00:01:00
+E07000199,Tamworth Borough Council,YES,2020-12-31T00:01:00
+E07000199,Tamworth Borough Council,YES,2021-01-04T00:01:00
+E07000200,Babergh District Council,YES,2020-12-26T00:01:00
+E07000200,Babergh District Council,YES,2021-01-04T00:01:00
+E07000202,Ipswich Borough Council,YES,2020-12-26T00:01:00
+E07000202,Ipswich Borough Council,YES,2021-01-04T00:01:00
+E07000203,Mid Suffolk District Council,YES,2020-12-26T00:01:00
+E07000203,Mid Suffolk District Council,YES,2021-01-04T00:01:00
+E07000207,Elmbridge Borough Council,YES,2020-12-20T00:01:00
+E07000207,Elmbridge Borough Council,YES,2021-01-04T00:01:00
+E07000208,Epsom and Ewell Borough Council,YES,2020-12-20T00:01:00
+E07000208,Epsom and Ewell Borough Council,YES,2021-01-04T00:01:00
+E07000209,Guildford Borough Council,YES,2020-12-20T00:01:00
+E07000209,Guildford Borough Council,YES,2021-01-04T00:01:00
+E07000210,Mole Valley District Council,YES,2020-12-20T00:01:00
+E07000210,Mole Valley District Council,YES,2021-01-04T00:01:00
+E07000211,Reigate and Banstead Borough Council,YES,2020-12-20T00:01:00
+E07000211,Reigate and Banstead Borough Council,YES,2021-01-04T00:01:00
+E07000212,Runnymede Borough Council,YES,2020-12-20T00:01:00
+E07000212,Runnymede Borough Council,YES,2021-01-04T00:01:00
+E07000213,Spelthorne Borough Council,YES,2020-12-20T00:01:00
+E07000213,Spelthorne Borough Council,YES,2021-01-04T00:01:00
+E07000214,Surrey Heath Borough Council,YES,2020-12-20T00:01:00
+E07000214,Surrey Heath Borough Council,YES,2021-01-04T00:01:00
+E07000215,Tandridge District Council,YES,2020-12-20T00:01:00
+E07000215,Tandridge District Council,YES,2021-01-04T00:01:00
+E07000216,Waverley Borough Council,YES,2020-12-26T00:01:00
+E07000216,Waverley Borough Council,YES,2021-01-04T00:01:00
+E07000217,Woking Borough Council,YES,2020-12-20T00:01:00
+E07000217,Woking Borough Council,YES,2021-01-04T00:01:00
+E07000218,North Warwickshire Borough Council,YES,2020-12-31T00:01:00
+E07000218,North Warwickshire Borough Council,YES,2021-01-04T00:01:00
+E07000219,Nuneaton and Bedworth Borough Council,YES,2020-12-31T00:01:00
+E07000219,Nuneaton and Bedworth Borough Council,YES,2021-01-04T00:01:00
+E07000220,Rugby Borough Council,YES,2020-12-31T00:01:00
+E07000220,Rugby Borough Council,YES,2021-01-04T00:01:00
+E07000221,Stratford-on-Avon District Council,YES,2020-12-31T00:01:00
+E07000221,Stratford-on-Avon District Council,YES,2021-01-04T00:01:00
+E07000222,Warwick District Council,YES,2020-12-31T00:01:00
+E07000222,Warwick District Council,YES,2021-01-04T00:01:00
+E07000223,Adur District Council,YES,2020-12-26T00:01:00
+E07000223,Adur District Council,YES,2021-01-04T00:01:00
+E07000224,Arun District Council,YES,2020-12-26T00:01:00
+E07000224,Arun District Council,YES,2021-01-04T00:01:00
+E07000225,Chichester District Council,YES,2020-12-26T00:01:00
+E07000225,Chichester District Council,YES,2021-01-04T00:01:00
+E07000226,Crawley Borough Council,YES,2020-12-26T00:01:00
+E07000226,Crawley Borough Council,YES,2021-01-04T00:01:00
+E07000227,Horsham District Council,YES,2020-12-26T00:01:00
+E07000227,Horsham District Council,YES,2021-01-04T00:01:00
+E07000228,Mid Sussex District Council,YES,2020-12-26T00:01:00
+E07000228,Mid Sussex District Council,YES,2021-01-04T00:01:00
+E07000229,Worthing Borough Council,YES,2020-12-26T00:01:00
+E07000229,Worthing Borough Council,YES,2021-01-04T00:01:00
+E07000234,Bromsgrove District Council,YES,2021-01-04T00:01:00
+E07000235,Malvern Hills District Council,YES,2021-01-04T00:01:00
+E07000236,Redditch Borough Council,YES,2021-01-04T00:01:00
+E07000237,Worcester City Council,YES,2021-01-04T00:01:00
+E07000238,Wychavon District Council,YES,2021-01-04T00:01:00
+E07000239,Wyre Forest District Council,YES,2021-01-04T00:01:00
+E07000240,St Albans City and District Council,YES,2020-12-20T00:01:00
+E07000240,St Albans City and District Council,YES,2021-01-04T00:01:00
+E07000241,Welwyn Hatfield Council,YES,2020-12-20T00:01:00
+E07000241,Welwyn Hatfield Council,YES,2021-01-04T00:01:00
+E07000242,East Hertfordshire District Council,YES,2020-12-20T00:01:00
+E07000242,East Hertfordshire District Council,YES,2021-01-04T00:01:00
+E07000243,Stevenage Borough Council,YES,2020-12-20T00:01:00
+E07000243,Stevenage Borough Council,YES,2021-01-04T00:01:00
+E07000244,East Suffolk District Council,YES,2020-12-26T00:01:00
+E07000244,East Suffolk District Council,YES,2021-01-04T00:01:00
+E07000245,West Suffolk District Council,YES,2020-12-26T00:01:00
+E07000245,West Suffolk District Council,YES,2021-01-04T00:01:00
+E07000246,Somerset West and Taunton District Council,YES,2020-12-31T00:01:00
+E07000246,Somerset West and Taunton District Council,YES,2021-01-04T00:01:00
+E08000001,Bolton Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000001,Bolton Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E08000002,Bury Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000002,Bury Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E08000003,Manchester City Council,YES,2020-12-31T00:01:00
+E08000003,Manchester City Council,YES,2021-01-04T00:01:00
+E08000004,Oldham Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000004,Oldham Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E08000005,Rochdale Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000005,Rochdale Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E08000006,Salford City Council,YES,2020-12-31T00:01:00
+E08000006,Salford City Council,YES,2021-01-04T00:01:00
+E08000007,Stockport Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000007,Stockport Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E08000008,Tameside Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000008,Tameside Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E08000009,Trafford Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000009,Trafford Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E08000010,Wigan Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000010,Wigan Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E08000011,Knowsley Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E08000012,Liverpool City Council,YES,2021-01-04T00:01:00
+E08000013,St Helens Council,YES,2021-01-04T00:01:00
+E08000014,Sefton Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E08000015,Wirral Council,YES,2021-01-04T00:01:00
+E08000016,Barnsley Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E08000017,Doncaster Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E08000018,Rotherham Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E08000019,Sheffield City Council,YES,2021-01-04T00:01:00
+E08000021,Newcastle City Council,YES,2020-12-31T00:01:00
+E08000021,Newcastle City Council,YES,2021-01-04T00:01:00
+E08000022,North Tyneside Council,YES,2020-12-31T00:01:00
+E08000022,North Tyneside Council,YES,2021-01-04T00:01:00
+E08000023,South Tyneside Council,YES,2020-12-31T00:01:00
+E08000023,South Tyneside Council,YES,2021-01-04T00:01:00
+E08000024,Sunderland City Council,YES,2020-12-31T00:01:00
+E08000024,Sunderland City Council,YES,2021-01-04T00:01:00
+E08000025,Birmingham City Council,YES,2020-12-31T00:01:00
+E08000025,Birmingham City Council,YES,2021-01-04T00:01:00
+E08000026,Coventry City Council,YES,2020-12-31T00:01:00
+E08000026,Coventry City Council,YES,2021-01-04T00:01:00
+E08000027,Dudley Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000027,Dudley Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E08000028,Sandwell Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000028,Sandwell Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E08000029,Solihull Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000029,Solihull Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E08000030,Walsall Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000030,Walsall Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E08000031,City of Wolverhampton Council,YES,2020-12-31T00:01:00
+E08000031,City of Wolverhampton Council,YES,2021-01-04T00:01:00
+E08000032,City of Bradford Metropolitan District Council,YES,2021-01-04T00:01:00
+E08000033,Calderdale Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E08000034,Kirklees Council,YES,2021-01-04T00:01:00
+E08000035,Leeds City Council,YES,2021-01-04T00:01:00
+E08000036,Wakefield Metropolitan District Council,YES,2021-01-04T00:01:00
+E08000037,Gateshead Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000037,Gateshead Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E09000001,City of London Corporation,YES,2020-12-20T00:01:00
+E09000001,City of London Corporation,YES,2021-01-04T00:01:00
+E09000002,London Borough of Barking and Dagenham,YES,2020-12-20T00:01:00
+E09000002,London Borough of Barking and Dagenham,YES,2021-01-04T00:01:00
+E09000003,London Borough of Barnet,YES,2020-12-20T00:01:00
+E09000003,London Borough of Barnet,YES,2021-01-04T00:01:00
+E09000004,London Borough of Bexley,YES,2020-12-20T00:01:00
+E09000004,London Borough of Bexley,YES,2021-01-04T00:01:00
+E09000005,London Borough of Brent,YES,2020-12-20T00:01:00
+E09000005,London Borough of Brent,YES,2021-01-04T00:01:00
+E09000006,London Borough of Bromley,YES,2020-12-20T00:01:00
+E09000006,London Borough of Bromley,YES,2021-01-04T00:01:00
+E09000007,London Borough of Camden,YES,2020-12-20T00:01:00
+E09000007,London Borough of Camden,YES,2021-01-04T00:01:00
+E09000008,London Borough of Croydon,YES,2020-12-20T00:01:00
+E09000008,London Borough of Croydon,YES,2021-01-04T00:01:00
+E09000009,London Borough of Ealing,YES,2020-12-20T00:01:00
+E09000009,London Borough of Ealing,YES,2021-01-04T00:01:00
+E09000010,London Borough of Enfield,YES,2020-12-20T00:01:00
+E09000010,London Borough of Enfield,YES,2021-01-04T00:01:00
+E09000011,Royal Borough of Greenwich,YES,2020-12-20T00:01:00
+E09000011,Royal Borough of Greenwich,YES,2021-01-04T00:01:00
+E09000012,London Borough of Hackney,YES,2020-12-20T00:01:00
+E09000012,London Borough of Hackney,YES,2021-01-04T00:01:00
+E09000013,London Borough of Hammersmith & Fulham,YES,2020-12-20T00:01:00
+E09000013,London Borough of Hammersmith & Fulham,YES,2021-01-04T00:01:00
+E09000014,London Borough of Haringey,YES,2020-12-20T00:01:00
+E09000014,London Borough of Haringey,YES,2021-01-04T00:01:00
+E09000015,London Borough of Harrow,YES,2020-12-20T00:01:00
+E09000015,London Borough of Harrow,YES,2021-01-04T00:01:00
+E09000016,London Borough of Havering,YES,2020-12-20T00:01:00
+E09000016,London Borough of Havering,YES,2021-01-04T00:01:00
+E09000017,London Borough of Hillingdon,YES,2020-12-20T00:01:00
+E09000017,London Borough of Hillingdon,YES,2021-01-04T00:01:00
+E09000018,London Borough of Hounslow,YES,2020-12-20T00:01:00
+E09000018,London Borough of Hounslow,YES,2021-01-04T00:01:00
+E09000019,London Borough of Islington,YES,2020-12-20T00:01:00
+E09000019,London Borough of Islington,YES,2021-01-04T00:01:00
+E09000020,Royal Borough of Kensington and Chelsea,YES,2020-12-20T00:01:00
+E09000020,Royal Borough of Kensington and Chelsea,YES,2021-01-04T00:01:00
+E09000021,Royal Borough of Kingston upon Thames,YES,2020-12-20T00:01:00
+E09000021,Royal Borough of Kingston upon Thames,YES,2021-01-04T00:01:00
+E09000022,London Borough of Lambeth,YES,2020-12-20T00:01:00
+E09000022,London Borough of Lambeth,YES,2021-01-04T00:01:00
+E09000023,London Borough of Lewisham,YES,2020-12-20T00:01:00
+E09000023,London Borough of Lewisham,YES,2021-01-04T00:01:00
+E09000024,London Borough of Merton,YES,2020-12-20T00:01:00
+E09000024,London Borough of Merton,YES,2021-01-04T00:01:00
+E09000025,London Borough of Newham,YES,2020-12-20T00:01:00
+E09000025,London Borough of Newham,YES,2021-01-04T00:01:00
+E09000026,London Borough of Redbridge,YES,2020-12-20T00:01:00
+E09000026,London Borough of Redbridge,YES,2021-01-04T00:01:00
+E09000027,London Borough of Richmond upon Thames,YES,2020-12-20T00:01:00
+E09000027,London Borough of Richmond upon Thames,YES,2021-01-04T00:01:00
+E09000028,London Borough of Southwark,YES,2020-12-20T00:01:00
+E09000028,London Borough of Southwark,YES,2021-01-04T00:01:00
+E09000029,London Borough of Sutton,YES,2020-12-20T00:01:00
+E09000029,London Borough of Sutton,YES,2021-01-04T00:01:00
+E09000030,London Borough of Tower Hamlets,YES,2020-12-20T00:01:00
+E09000030,London Borough of Tower Hamlets,YES,2021-01-04T00:01:00
+E09000031,London Borough of Waltham Forest,YES,2020-12-20T00:01:00
+E09000031,London Borough of Waltham Forest,YES,2021-01-04T00:01:00
+E09000032,London Borough of Wandsworth,YES,2020-12-20T00:01:00
+E09000032,London Borough of Wandsworth,YES,2021-01-04T00:01:00
+E09000033,City of Westminster,YES,2020-12-20T00:01:00
+E09000033,City of Westminster,YES,2021-01-04T00:01:00

--- a/vulnerable_people_form/integrations/data/local-area-shielding-advice-sandbox.csv
+++ b/vulnerable_people_form/integrations/data/local-area-shielding-advice-sandbox.csv
@@ -1,0 +1,2 @@
+ladcode,ladname,shielding_advice,start_datetime_utc
+E06000008,Blackburn with Darwen Borough Council,YES,2020-12-20T00:01:00

--- a/vulnerable_people_form/integrations/data/local-area-shielding-advice-staging.csv
+++ b/vulnerable_people_form/integrations/data/local-area-shielding-advice-staging.csv
@@ -1,0 +1,264 @@
+ladcode,ladname,shielding_advice,start_datetime_utc
+E06000001,Hartlepool Borough Council,YES,2020-12-31T00:01:00
+E06000002,Middlesbrough Borough Council,YES,2020-12-31T00:01:00
+E06000003,Redcar and Cleveland Borough Council,YES,2020-12-31T00:01:00
+E06000004,Stockton-on-Tees Borough Council,YES,2020-12-31T00:01:00
+E06000005,Darlington Borough Council,YES,2020-12-31T00:01:00
+E06000007,Warrington Borough Council,YES,2020-12-31T00:01:00
+E06000008,Blackburn with Darwen Borough Council,YES,2020-12-31T00:01:00
+E06000009,Blackpool Borough Council,YES,2020-12-31T00:01:00
+E06000015,Derby City,YES,2020-12-31T00:01:00
+E06000016,Leicester City Council,YES,2020-12-31T00:01:00
+E06000018,Nottingham City Council,YES,2020-12-31T00:01:00
+E06000021,Stoke-on-Trent City Council,YES,2020-12-31T00:01:00
+E06000030,Swindon Borough Council,YES,2020-12-31T00:01:00
+E06000031,Peterborough City Council,YES,2020-12-20T00:01:00
+E06000032,Luton Borough Council,YES,2020-12-20T00:01:00
+E06000033,Southend-on-Sea Borough Council,YES,2020-12-20T00:01:00
+E06000034,Thurrock Council,YES,2020-12-20T00:01:00
+E06000035,Medway Council,YES,2020-12-20T00:01:00
+E06000036,Bracknell Forest Council,YES,2020-12-20T00:01:00
+E06000037,West Berkshire Council,YES,2020-12-20T00:01:00
+E06000038,Reading Borough Council,YES,2020-12-20T00:01:00
+E06000039,Slough Borough Council,YES,2020-12-20T00:01:00
+E06000040,Royal Borough of Windsor and Maidenhead,YES,2020-12-20T00:01:00
+E06000041,Wokingham Borough Council,YES,2020-12-20T00:01:00
+E06000042,Milton Keynes Council,YES,2020-12-20T00:01:00
+E06000043,Brighton and Hove City Council,YES,2020-12-26T00:01:00
+E06000044,Portsmouth City Council,YES,2020-12-20T00:01:00
+E06000045,Southampton City Council,YES,2020-12-26T00:01:00
+E06000047,Durham County Council,YES,2020-12-31T00:01:00
+E06000049,Cheshire East Council,YES,2020-12-31T00:01:00
+E06000050,Cheshire West and Chester Council,YES,2020-12-31T00:01:00
+E06000055,Bedford Borough Council,YES,2020-12-20T00:01:00
+E06000056,Central Bedfordshire Council,YES,2020-12-20T00:01:00
+E06000057,Northumberland County Council,YES,2020-12-31T00:01:00
+E06000058,"Bournemouth, Christchurch and Poole Council",YES,2020-12-31T00:01:00
+E08000001,Bolton Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000002,Bury Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000003,Manchester City Council,YES,2020-12-31T00:01:00
+E08000004,Oldham Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000005,Rochdale Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000006,Salford City Council,YES,2020-12-31T00:01:00
+E08000007,Stockport Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000008,Tameside Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000009,Trafford Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000010,Wigan Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E09000023,London Borough of Lewisham,YES,2020-12-20T00:01:00
+E08000021,Newcastle City Council,YES,2020-12-31T00:01:00
+E08000022,North Tyneside Council,YES,2020-12-31T00:01:00
+E08000023,South Tyneside Council,YES,2020-12-31T00:01:00
+E08000024,Sunderland City Council,YES,2020-12-31T00:01:00
+E08000025,Birmingham City Council,YES,2020-12-31T00:01:00
+E08000026,Coventry City Council,YES,2020-12-31T00:01:00
+E08000027,Dudley Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000028,Sandwell Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000029,Solihull Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000030,Walsall Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000031,City of Wolverhampton Council,YES,2020-12-31T00:01:00
+E08000037,Gateshead Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E09000001,City of London Corporation,YES,2020-12-20T00:01:00
+E09000002,London Borough of Barking and Dagenham,YES,2020-12-20T00:01:00
+E09000003,London Borough of Barnet,YES,2020-12-20T00:01:00
+E09000004,London Borough of Bexley,YES,2020-12-20T00:01:00
+E09000005,London Borough of Brent,YES,2020-12-20T00:01:00
+E09000006,London Borough of Bromley,YES,2020-12-20T00:01:00
+E09000007,London Borough of Camden,YES,2020-12-20T00:01:00
+E09000008,London Borough of Croydon,YES,2020-12-20T00:01:00
+E09000009,London Borough of Ealing,YES,2020-12-20T00:01:00
+E09000010,London Borough of Enfield,YES,2020-12-20T00:01:00
+E09000011,Royal Borough of Greenwich,YES,2020-12-20T00:01:00
+E09000012,London Borough of Hackney,YES,2020-12-20T00:01:00
+E09000013,London Borough of Hammersmith & Fulham,YES,2020-12-20T00:01:00
+E09000014,London Borough of Haringey,YES,2020-12-20T00:01:00
+E09000015,London Borough of Harrow,YES,2020-12-20T00:01:00
+E09000016,London Borough of Havering,YES,2020-12-20T00:01:00
+E09000017,London Borough of Hillingdon,YES,2020-12-20T00:01:00
+E09000018,London Borough of Hounslow,YES,2020-12-20T00:01:00
+E09000019,London Borough of Islington,YES,2020-12-20T00:01:00
+E09000020,Royal Borough of Kensington and Chelsea,YES,2020-12-20T00:01:00
+E09000021,Royal Borough of Kingston upon Thames,YES,2020-12-20T00:01:00
+E09000022,London Borough of Lambeth,YES,2020-12-20T00:01:00
+E09000024,London Borough of Merton,YES,2020-12-20T00:01:00
+E09000025,London Borough of Newham,YES,2020-12-20T00:01:00
+E09000026,London Borough of Redbridge,YES,2020-12-20T00:01:00
+E09000027,London Borough of Richmond upon Thames,YES,2020-12-20T00:01:00
+E09000028,London Borough of Southwark,YES,2020-12-20T00:01:00
+E09000029,London Borough of Sutton,YES,2020-12-20T00:01:00
+E09000030,London Borough of Tower Hamlets,YES,2020-12-20T00:01:00
+E09000031,London Borough of Waltham Forest,YES,2020-12-20T00:01:00
+E09000032,London Borough of Wandsworth,YES,2020-12-20T00:01:00
+E09000033,City of Westminster,YES,2020-12-20T00:01:00
+E07000004,Buckinghamshire Council,YES,2020-12-20T00:01:00
+E07000005,Buckinghamshire Council,YES,2020-12-20T00:01:00
+E07000006,Buckinghamshire Council,YES,2020-12-20T00:01:00
+E07000007,Buckinghamshire Council,YES,2020-12-20T00:01:00
+E06000060,Buckinghamshire Council,YES,2020-12-20T00:01:00
+E07000008,Cambridge City Council,YES,2020-12-26T00:01:00
+E07000009,East Cambridgeshire District Council,YES,2020-12-26T00:01:00
+E07000010,Fenland District Council,YES,2020-12-26T00:01:00
+E07000011,Huntingdonshire District Council,YES,2020-12-26T00:01:00
+E07000012,South Cambridgeshire District Council,YES,2020-12-26T00:01:00
+E07000026,Allerdale Borough Council,YES,2020-12-31T00:01:00
+E07000027,Borough of Barrow-in-Furness,YES,2020-12-31T00:01:00
+E07000028,Carlisle City Council,YES,2020-12-31T00:01:00
+E07000029,Copeland Borough Council,YES,2020-12-31T00:01:00
+E07000030,Eden District Council,YES,2020-12-31T00:01:00
+E07000031,South Lakeland District Council,YES,2020-12-31T00:01:00
+E07000032,Amber Valley Borough Council,YES,2020-12-31T00:01:00
+E07000033,Bolsover District Council,YES,2020-12-31T00:01:00
+E07000034,Chesterfield Borough Council,YES,2020-12-31T00:01:00
+E07000035,Derbyshire Dales District Council,YES,2020-12-31T00:01:00
+E07000036,Erewash Borough Council,YES,2020-12-31T00:01:00
+E07000037,High Peak Borough Council,YES,2020-12-31T00:01:00
+E07000038,North East Derbyshire District Council,YES,2020-12-31T00:01:00
+E07000039,South Derbyshire District Council,YES,2020-12-31T00:01:00
+E07000061,Eastbourne Borough Council,YES,2020-12-26T00:01:00
+E07000062,Hastings Borough Council,YES,2020-12-20T00:01:00
+E07000063,Lewes District Council,YES,2020-12-26T00:01:00
+E07000064,Rother District Council,YES,2020-12-20T00:01:00
+E07000065,Wealden District Council,YES,2020-12-26T00:01:00
+E07000066,Basildon Borough Council,YES,2020-12-20T00:01:00
+E07000067,Braintree District Council,YES,2020-12-20T00:01:00
+E07000068,Brentwood Borough Council,YES,2020-12-20T00:01:00
+E07000069,Castle Point Borough Council,YES,2020-12-20T00:01:00
+E07000070,Chelmsford City Council,YES,2020-12-20T00:01:00
+E07000071,Colchester Borough Council,YES,2020-12-26T00:01:00
+E07000072,Epping Forest District Council,YES,2020-12-20T00:01:00
+E07000073,Harlow Council,YES,2020-12-20T00:01:00
+E07000074,Maldon District Council,YES,2020-12-20T00:01:00
+E07000075,Rochford District Council,YES,2020-12-20T00:01:00
+E07000203,Mid Suffolk District Council,YES,2020-12-26T00:01:00
+E07000244,East Suffolk District Council,YES,2020-12-26T00:01:00
+E07000245,West Suffolk District Council,YES,2020-12-26T00:01:00
+E07000207,Elmbridge Borough Council,YES,2020-12-20T00:01:00
+E07000208,Epsom and Ewell Borough Council,YES,2020-12-20T00:01:00
+E07000209,Guildford Borough Council,YES,2020-12-20T00:01:00
+E07000210,Mole Valley District Council,YES,2020-12-20T00:01:00
+E07000211,Reigate and Banstead Borough Council,YES,2020-12-20T00:01:00
+E07000212,Runnymede Borough Council,YES,2020-12-20T00:01:00
+E07000213,Spelthorne Borough Council,YES,2020-12-20T00:01:00
+E07000214,Surrey Heath Borough Council,YES,2020-12-20T00:01:00
+E07000215,Tandridge District Council,YES,2020-12-20T00:01:00
+E07000216,Waverley Borough Council,YES,2020-12-26T00:01:00
+E07000217,Woking Borough Council,YES,2020-12-20T00:01:00
+E07000218,North Warwickshire Borough Council,YES,2020-12-31T00:01:00
+E07000219,Nuneaton and Bedworth Borough Council,YES,2020-12-31T00:01:00
+E07000220,Rugby Borough Council,YES,2020-12-31T00:01:00
+E07000221,Stratford-on-Avon District Council,YES,2020-12-31T00:01:00
+E07000222,Warwick District Council,YES,2020-12-31T00:01:00
+E07000223,Adur District Council,YES,2020-12-26T00:01:00
+E07000224,Arun District Council,YES,2020-12-26T00:01:00
+E07000225,Chichester District Council,YES,2020-12-26T00:01:00
+E07000226,Crawley Borough Council,YES,2020-12-26T00:01:00
+E07000227,Horsham District Council,YES,2020-12-26T00:01:00
+E07000228,Mid Sussex District Council,YES,2020-12-26T00:01:00
+E07000229,Worthing Borough Council,YES,2020-12-26T00:01:00
+E07000076,Tendring District Council,YES,2020-12-26T00:01:00
+E07000077,Uttlesford District Council,YES,2020-12-26T00:01:00
+E07000078,Cheltenham Borough Council,YES,2020-12-31T00:01:00
+E07000079,Cotswold District Council,YES,2020-12-31T00:01:00
+E07000080,Forest of Dean District Council,YES,2020-12-31T00:01:00
+E07000081,Gloucester City Council,YES,2020-12-31T00:01:00
+E07000082,Stroud District Council,YES,2020-12-31T00:01:00
+E07000083,Tewkesbury Borough Council,YES,2020-12-31T00:01:00
+E07000084,Basingstoke and Deane Borough Council,YES,2020-12-26T00:01:00
+E07000085,East Hampshire District Council,YES,2020-12-26T00:01:00
+E07000086,Eastleigh Borough Council,YES,2020-12-26T00:01:00
+E07000087,Fareham Borough Council,YES,2020-12-26T00:01:00
+E07000088,Gosport Borough Council,YES,2020-12-20T00:01:00
+E07000089,Hart District Council,YES,2020-12-26T00:01:00
+E07000090,Havant Borough Council,YES,2020-12-20T00:01:00
+E07000091,New Forest District Council,YES,2020-12-31T00:01:00
+E07000092,Rushmoor Borough Council,YES,2020-12-26T00:01:00
+E07000093,Test Valley Borough Council,YES,2020-12-26T00:01:00
+E07000094,Winchester City Council,YES,2020-12-26T00:01:00
+E07000095,Borough of Broxbourne,YES,2020-12-20T00:01:00
+E07000096,Dacorum Borough Council,YES,2020-12-20T00:01:00
+E07000098,Hertsmere Borough Council,YES,2020-12-20T00:01:00
+E07000099,North Hertfordshire District Council,YES,2020-12-20T00:01:00
+E07000102,Three Rivers District Council,YES,2020-12-20T00:01:00
+E07000103,Watford Borough Council,YES,2020-12-20T00:01:00
+E07000240,St Albans City and District Council,YES,2020-12-20T00:01:00
+E07000241,Welwyn Hatfield Council,YES,2020-12-20T00:01:00
+E07000242,East Hertfordshire District Council,YES,2020-12-20T00:01:00
+E07000243,Stevenage Borough Council,YES,2020-12-20T00:01:00
+E07000105,Ashford Borough Council,YES,2020-12-20T00:01:00
+E07000106,Canterbury City Council,YES,2020-12-20T00:01:00
+E07000107,Dartford Borough Council,YES,2020-12-20T00:01:00
+E07000108,Dover District Council,YES,2020-12-20T00:01:00
+E07000109,Gravesham Borough Council,YES,2020-12-20T00:01:00
+E07000110,Maidstone Borough Council,YES,2020-12-20T00:01:00
+E07000111,Sevenoaks District Council,YES,2020-12-20T00:01:00
+E07000112,Folkestone and Hythe,YES,2020-12-20T00:01:00
+E07000113,Swale Borough Council,YES,2020-12-20T00:01:00
+E07000114,Thanet District Council,YES,2020-12-20T00:01:00
+E07000115,Tonbridge and Malling Borough Council,YES,2020-12-20T00:01:00
+E07000116,Tunbridge Wells Borough Council,YES,2020-12-20T00:01:00
+E07000117,Burnley Borough Council,YES,2020-12-31T00:01:00
+E07000118,Chorley Council,YES,2020-12-31T00:01:00
+E07000119,Fylde Borough Council,YES,2020-12-31T00:01:00
+E07000120,Hyndburn Borough Council,YES,2020-12-31T00:01:00
+E07000121,Lancaster City Council,YES,2020-12-31T00:01:00
+E07000122,Pendle Borough Council,YES,2020-12-31T00:01:00
+E07000123,Preston City Council,YES,2020-12-31T00:01:00
+E07000124,Ribble Valley Borough Council,YES,2020-12-31T00:01:00
+E07000125,Rossendale Borough Council,YES,2020-12-31T00:01:00
+E07000126,South Ribble Borough Council,YES,2020-12-31T00:01:00
+E07000127,West Lancashire Borough Council,YES,2020-12-31T00:01:00
+E07000128,Wyre Council,YES,2020-12-31T00:01:00
+E07000129,Blaby District Council,YES,2020-12-31T00:01:00
+E07000130,Charnwood Borough Council,YES,2020-12-31T00:01:00
+E07000131,Harborough District Council,YES,2020-12-31T00:01:00
+E07000132,Hinckley and Bosworth Borough Council,YES,2020-12-31T00:01:00
+E07000133,Melton Borough Council,YES,2020-12-31T00:01:00
+E07000134,North West Leicestershire District Council,YES,2020-12-31T00:01:00
+E07000135,Oadby and Wigston District Council,YES,2020-12-31T00:01:00
+E07000136,Boston Borough Council,YES,2020-12-31T00:01:00
+E07000137,East Lindsey District Council,YES,2020-12-31T00:01:00
+E07000138,City of Lincoln Council,YES,2020-12-31T00:01:00
+E07000139,North Kesteven District Council,YES,2020-12-31T00:01:00
+E07000140,South Holland District Council,YES,2020-12-31T00:01:00
+E07000141,South Kesteven District Council,YES,2020-12-31T00:01:00
+E07000142,West Lindsey District Council,YES,2020-12-31T00:01:00
+E07000143,Breckland Council,YES,2020-12-26T00:01:00
+E07000144,Broadland District Council,YES,2020-12-26T00:01:00
+E07000145,Great Yarmouth Borough Council,YES,2020-12-26T00:01:00
+E07000146,Borough Council of Kings Lynn and West Norfolk,YES,2020-12-26T00:01:00
+E07000147,North Norfolk District Council,YES,2020-12-26T00:01:00
+E07000148,Norwich City Council,YES,2020-12-26T00:01:00
+E07000149,South Norfolk District Council,YES,2020-12-26T00:01:00
+E07000150,Corby Borough Council,YES,2020-12-31T00:01:00
+E07000151,Daventry District Council,YES,2020-12-31T00:01:00
+E07000152,East Northamptonshire Council,YES,2020-12-31T00:01:00
+E07000153,Kettering Borough Council,YES,2020-12-31T00:01:00
+E07000154,Northampton Borough Council,YES,2020-12-31T00:01:00
+E07000155,South Northamptonshire Council,YES,2020-12-31T00:01:00
+E07000156,Wellingborough Borough Council,YES,2020-12-31T00:01:00
+E07000170,Ashfield District Council,YES,2020-12-31T00:01:00
+E07000171,Bassetlaw District Council,YES,2020-12-31T00:01:00
+E07000172,Broxtowe Borough Council,YES,2020-12-31T00:01:00
+E07000173,Gedling Borough Council,YES,2020-12-31T00:01:00
+E07000174,Mansfield District Council,YES,2020-12-31T00:01:00
+E07000175,Newark and Sherwood District Council,YES,2020-12-31T00:01:00
+E07000176,Rushcliffe Borough Council,YES,2020-12-31T00:01:00
+E07000177,Cherwell District Council,YES,2020-12-26T00:01:00
+E07000178,Oxford City Council,YES,2020-12-26T00:01:00
+E07000179,South Oxfordshire District Council,YES,2020-12-26T00:01:00
+E07000180,Vale of White Horse District Council,YES,2020-12-26T00:01:00
+E07000181,West Oxfordshire District Council,YES,2020-12-26T00:01:00
+E07000187,Mendip District Council,YES,2020-12-31T00:01:00
+E07000188,Sedgemoor District Council,YES,2020-12-31T00:01:00
+E07000189,South Somerset District Council,YES,2020-12-31T00:01:00
+E07000246,Somerset West and Taunton District Council,YES,2020-12-31T00:01:00
+E07000192,Cannock Chase District Council,YES,2020-12-31T00:01:00
+E07000193,East Staffordshire Borough Council,YES,2020-12-31T00:01:00
+E07000194,Lichfield District Council,YES,2020-12-31T00:01:00
+E07000195,Newcastle-under-Lyme District Council,YES,2020-12-31T00:01:00
+E07000196,South Staffordshire Council,YES,2020-12-31T00:01:00
+E07000197,Stafford Borough Council,YES,2020-12-31T00:01:00
+E07000198,Staffordshire Moorlands District Council,YES,2020-12-31T00:01:00
+E07000199,Tamworth Borough Council,YES,2020-12-31T00:01:00
+E07000200,Babergh District Council,YES,2020-12-26T00:01:00
+E07000202,Ipswich Borough Council,YES,2020-12-26T00:01:00
+E06000046,Isle of Wight Council,YES,2020-12-31T00:01:00

--- a/vulnerable_people_form/integrations/data/local-area-shielding-advice-staging.csv
+++ b/vulnerable_people_form/integrations/data/local-area-shielding-advice-staging.csv
@@ -1,264 +1,582 @@
 ladcode,ladname,shielding_advice,start_datetime_utc
 E06000001,Hartlepool Borough Council,YES,2020-12-31T00:01:00
+E06000001,Hartlepool Borough Council,YES,2021-01-04T00:01:00
 E06000002,Middlesbrough Borough Council,YES,2020-12-31T00:01:00
+E06000002,Middlesbrough Borough Council,YES,2021-01-04T00:01:00
 E06000003,Redcar and Cleveland Borough Council,YES,2020-12-31T00:01:00
+E06000003,Redcar and Cleveland Borough Council,YES,2021-01-04T00:01:00
 E06000004,Stockton-on-Tees Borough Council,YES,2020-12-31T00:01:00
+E06000004,Stockton-on-Tees Borough Council,YES,2021-01-04T00:01:00
 E06000005,Darlington Borough Council,YES,2020-12-31T00:01:00
+E06000005,Darlington Borough Council,YES,2021-01-04T00:01:00
+E06000006,Halton Borough Council,YES,2021-01-04T00:01:00
 E06000007,Warrington Borough Council,YES,2020-12-31T00:01:00
+E06000007,Warrington Borough Council,YES,2021-01-04T00:01:00
 E06000008,Blackburn with Darwen Borough Council,YES,2020-12-31T00:01:00
+E06000008,Blackburn with Darwen Borough Council,YES,2021-01-04T00:01:00
 E06000009,Blackpool Borough Council,YES,2020-12-31T00:01:00
+E06000009,Blackpool Borough Council,YES,2021-01-04T00:01:00
+E06000010,Hull City Council,YES,2021-01-04T00:01:00
+E06000011,East Riding of Yorkshire Council,YES,2021-01-04T00:01:00
+E06000012,North East Lincolnshire Council,YES,2021-01-04T00:01:00
+E06000013,North Lincolnshire Council,YES,2021-01-04T00:01:00
+E06000014,City of York Council,YES,2021-01-04T00:01:00
 E06000015,Derby City,YES,2020-12-31T00:01:00
+E06000015,Derby City,YES,2021-01-04T00:01:00
 E06000016,Leicester City Council,YES,2020-12-31T00:01:00
+E06000016,Leicester City Council,YES,2021-01-04T00:01:00
+E06000017,Rutland County Council,YES,2021-01-04T00:01:00
 E06000018,Nottingham City Council,YES,2020-12-31T00:01:00
+E06000018,Nottingham City Council,YES,2021-01-04T00:01:00
+E06000019,Herefordshire Council,YES,2021-01-04T00:01:00
+E06000020,Telford & Wrekin Council,YES,2021-01-04T00:01:00
 E06000021,Stoke-on-Trent City Council,YES,2020-12-31T00:01:00
+E06000021,Stoke-on-Trent City Council,YES,2021-01-04T00:01:00
+E06000022,Bath and North East Somerset Council,YES,2021-01-04T00:01:00
+E06000023,Bristol City Council,YES,2021-01-04T00:01:00
+E06000024,North Somerset Council,YES,2021-01-04T00:01:00
+E06000025,South Gloucestershire Council,YES,2021-01-04T00:01:00
+E06000026,Plymouth City Council,YES,2021-01-04T00:01:00
+E06000027,Torbay Council,YES,2021-01-04T00:01:00
 E06000030,Swindon Borough Council,YES,2020-12-31T00:01:00
+E06000030,Swindon Borough Council,YES,2021-01-04T00:01:00
 E06000031,Peterborough City Council,YES,2020-12-20T00:01:00
+E06000031,Peterborough City Council,YES,2021-01-04T00:01:00
 E06000032,Luton Borough Council,YES,2020-12-20T00:01:00
+E06000032,Luton Borough Council,YES,2021-01-04T00:01:00
 E06000033,Southend-on-Sea Borough Council,YES,2020-12-20T00:01:00
+E06000033,Southend-on-Sea Borough Council,YES,2021-01-04T00:01:00
 E06000034,Thurrock Council,YES,2020-12-20T00:01:00
+E06000034,Thurrock Council,YES,2021-01-04T00:01:00
 E06000035,Medway Council,YES,2020-12-20T00:01:00
+E06000035,Medway Council,YES,2021-01-04T00:01:00
 E06000036,Bracknell Forest Council,YES,2020-12-20T00:01:00
+E06000036,Bracknell Forest Council,YES,2021-01-04T00:01:00
 E06000037,West Berkshire Council,YES,2020-12-20T00:01:00
+E06000037,West Berkshire Council,YES,2021-01-04T00:01:00
 E06000038,Reading Borough Council,YES,2020-12-20T00:01:00
+E06000038,Reading Borough Council,YES,2021-01-04T00:01:00
 E06000039,Slough Borough Council,YES,2020-12-20T00:01:00
+E06000039,Slough Borough Council,YES,2021-01-04T00:01:00
 E06000040,Royal Borough of Windsor and Maidenhead,YES,2020-12-20T00:01:00
+E06000040,Royal Borough of Windsor and Maidenhead,YES,2021-01-04T00:01:00
 E06000041,Wokingham Borough Council,YES,2020-12-20T00:01:00
+E06000041,Wokingham Borough Council,YES,2021-01-04T00:01:00
 E06000042,Milton Keynes Council,YES,2020-12-20T00:01:00
+E06000042,Milton Keynes Council,YES,2021-01-04T00:01:00
 E06000043,Brighton and Hove City Council,YES,2020-12-26T00:01:00
+E06000043,Brighton and Hove City Council,YES,2021-01-04T00:01:00
 E06000044,Portsmouth City Council,YES,2020-12-20T00:01:00
+E06000044,Portsmouth City Council,YES,2021-01-04T00:01:00
 E06000045,Southampton City Council,YES,2020-12-26T00:01:00
-E06000047,Durham County Council,YES,2020-12-31T00:01:00
-E06000049,Cheshire East Council,YES,2020-12-31T00:01:00
-E06000050,Cheshire West and Chester Council,YES,2020-12-31T00:01:00
-E06000055,Bedford Borough Council,YES,2020-12-20T00:01:00
-E06000056,Central Bedfordshire Council,YES,2020-12-20T00:01:00
-E06000057,Northumberland County Council,YES,2020-12-31T00:01:00
-E06000058,"Bournemouth, Christchurch and Poole Council",YES,2020-12-31T00:01:00
-E08000001,Bolton Metropolitan Borough Council,YES,2020-12-31T00:01:00
-E08000002,Bury Metropolitan Borough Council,YES,2020-12-31T00:01:00
-E08000003,Manchester City Council,YES,2020-12-31T00:01:00
-E08000004,Oldham Metropolitan Borough Council,YES,2020-12-31T00:01:00
-E08000005,Rochdale Metropolitan Borough Council,YES,2020-12-31T00:01:00
-E08000006,Salford City Council,YES,2020-12-31T00:01:00
-E08000007,Stockport Metropolitan Borough Council,YES,2020-12-31T00:01:00
-E08000008,Tameside Metropolitan Borough Council,YES,2020-12-31T00:01:00
-E08000009,Trafford Metropolitan Borough Council,YES,2020-12-31T00:01:00
-E08000010,Wigan Metropolitan Borough Council,YES,2020-12-31T00:01:00
-E09000023,London Borough of Lewisham,YES,2020-12-20T00:01:00
-E08000021,Newcastle City Council,YES,2020-12-31T00:01:00
-E08000022,North Tyneside Council,YES,2020-12-31T00:01:00
-E08000023,South Tyneside Council,YES,2020-12-31T00:01:00
-E08000024,Sunderland City Council,YES,2020-12-31T00:01:00
-E08000025,Birmingham City Council,YES,2020-12-31T00:01:00
-E08000026,Coventry City Council,YES,2020-12-31T00:01:00
-E08000027,Dudley Metropolitan Borough Council,YES,2020-12-31T00:01:00
-E08000028,Sandwell Metropolitan Borough Council,YES,2020-12-31T00:01:00
-E08000029,Solihull Metropolitan Borough Council,YES,2020-12-31T00:01:00
-E08000030,Walsall Metropolitan Borough Council,YES,2020-12-31T00:01:00
-E08000031,City of Wolverhampton Council,YES,2020-12-31T00:01:00
-E08000037,Gateshead Metropolitan Borough Council,YES,2020-12-31T00:01:00
-E09000001,City of London Corporation,YES,2020-12-20T00:01:00
-E09000002,London Borough of Barking and Dagenham,YES,2020-12-20T00:01:00
-E09000003,London Borough of Barnet,YES,2020-12-20T00:01:00
-E09000004,London Borough of Bexley,YES,2020-12-20T00:01:00
-E09000005,London Borough of Brent,YES,2020-12-20T00:01:00
-E09000006,London Borough of Bromley,YES,2020-12-20T00:01:00
-E09000007,London Borough of Camden,YES,2020-12-20T00:01:00
-E09000008,London Borough of Croydon,YES,2020-12-20T00:01:00
-E09000009,London Borough of Ealing,YES,2020-12-20T00:01:00
-E09000010,London Borough of Enfield,YES,2020-12-20T00:01:00
-E09000011,Royal Borough of Greenwich,YES,2020-12-20T00:01:00
-E09000012,London Borough of Hackney,YES,2020-12-20T00:01:00
-E09000013,London Borough of Hammersmith & Fulham,YES,2020-12-20T00:01:00
-E09000014,London Borough of Haringey,YES,2020-12-20T00:01:00
-E09000015,London Borough of Harrow,YES,2020-12-20T00:01:00
-E09000016,London Borough of Havering,YES,2020-12-20T00:01:00
-E09000017,London Borough of Hillingdon,YES,2020-12-20T00:01:00
-E09000018,London Borough of Hounslow,YES,2020-12-20T00:01:00
-E09000019,London Borough of Islington,YES,2020-12-20T00:01:00
-E09000020,Royal Borough of Kensington and Chelsea,YES,2020-12-20T00:01:00
-E09000021,Royal Borough of Kingston upon Thames,YES,2020-12-20T00:01:00
-E09000022,London Borough of Lambeth,YES,2020-12-20T00:01:00
-E09000024,London Borough of Merton,YES,2020-12-20T00:01:00
-E09000025,London Borough of Newham,YES,2020-12-20T00:01:00
-E09000026,London Borough of Redbridge,YES,2020-12-20T00:01:00
-E09000027,London Borough of Richmond upon Thames,YES,2020-12-20T00:01:00
-E09000028,London Borough of Southwark,YES,2020-12-20T00:01:00
-E09000029,London Borough of Sutton,YES,2020-12-20T00:01:00
-E09000030,London Borough of Tower Hamlets,YES,2020-12-20T00:01:00
-E09000031,London Borough of Waltham Forest,YES,2020-12-20T00:01:00
-E09000032,London Borough of Wandsworth,YES,2020-12-20T00:01:00
-E09000033,City of Westminster,YES,2020-12-20T00:01:00
-E07000004,Buckinghamshire Council,YES,2020-12-20T00:01:00
-E07000005,Buckinghamshire Council,YES,2020-12-20T00:01:00
-E07000006,Buckinghamshire Council,YES,2020-12-20T00:01:00
-E07000007,Buckinghamshire Council,YES,2020-12-20T00:01:00
-E06000060,Buckinghamshire Council,YES,2020-12-20T00:01:00
-E07000008,Cambridge City Council,YES,2020-12-26T00:01:00
-E07000009,East Cambridgeshire District Council,YES,2020-12-26T00:01:00
-E07000010,Fenland District Council,YES,2020-12-26T00:01:00
-E07000011,Huntingdonshire District Council,YES,2020-12-26T00:01:00
-E07000012,South Cambridgeshire District Council,YES,2020-12-26T00:01:00
-E07000026,Allerdale Borough Council,YES,2020-12-31T00:01:00
-E07000027,Borough of Barrow-in-Furness,YES,2020-12-31T00:01:00
-E07000028,Carlisle City Council,YES,2020-12-31T00:01:00
-E07000029,Copeland Borough Council,YES,2020-12-31T00:01:00
-E07000030,Eden District Council,YES,2020-12-31T00:01:00
-E07000031,South Lakeland District Council,YES,2020-12-31T00:01:00
-E07000032,Amber Valley Borough Council,YES,2020-12-31T00:01:00
-E07000033,Bolsover District Council,YES,2020-12-31T00:01:00
-E07000034,Chesterfield Borough Council,YES,2020-12-31T00:01:00
-E07000035,Derbyshire Dales District Council,YES,2020-12-31T00:01:00
-E07000036,Erewash Borough Council,YES,2020-12-31T00:01:00
-E07000037,High Peak Borough Council,YES,2020-12-31T00:01:00
-E07000038,North East Derbyshire District Council,YES,2020-12-31T00:01:00
-E07000039,South Derbyshire District Council,YES,2020-12-31T00:01:00
-E07000061,Eastbourne Borough Council,YES,2020-12-26T00:01:00
-E07000062,Hastings Borough Council,YES,2020-12-20T00:01:00
-E07000063,Lewes District Council,YES,2020-12-26T00:01:00
-E07000064,Rother District Council,YES,2020-12-20T00:01:00
-E07000065,Wealden District Council,YES,2020-12-26T00:01:00
-E07000066,Basildon Borough Council,YES,2020-12-20T00:01:00
-E07000067,Braintree District Council,YES,2020-12-20T00:01:00
-E07000068,Brentwood Borough Council,YES,2020-12-20T00:01:00
-E07000069,Castle Point Borough Council,YES,2020-12-20T00:01:00
-E07000070,Chelmsford City Council,YES,2020-12-20T00:01:00
-E07000071,Colchester Borough Council,YES,2020-12-26T00:01:00
-E07000072,Epping Forest District Council,YES,2020-12-20T00:01:00
-E07000073,Harlow Council,YES,2020-12-20T00:01:00
-E07000074,Maldon District Council,YES,2020-12-20T00:01:00
-E07000075,Rochford District Council,YES,2020-12-20T00:01:00
-E07000203,Mid Suffolk District Council,YES,2020-12-26T00:01:00
-E07000244,East Suffolk District Council,YES,2020-12-26T00:01:00
-E07000245,West Suffolk District Council,YES,2020-12-26T00:01:00
-E07000207,Elmbridge Borough Council,YES,2020-12-20T00:01:00
-E07000208,Epsom and Ewell Borough Council,YES,2020-12-20T00:01:00
-E07000209,Guildford Borough Council,YES,2020-12-20T00:01:00
-E07000210,Mole Valley District Council,YES,2020-12-20T00:01:00
-E07000211,Reigate and Banstead Borough Council,YES,2020-12-20T00:01:00
-E07000212,Runnymede Borough Council,YES,2020-12-20T00:01:00
-E07000213,Spelthorne Borough Council,YES,2020-12-20T00:01:00
-E07000214,Surrey Heath Borough Council,YES,2020-12-20T00:01:00
-E07000215,Tandridge District Council,YES,2020-12-20T00:01:00
-E07000216,Waverley Borough Council,YES,2020-12-26T00:01:00
-E07000217,Woking Borough Council,YES,2020-12-20T00:01:00
-E07000218,North Warwickshire Borough Council,YES,2020-12-31T00:01:00
-E07000219,Nuneaton and Bedworth Borough Council,YES,2020-12-31T00:01:00
-E07000220,Rugby Borough Council,YES,2020-12-31T00:01:00
-E07000221,Stratford-on-Avon District Council,YES,2020-12-31T00:01:00
-E07000222,Warwick District Council,YES,2020-12-31T00:01:00
-E07000223,Adur District Council,YES,2020-12-26T00:01:00
-E07000224,Arun District Council,YES,2020-12-26T00:01:00
-E07000225,Chichester District Council,YES,2020-12-26T00:01:00
-E07000226,Crawley Borough Council,YES,2020-12-26T00:01:00
-E07000227,Horsham District Council,YES,2020-12-26T00:01:00
-E07000228,Mid Sussex District Council,YES,2020-12-26T00:01:00
-E07000229,Worthing Borough Council,YES,2020-12-26T00:01:00
-E07000076,Tendring District Council,YES,2020-12-26T00:01:00
-E07000077,Uttlesford District Council,YES,2020-12-26T00:01:00
-E07000078,Cheltenham Borough Council,YES,2020-12-31T00:01:00
-E07000079,Cotswold District Council,YES,2020-12-31T00:01:00
-E07000080,Forest of Dean District Council,YES,2020-12-31T00:01:00
-E07000081,Gloucester City Council,YES,2020-12-31T00:01:00
-E07000082,Stroud District Council,YES,2020-12-31T00:01:00
-E07000083,Tewkesbury Borough Council,YES,2020-12-31T00:01:00
-E07000084,Basingstoke and Deane Borough Council,YES,2020-12-26T00:01:00
-E07000085,East Hampshire District Council,YES,2020-12-26T00:01:00
-E07000086,Eastleigh Borough Council,YES,2020-12-26T00:01:00
-E07000087,Fareham Borough Council,YES,2020-12-26T00:01:00
-E07000088,Gosport Borough Council,YES,2020-12-20T00:01:00
-E07000089,Hart District Council,YES,2020-12-26T00:01:00
-E07000090,Havant Borough Council,YES,2020-12-20T00:01:00
-E07000091,New Forest District Council,YES,2020-12-31T00:01:00
-E07000092,Rushmoor Borough Council,YES,2020-12-26T00:01:00
-E07000093,Test Valley Borough Council,YES,2020-12-26T00:01:00
-E07000094,Winchester City Council,YES,2020-12-26T00:01:00
-E07000095,Borough of Broxbourne,YES,2020-12-20T00:01:00
-E07000096,Dacorum Borough Council,YES,2020-12-20T00:01:00
-E07000098,Hertsmere Borough Council,YES,2020-12-20T00:01:00
-E07000099,North Hertfordshire District Council,YES,2020-12-20T00:01:00
-E07000102,Three Rivers District Council,YES,2020-12-20T00:01:00
-E07000103,Watford Borough Council,YES,2020-12-20T00:01:00
-E07000240,St Albans City and District Council,YES,2020-12-20T00:01:00
-E07000241,Welwyn Hatfield Council,YES,2020-12-20T00:01:00
-E07000242,East Hertfordshire District Council,YES,2020-12-20T00:01:00
-E07000243,Stevenage Borough Council,YES,2020-12-20T00:01:00
-E07000105,Ashford Borough Council,YES,2020-12-20T00:01:00
-E07000106,Canterbury City Council,YES,2020-12-20T00:01:00
-E07000107,Dartford Borough Council,YES,2020-12-20T00:01:00
-E07000108,Dover District Council,YES,2020-12-20T00:01:00
-E07000109,Gravesham Borough Council,YES,2020-12-20T00:01:00
-E07000110,Maidstone Borough Council,YES,2020-12-20T00:01:00
-E07000111,Sevenoaks District Council,YES,2020-12-20T00:01:00
-E07000112,Folkestone and Hythe,YES,2020-12-20T00:01:00
-E07000113,Swale Borough Council,YES,2020-12-20T00:01:00
-E07000114,Thanet District Council,YES,2020-12-20T00:01:00
-E07000115,Tonbridge and Malling Borough Council,YES,2020-12-20T00:01:00
-E07000116,Tunbridge Wells Borough Council,YES,2020-12-20T00:01:00
-E07000117,Burnley Borough Council,YES,2020-12-31T00:01:00
-E07000118,Chorley Council,YES,2020-12-31T00:01:00
-E07000119,Fylde Borough Council,YES,2020-12-31T00:01:00
-E07000120,Hyndburn Borough Council,YES,2020-12-31T00:01:00
-E07000121,Lancaster City Council,YES,2020-12-31T00:01:00
-E07000122,Pendle Borough Council,YES,2020-12-31T00:01:00
-E07000123,Preston City Council,YES,2020-12-31T00:01:00
-E07000124,Ribble Valley Borough Council,YES,2020-12-31T00:01:00
-E07000125,Rossendale Borough Council,YES,2020-12-31T00:01:00
-E07000126,South Ribble Borough Council,YES,2020-12-31T00:01:00
-E07000127,West Lancashire Borough Council,YES,2020-12-31T00:01:00
-E07000128,Wyre Council,YES,2020-12-31T00:01:00
-E07000129,Blaby District Council,YES,2020-12-31T00:01:00
-E07000130,Charnwood Borough Council,YES,2020-12-31T00:01:00
-E07000131,Harborough District Council,YES,2020-12-31T00:01:00
-E07000132,Hinckley and Bosworth Borough Council,YES,2020-12-31T00:01:00
-E07000133,Melton Borough Council,YES,2020-12-31T00:01:00
-E07000134,North West Leicestershire District Council,YES,2020-12-31T00:01:00
-E07000135,Oadby and Wigston District Council,YES,2020-12-31T00:01:00
-E07000136,Boston Borough Council,YES,2020-12-31T00:01:00
-E07000137,East Lindsey District Council,YES,2020-12-31T00:01:00
-E07000138,City of Lincoln Council,YES,2020-12-31T00:01:00
-E07000139,North Kesteven District Council,YES,2020-12-31T00:01:00
-E07000140,South Holland District Council,YES,2020-12-31T00:01:00
-E07000141,South Kesteven District Council,YES,2020-12-31T00:01:00
-E07000142,West Lindsey District Council,YES,2020-12-31T00:01:00
-E07000143,Breckland Council,YES,2020-12-26T00:01:00
-E07000144,Broadland District Council,YES,2020-12-26T00:01:00
-E07000145,Great Yarmouth Borough Council,YES,2020-12-26T00:01:00
-E07000146,Borough Council of Kings Lynn and West Norfolk,YES,2020-12-26T00:01:00
-E07000147,North Norfolk District Council,YES,2020-12-26T00:01:00
-E07000148,Norwich City Council,YES,2020-12-26T00:01:00
-E07000149,South Norfolk District Council,YES,2020-12-26T00:01:00
-E07000150,Corby Borough Council,YES,2020-12-31T00:01:00
-E07000151,Daventry District Council,YES,2020-12-31T00:01:00
-E07000152,East Northamptonshire Council,YES,2020-12-31T00:01:00
-E07000153,Kettering Borough Council,YES,2020-12-31T00:01:00
-E07000154,Northampton Borough Council,YES,2020-12-31T00:01:00
-E07000155,South Northamptonshire Council,YES,2020-12-31T00:01:00
-E07000156,Wellingborough Borough Council,YES,2020-12-31T00:01:00
-E07000170,Ashfield District Council,YES,2020-12-31T00:01:00
-E07000171,Bassetlaw District Council,YES,2020-12-31T00:01:00
-E07000172,Broxtowe Borough Council,YES,2020-12-31T00:01:00
-E07000173,Gedling Borough Council,YES,2020-12-31T00:01:00
-E07000174,Mansfield District Council,YES,2020-12-31T00:01:00
-E07000175,Newark and Sherwood District Council,YES,2020-12-31T00:01:00
-E07000176,Rushcliffe Borough Council,YES,2020-12-31T00:01:00
-E07000177,Cherwell District Council,YES,2020-12-26T00:01:00
-E07000178,Oxford City Council,YES,2020-12-26T00:01:00
-E07000179,South Oxfordshire District Council,YES,2020-12-26T00:01:00
-E07000180,Vale of White Horse District Council,YES,2020-12-26T00:01:00
-E07000181,West Oxfordshire District Council,YES,2020-12-26T00:01:00
-E07000187,Mendip District Council,YES,2020-12-31T00:01:00
-E07000188,Sedgemoor District Council,YES,2020-12-31T00:01:00
-E07000189,South Somerset District Council,YES,2020-12-31T00:01:00
-E07000246,Somerset West and Taunton District Council,YES,2020-12-31T00:01:00
-E07000192,Cannock Chase District Council,YES,2020-12-31T00:01:00
-E07000193,East Staffordshire Borough Council,YES,2020-12-31T00:01:00
-E07000194,Lichfield District Council,YES,2020-12-31T00:01:00
-E07000195,Newcastle-under-Lyme District Council,YES,2020-12-31T00:01:00
-E07000196,South Staffordshire Council,YES,2020-12-31T00:01:00
-E07000197,Stafford Borough Council,YES,2020-12-31T00:01:00
-E07000198,Staffordshire Moorlands District Council,YES,2020-12-31T00:01:00
-E07000199,Tamworth Borough Council,YES,2020-12-31T00:01:00
-E07000200,Babergh District Council,YES,2020-12-26T00:01:00
-E07000202,Ipswich Borough Council,YES,2020-12-26T00:01:00
+E06000045,Southampton City Council,YES,2021-01-04T00:01:00
 E06000046,Isle of Wight Council,YES,2020-12-31T00:01:00
+E06000046,Isle of Wight Council,YES,2021-01-04T00:01:00
+E06000047,Durham County Council,YES,2020-12-31T00:01:00
+E06000047,Durham County Council,YES,2021-01-04T00:01:00
+E06000049,Cheshire East Council,YES,2020-12-31T00:01:00
+E06000049,Cheshire East Council,YES,2021-01-04T00:01:00
+E06000050,Cheshire West and Chester Council,YES,2020-12-31T00:01:00
+E06000050,Cheshire West and Chester Council,YES,2021-01-04T00:01:00
+E06000051,Shropshire Council,YES,2021-01-04T00:01:00
+E06000052,Cornwall Council,YES,2021-01-04T00:01:00
+E06000053,Council of the Isles of Scilly,YES,2021-01-04T00:01:00
+E06000054,Wiltshire Council,YES,2021-01-04T00:01:00
+E06000055,Bedford Borough Council,YES,2020-12-20T00:01:00
+E06000055,Bedford Borough Council,YES,2021-01-04T00:01:00
+E06000056,Central Bedfordshire Council,YES,2020-12-20T00:01:00
+E06000056,Central Bedfordshire Council,YES,2021-01-04T00:01:00
+E06000057,Northumberland County Council,YES,2020-12-31T00:01:00
+E06000057,Northumberland County Council,YES,2021-01-04T00:01:00
+E06000058,"Bournemouth, Christchurch and Poole Council",YES,2020-12-31T00:01:00
+E06000058,"Bournemouth, Christchurch and Poole Council",YES,2021-01-04T00:01:00
+E06000059,Dorset Council,YES,2021-01-04T00:01:00
+E06000060,Buckinghamshire Council,YES,2020-12-20T00:01:00
+E06000060,Buckinghamshire Council,YES,2021-01-04T00:01:00
+E07000004,Buckinghamshire Council,YES,2020-12-20T00:01:00
+E07000004,Buckinghamshire Council,YES,2021-01-04T00:01:00
+E07000005,Buckinghamshire Council,YES,2020-12-20T00:01:00
+E07000005,Buckinghamshire Council,YES,2021-01-04T00:01:00
+E07000006,Buckinghamshire Council,YES,2020-12-20T00:01:00
+E07000006,Buckinghamshire Council,YES,2021-01-04T00:01:00
+E07000007,Buckinghamshire Council,YES,2020-12-20T00:01:00
+E07000007,Buckinghamshire Council,YES,2021-01-04T00:01:00
+E07000008,Cambridge City Council,YES,2020-12-26T00:01:00
+E07000008,Cambridge City Council,YES,2021-01-04T00:01:00
+E07000009,East Cambridgeshire District Council,YES,2020-12-26T00:01:00
+E07000009,East Cambridgeshire District Council,YES,2021-01-04T00:01:00
+E07000010,Fenland District Council,YES,2020-12-26T00:01:00
+E07000010,Fenland District Council,YES,2021-01-04T00:01:00
+E07000011,Huntingdonshire District Council,YES,2020-12-26T00:01:00
+E07000011,Huntingdonshire District Council,YES,2021-01-04T00:01:00
+E07000012,South Cambridgeshire District Council,YES,2020-12-26T00:01:00
+E07000012,South Cambridgeshire District Council,YES,2021-01-04T00:01:00
+E07000026,Allerdale Borough Council,YES,2020-12-31T00:01:00
+E07000026,Allerdale Borough Council,YES,2021-01-04T00:01:00
+E07000027,Borough of Barrow-in-Furness,YES,2020-12-31T00:01:00
+E07000027,Borough of Barrow-in-Furness,YES,2021-01-04T00:01:00
+E07000028,Carlisle City Council,YES,2020-12-31T00:01:00
+E07000028,Carlisle City Council,YES,2021-01-04T00:01:00
+E07000029,Copeland Borough Council,YES,2020-12-31T00:01:00
+E07000029,Copeland Borough Council,YES,2021-01-04T00:01:00
+E07000030,Eden District Council,YES,2020-12-31T00:01:00
+E07000030,Eden District Council,YES,2021-01-04T00:01:00
+E07000031,South Lakeland District Council,YES,2020-12-31T00:01:00
+E07000031,South Lakeland District Council,YES,2021-01-04T00:01:00
+E07000032,Amber Valley Borough Council,YES,2020-12-31T00:01:00
+E07000032,Amber Valley Borough Council,YES,2021-01-04T00:01:00
+E07000033,Bolsover District Council,YES,2020-12-31T00:01:00
+E07000033,Bolsover District Council,YES,2021-01-04T00:01:00
+E07000034,Chesterfield Borough Council,YES,2020-12-31T00:01:00
+E07000034,Chesterfield Borough Council,YES,2021-01-04T00:01:00
+E07000035,Derbyshire Dales District Council,YES,2020-12-31T00:01:00
+E07000035,Derbyshire Dales District Council,YES,2021-01-04T00:01:00
+E07000036,Erewash Borough Council,YES,2020-12-31T00:01:00
+E07000036,Erewash Borough Council,YES,2021-01-04T00:01:00
+E07000037,High Peak Borough Council,YES,2020-12-31T00:01:00
+E07000037,High Peak Borough Council,YES,2021-01-04T00:01:00
+E07000038,North East Derbyshire District Council,YES,2020-12-31T00:01:00
+E07000038,North East Derbyshire District Council,YES,2021-01-04T00:01:00
+E07000039,South Derbyshire District Council,YES,2020-12-31T00:01:00
+E07000039,South Derbyshire District Council,YES,2021-01-04T00:01:00
+E07000040,East Devon District Council,YES,2021-01-04T00:01:00
+E07000041,Exeter City Council,YES,2021-01-04T00:01:00
+E07000042,Mid Devon District Council,YES,2021-01-04T00:01:00
+E07000043,North Devon Council,YES,2021-01-04T00:01:00
+E07000044,South Hams District Council,YES,2021-01-04T00:01:00
+E07000045,Teignbridge District Council,YES,2021-01-04T00:01:00
+E07000046,Torridge District Council,YES,2021-01-04T00:01:00
+E07000047,West Devon Borough Council,YES,2021-01-04T00:01:00
+E07000061,Eastbourne Borough Council,YES,2020-12-26T00:01:00
+E07000061,Eastbourne Borough Council,YES,2021-01-04T00:01:00
+E07000062,Hastings Borough Council,YES,2020-12-20T00:01:00
+E07000062,Hastings Borough Council,YES,2021-01-04T00:01:00
+E07000063,Lewes District Council,YES,2020-12-26T00:01:00
+E07000063,Lewes District Council,YES,2021-01-04T00:01:00
+E07000064,Rother District Council,YES,2020-12-20T00:01:00
+E07000064,Rother District Council,YES,2021-01-04T00:01:00
+E07000065,Wealden District Council,YES,2020-12-26T00:01:00
+E07000065,Wealden District Council,YES,2021-01-04T00:01:00
+E07000066,Basildon Borough Council,YES,2020-12-20T00:01:00
+E07000066,Basildon Borough Council,YES,2021-01-04T00:01:00
+E07000067,Braintree District Council,YES,2020-12-20T00:01:00
+E07000067,Braintree District Council,YES,2021-01-04T00:01:00
+E07000068,Brentwood Borough Council,YES,2020-12-20T00:01:00
+E07000068,Brentwood Borough Council,YES,2021-01-04T00:01:00
+E07000069,Castle Point Borough Council,YES,2020-12-20T00:01:00
+E07000069,Castle Point Borough Council,YES,2021-01-04T00:01:00
+E07000070,Chelmsford City Council,YES,2020-12-20T00:01:00
+E07000070,Chelmsford City Council,YES,2021-01-04T00:01:00
+E07000071,Colchester Borough Council,YES,2020-12-26T00:01:00
+E07000071,Colchester Borough Council,YES,2021-01-04T00:01:00
+E07000072,Epping Forest District Council,YES,2020-12-20T00:01:00
+E07000072,Epping Forest District Council,YES,2021-01-04T00:01:00
+E07000073,Harlow Council,YES,2020-12-20T00:01:00
+E07000073,Harlow Council,YES,2021-01-04T00:01:00
+E07000074,Maldon District Council,YES,2020-12-20T00:01:00
+E07000074,Maldon District Council,YES,2021-01-04T00:01:00
+E07000075,Rochford District Council,YES,2020-12-20T00:01:00
+E07000075,Rochford District Council,YES,2021-01-04T00:01:00
+E07000076,Tendring District Council,YES,2020-12-26T00:01:00
+E07000076,Tendring District Council,YES,2021-01-04T00:01:00
+E07000077,Uttlesford District Council,YES,2020-12-26T00:01:00
+E07000077,Uttlesford District Council,YES,2021-01-04T00:01:00
+E07000078,Cheltenham Borough Council,YES,2020-12-31T00:01:00
+E07000078,Cheltenham Borough Council,YES,2021-01-04T00:01:00
+E07000079,Cotswold District Council,YES,2020-12-31T00:01:00
+E07000079,Cotswold District Council,YES,2021-01-04T00:01:00
+E07000080,Forest of Dean District Council,YES,2020-12-31T00:01:00
+E07000080,Forest of Dean District Council,YES,2021-01-04T00:01:00
+E07000081,Gloucester City Council,YES,2020-12-31T00:01:00
+E07000081,Gloucester City Council,YES,2021-01-04T00:01:00
+E07000082,Stroud District Council,YES,2020-12-31T00:01:00
+E07000082,Stroud District Council,YES,2021-01-04T00:01:00
+E07000083,Tewkesbury Borough Council,YES,2020-12-31T00:01:00
+E07000083,Tewkesbury Borough Council,YES,2021-01-04T00:01:00
+E07000084,Basingstoke and Deane Borough Council,YES,2020-12-26T00:01:00
+E07000084,Basingstoke and Deane Borough Council,YES,2021-01-04T00:01:00
+E07000085,East Hampshire District Council,YES,2020-12-26T00:01:00
+E07000085,East Hampshire District Council,YES,2021-01-04T00:01:00
+E07000086,Eastleigh Borough Council,YES,2020-12-26T00:01:00
+E07000086,Eastleigh Borough Council,YES,2021-01-04T00:01:00
+E07000087,Fareham Borough Council,YES,2020-12-26T00:01:00
+E07000087,Fareham Borough Council,YES,2021-01-04T00:01:00
+E07000088,Gosport Borough Council,YES,2020-12-20T00:01:00
+E07000088,Gosport Borough Council,YES,2021-01-04T00:01:00
+E07000089,Hart District Council,YES,2020-12-26T00:01:00
+E07000089,Hart District Council,YES,2021-01-04T00:01:00
+E07000090,Havant Borough Council,YES,2020-12-20T00:01:00
+E07000090,Havant Borough Council,YES,2021-01-04T00:01:00
+E07000091,New Forest District Council,YES,2020-12-31T00:01:00
+E07000091,New Forest District Council,YES,2021-01-04T00:01:00
+E07000092,Rushmoor Borough Council,YES,2020-12-26T00:01:00
+E07000092,Rushmoor Borough Council,YES,2021-01-04T00:01:00
+E07000093,Test Valley Borough Council,YES,2020-12-26T00:01:00
+E07000093,Test Valley Borough Council,YES,2021-01-04T00:01:00
+E07000094,Winchester City Council,YES,2020-12-26T00:01:00
+E07000094,Winchester City Council,YES,2021-01-04T00:01:00
+E07000095,Borough of Broxbourne,YES,2020-12-20T00:01:00
+E07000095,Borough of Broxbourne,YES,2021-01-04T00:01:00
+E07000096,Dacorum Borough Council,YES,2020-12-20T00:01:00
+E07000096,Dacorum Borough Council,YES,2021-01-04T00:01:00
+E07000098,Hertsmere Borough Council,YES,2020-12-20T00:01:00
+E07000098,Hertsmere Borough Council,YES,2021-01-04T00:01:00
+E07000099,North Hertfordshire District Council,YES,2020-12-20T00:01:00
+E07000099,North Hertfordshire District Council,YES,2021-01-04T00:01:00
+E07000102,Three Rivers District Council,YES,2020-12-20T00:01:00
+E07000102,Three Rivers District Council,YES,2021-01-04T00:01:00
+E07000103,Watford Borough Council,YES,2020-12-20T00:01:00
+E07000103,Watford Borough Council,YES,2021-01-04T00:01:00
+E07000105,Ashford Borough Council,YES,2020-12-20T00:01:00
+E07000105,Ashford Borough Council,YES,2021-01-04T00:01:00
+E07000106,Canterbury City Council,YES,2020-12-20T00:01:00
+E07000106,Canterbury City Council,YES,2021-01-04T00:01:00
+E07000107,Dartford Borough Council,YES,2020-12-20T00:01:00
+E07000107,Dartford Borough Council,YES,2021-01-04T00:01:00
+E07000108,Dover District Council,YES,2020-12-20T00:01:00
+E07000108,Dover District Council,YES,2021-01-04T00:01:00
+E07000109,Gravesham Borough Council,YES,2020-12-20T00:01:00
+E07000109,Gravesham Borough Council,YES,2021-01-04T00:01:00
+E07000110,Maidstone Borough Council,YES,2020-12-20T00:01:00
+E07000110,Maidstone Borough Council,YES,2021-01-04T00:01:00
+E07000111,Sevenoaks District Council,YES,2020-12-20T00:01:00
+E07000111,Sevenoaks District Council,YES,2021-01-04T00:01:00
+E07000112,Folkestone and Hythe,YES,2020-12-20T00:01:00
+E07000112,Folkestone and Hythe,YES,2021-01-04T00:01:00
+E07000113,Swale Borough Council,YES,2020-12-20T00:01:00
+E07000113,Swale Borough Council,YES,2021-01-04T00:01:00
+E07000114,Thanet District Council,YES,2020-12-20T00:01:00
+E07000114,Thanet District Council,YES,2021-01-04T00:01:00
+E07000115,Tonbridge and Malling Borough Council,YES,2020-12-20T00:01:00
+E07000115,Tonbridge and Malling Borough Council,YES,2021-01-04T00:01:00
+E07000116,Tunbridge Wells Borough Council,YES,2020-12-20T00:01:00
+E07000116,Tunbridge Wells Borough Council,YES,2021-01-04T00:01:00
+E07000117,Burnley Borough Council,YES,2020-12-31T00:01:00
+E07000117,Burnley Borough Council,YES,2021-01-04T00:01:00
+E07000118,Chorley Council,YES,2020-12-31T00:01:00
+E07000118,Chorley Council,YES,2021-01-04T00:01:00
+E07000119,Fylde Borough Council,YES,2020-12-31T00:01:00
+E07000119,Fylde Borough Council,YES,2021-01-04T00:01:00
+E07000120,Hyndburn Borough Council,YES,2020-12-31T00:01:00
+E07000120,Hyndburn Borough Council,YES,2021-01-04T00:01:00
+E07000121,Lancaster City Council,YES,2020-12-31T00:01:00
+E07000121,Lancaster City Council,YES,2021-01-04T00:01:00
+E07000122,Pendle Borough Council,YES,2020-12-31T00:01:00
+E07000122,Pendle Borough Council,YES,2021-01-04T00:01:00
+E07000123,Preston City Council,YES,2020-12-31T00:01:00
+E07000123,Preston City Council,YES,2021-01-04T00:01:00
+E07000124,Ribble Valley Borough Council,YES,2020-12-31T00:01:00
+E07000124,Ribble Valley Borough Council,YES,2021-01-04T00:01:00
+E07000125,Rossendale Borough Council,YES,2020-12-31T00:01:00
+E07000125,Rossendale Borough Council,YES,2021-01-04T00:01:00
+E07000126,South Ribble Borough Council,YES,2020-12-31T00:01:00
+E07000126,South Ribble Borough Council,YES,2021-01-04T00:01:00
+E07000127,West Lancashire Borough Council,YES,2020-12-31T00:01:00
+E07000127,West Lancashire Borough Council,YES,2021-01-04T00:01:00
+E07000128,Wyre Council,YES,2020-12-31T00:01:00
+E07000128,Wyre Council,YES,2021-01-04T00:01:00
+E07000129,Blaby District Council,YES,2020-12-31T00:01:00
+E07000129,Blaby District Council,YES,2021-01-04T00:01:00
+E07000130,Charnwood Borough Council,YES,2020-12-31T00:01:00
+E07000130,Charnwood Borough Council,YES,2021-01-04T00:01:00
+E07000131,Harborough District Council,YES,2020-12-31T00:01:00
+E07000131,Harborough District Council,YES,2021-01-04T00:01:00
+E07000132,Hinckley and Bosworth Borough Council,YES,2020-12-31T00:01:00
+E07000132,Hinckley and Bosworth Borough Council,YES,2021-01-04T00:01:00
+E07000133,Melton Borough Council,YES,2020-12-31T00:01:00
+E07000133,Melton Borough Council,YES,2021-01-04T00:01:00
+E07000134,North West Leicestershire District Council,YES,2020-12-31T00:01:00
+E07000134,North West Leicestershire District Council,YES,2021-01-04T00:01:00
+E07000135,Oadby and Wigston District Council,YES,2020-12-31T00:01:00
+E07000135,Oadby and Wigston District Council,YES,2021-01-04T00:01:00
+E07000136,Boston Borough Council,YES,2020-12-31T00:01:00
+E07000136,Boston Borough Council,YES,2021-01-04T00:01:00
+E07000137,East Lindsey District Council,YES,2020-12-31T00:01:00
+E07000137,East Lindsey District Council,YES,2021-01-04T00:01:00
+E07000138,City of Lincoln Council,YES,2020-12-31T00:01:00
+E07000138,City of Lincoln Council,YES,2021-01-04T00:01:00
+E07000139,North Kesteven District Council,YES,2020-12-31T00:01:00
+E07000139,North Kesteven District Council,YES,2021-01-04T00:01:00
+E07000140,South Holland District Council,YES,2020-12-31T00:01:00
+E07000140,South Holland District Council,YES,2021-01-04T00:01:00
+E07000141,South Kesteven District Council,YES,2020-12-31T00:01:00
+E07000141,South Kesteven District Council,YES,2021-01-04T00:01:00
+E07000142,West Lindsey District Council,YES,2020-12-31T00:01:00
+E07000142,West Lindsey District Council,YES,2021-01-04T00:01:00
+E07000143,Breckland Council,YES,2020-12-26T00:01:00
+E07000143,Breckland Council,YES,2021-01-04T00:01:00
+E07000144,Broadland District Council,YES,2020-12-26T00:01:00
+E07000144,Broadland District Council,YES,2021-01-04T00:01:00
+E07000145,Great Yarmouth Borough Council,YES,2020-12-26T00:01:00
+E07000145,Great Yarmouth Borough Council,YES,2021-01-04T00:01:00
+E07000146,Borough Council of Kings Lynn and West Norfolk,YES,2020-12-26T00:01:00
+E07000146,Borough Council of Kings Lynn and West Norfolk,YES,2021-01-04T00:01:00
+E07000147,North Norfolk District Council,YES,2020-12-26T00:01:00
+E07000147,North Norfolk District Council,YES,2021-01-04T00:01:00
+E07000148,Norwich City Council,YES,2020-12-26T00:01:00
+E07000148,Norwich City Council,YES,2021-01-04T00:01:00
+E07000149,South Norfolk District Council,YES,2020-12-26T00:01:00
+E07000149,South Norfolk District Council,YES,2021-01-04T00:01:00
+E07000150,Corby Borough Council,YES,2020-12-31T00:01:00
+E07000150,Corby Borough Council,YES,2021-01-04T00:01:00
+E07000151,Daventry District Council,YES,2020-12-31T00:01:00
+E07000151,Daventry District Council,YES,2021-01-04T00:01:00
+E07000152,East Northamptonshire Council,YES,2020-12-31T00:01:00
+E07000152,East Northamptonshire Council,YES,2021-01-04T00:01:00
+E07000153,Kettering Borough Council,YES,2020-12-31T00:01:00
+E07000153,Kettering Borough Council,YES,2021-01-04T00:01:00
+E07000154,Northampton Borough Council,YES,2020-12-31T00:01:00
+E07000154,Northampton Borough Council,YES,2021-01-04T00:01:00
+E07000155,South Northamptonshire Council,YES,2020-12-31T00:01:00
+E07000155,South Northamptonshire Council,YES,2021-01-04T00:01:00
+E07000156,Wellingborough Borough Council,YES,2020-12-31T00:01:00
+E07000156,Wellingborough Borough Council,YES,2021-01-04T00:01:00
+E07000163,Craven District Council,YES,2021-01-04T00:01:00
+E07000164,Hambleton District Council,YES,2021-01-04T00:01:00
+E07000165,Harrogate Borough Council,YES,2021-01-04T00:01:00
+E07000166,Richmondshire District Council,YES,2021-01-04T00:01:00
+E07000167,Ryedale District Council,YES,2021-01-04T00:01:00
+E07000168,Scarborough Borough Council,YES,2021-01-04T00:01:00
+E07000169,Selby District Council,YES,2021-01-04T00:01:00
+E07000170,Ashfield District Council,YES,2020-12-31T00:01:00
+E07000170,Ashfield District Council,YES,2021-01-04T00:01:00
+E07000171,Bassetlaw District Council,YES,2020-12-31T00:01:00
+E07000171,Bassetlaw District Council,YES,2021-01-04T00:01:00
+E07000172,Broxtowe Borough Council,YES,2020-12-31T00:01:00
+E07000172,Broxtowe Borough Council,YES,2021-01-04T00:01:00
+E07000173,Gedling Borough Council,YES,2020-12-31T00:01:00
+E07000173,Gedling Borough Council,YES,2021-01-04T00:01:00
+E07000174,Mansfield District Council,YES,2020-12-31T00:01:00
+E07000174,Mansfield District Council,YES,2021-01-04T00:01:00
+E07000175,Newark and Sherwood District Council,YES,2020-12-31T00:01:00
+E07000175,Newark and Sherwood District Council,YES,2021-01-04T00:01:00
+E07000176,Rushcliffe Borough Council,YES,2020-12-31T00:01:00
+E07000176,Rushcliffe Borough Council,YES,2021-01-04T00:01:00
+E07000177,Cherwell District Council,YES,2020-12-26T00:01:00
+E07000177,Cherwell District Council,YES,2021-01-04T00:01:00
+E07000178,Oxford City Council,YES,2020-12-26T00:01:00
+E07000178,Oxford City Council,YES,2021-01-04T00:01:00
+E07000179,South Oxfordshire District Council,YES,2020-12-26T00:01:00
+E07000179,South Oxfordshire District Council,YES,2021-01-04T00:01:00
+E07000180,Vale of White Horse District Council,YES,2020-12-26T00:01:00
+E07000180,Vale of White Horse District Council,YES,2021-01-04T00:01:00
+E07000181,West Oxfordshire District Council,YES,2020-12-26T00:01:00
+E07000181,West Oxfordshire District Council,YES,2021-01-04T00:01:00
+E07000187,Mendip District Council,YES,2020-12-31T00:01:00
+E07000187,Mendip District Council,YES,2021-01-04T00:01:00
+E07000188,Sedgemoor District Council,YES,2020-12-31T00:01:00
+E07000188,Sedgemoor District Council,YES,2021-01-04T00:01:00
+E07000189,South Somerset District Council,YES,2020-12-31T00:01:00
+E07000189,South Somerset District Council,YES,2021-01-04T00:01:00
+E07000192,Cannock Chase District Council,YES,2020-12-31T00:01:00
+E07000192,Cannock Chase District Council,YES,2021-01-04T00:01:00
+E07000193,East Staffordshire Borough Council,YES,2020-12-31T00:01:00
+E07000193,East Staffordshire Borough Council,YES,2021-01-04T00:01:00
+E07000194,Lichfield District Council,YES,2020-12-31T00:01:00
+E07000194,Lichfield District Council,YES,2021-01-04T00:01:00
+E07000195,Newcastle-under-Lyme District Council,YES,2020-12-31T00:01:00
+E07000195,Newcastle-under-Lyme District Council,YES,2021-01-04T00:01:00
+E07000196,South Staffordshire Council,YES,2020-12-31T00:01:00
+E07000196,South Staffordshire Council,YES,2021-01-04T00:01:00
+E07000197,Stafford Borough Council,YES,2020-12-31T00:01:00
+E07000197,Stafford Borough Council,YES,2021-01-04T00:01:00
+E07000198,Staffordshire Moorlands District Council,YES,2020-12-31T00:01:00
+E07000198,Staffordshire Moorlands District Council,YES,2021-01-04T00:01:00
+E07000199,Tamworth Borough Council,YES,2020-12-31T00:01:00
+E07000199,Tamworth Borough Council,YES,2021-01-04T00:01:00
+E07000200,Babergh District Council,YES,2020-12-26T00:01:00
+E07000200,Babergh District Council,YES,2021-01-04T00:01:00
+E07000202,Ipswich Borough Council,YES,2020-12-26T00:01:00
+E07000202,Ipswich Borough Council,YES,2021-01-04T00:01:00
+E07000203,Mid Suffolk District Council,YES,2020-12-26T00:01:00
+E07000203,Mid Suffolk District Council,YES,2021-01-04T00:01:00
+E07000207,Elmbridge Borough Council,YES,2020-12-20T00:01:00
+E07000207,Elmbridge Borough Council,YES,2021-01-04T00:01:00
+E07000208,Epsom and Ewell Borough Council,YES,2020-12-20T00:01:00
+E07000208,Epsom and Ewell Borough Council,YES,2021-01-04T00:01:00
+E07000209,Guildford Borough Council,YES,2020-12-20T00:01:00
+E07000209,Guildford Borough Council,YES,2021-01-04T00:01:00
+E07000210,Mole Valley District Council,YES,2020-12-20T00:01:00
+E07000210,Mole Valley District Council,YES,2021-01-04T00:01:00
+E07000211,Reigate and Banstead Borough Council,YES,2020-12-20T00:01:00
+E07000211,Reigate and Banstead Borough Council,YES,2021-01-04T00:01:00
+E07000212,Runnymede Borough Council,YES,2020-12-20T00:01:00
+E07000212,Runnymede Borough Council,YES,2021-01-04T00:01:00
+E07000213,Spelthorne Borough Council,YES,2020-12-20T00:01:00
+E07000213,Spelthorne Borough Council,YES,2021-01-04T00:01:00
+E07000214,Surrey Heath Borough Council,YES,2020-12-20T00:01:00
+E07000214,Surrey Heath Borough Council,YES,2021-01-04T00:01:00
+E07000215,Tandridge District Council,YES,2020-12-20T00:01:00
+E07000215,Tandridge District Council,YES,2021-01-04T00:01:00
+E07000216,Waverley Borough Council,YES,2020-12-26T00:01:00
+E07000216,Waverley Borough Council,YES,2021-01-04T00:01:00
+E07000217,Woking Borough Council,YES,2020-12-20T00:01:00
+E07000217,Woking Borough Council,YES,2021-01-04T00:01:00
+E07000218,North Warwickshire Borough Council,YES,2020-12-31T00:01:00
+E07000218,North Warwickshire Borough Council,YES,2021-01-04T00:01:00
+E07000219,Nuneaton and Bedworth Borough Council,YES,2020-12-31T00:01:00
+E07000219,Nuneaton and Bedworth Borough Council,YES,2021-01-04T00:01:00
+E07000220,Rugby Borough Council,YES,2020-12-31T00:01:00
+E07000220,Rugby Borough Council,YES,2021-01-04T00:01:00
+E07000221,Stratford-on-Avon District Council,YES,2020-12-31T00:01:00
+E07000221,Stratford-on-Avon District Council,YES,2021-01-04T00:01:00
+E07000222,Warwick District Council,YES,2020-12-31T00:01:00
+E07000222,Warwick District Council,YES,2021-01-04T00:01:00
+E07000223,Adur District Council,YES,2020-12-26T00:01:00
+E07000223,Adur District Council,YES,2021-01-04T00:01:00
+E07000224,Arun District Council,YES,2020-12-26T00:01:00
+E07000224,Arun District Council,YES,2021-01-04T00:01:00
+E07000225,Chichester District Council,YES,2020-12-26T00:01:00
+E07000225,Chichester District Council,YES,2021-01-04T00:01:00
+E07000226,Crawley Borough Council,YES,2020-12-26T00:01:00
+E07000226,Crawley Borough Council,YES,2021-01-04T00:01:00
+E07000227,Horsham District Council,YES,2020-12-26T00:01:00
+E07000227,Horsham District Council,YES,2021-01-04T00:01:00
+E07000228,Mid Sussex District Council,YES,2020-12-26T00:01:00
+E07000228,Mid Sussex District Council,YES,2021-01-04T00:01:00
+E07000229,Worthing Borough Council,YES,2020-12-26T00:01:00
+E07000229,Worthing Borough Council,YES,2021-01-04T00:01:00
+E07000234,Bromsgrove District Council,YES,2021-01-04T00:01:00
+E07000235,Malvern Hills District Council,YES,2021-01-04T00:01:00
+E07000236,Redditch Borough Council,YES,2021-01-04T00:01:00
+E07000237,Worcester City Council,YES,2021-01-04T00:01:00
+E07000238,Wychavon District Council,YES,2021-01-04T00:01:00
+E07000239,Wyre Forest District Council,YES,2021-01-04T00:01:00
+E07000240,St Albans City and District Council,YES,2020-12-20T00:01:00
+E07000240,St Albans City and District Council,YES,2021-01-04T00:01:00
+E07000241,Welwyn Hatfield Council,YES,2020-12-20T00:01:00
+E07000241,Welwyn Hatfield Council,YES,2021-01-04T00:01:00
+E07000242,East Hertfordshire District Council,YES,2020-12-20T00:01:00
+E07000242,East Hertfordshire District Council,YES,2021-01-04T00:01:00
+E07000243,Stevenage Borough Council,YES,2020-12-20T00:01:00
+E07000243,Stevenage Borough Council,YES,2021-01-04T00:01:00
+E07000244,East Suffolk District Council,YES,2020-12-26T00:01:00
+E07000244,East Suffolk District Council,YES,2021-01-04T00:01:00
+E07000245,West Suffolk District Council,YES,2020-12-26T00:01:00
+E07000245,West Suffolk District Council,YES,2021-01-04T00:01:00
+E07000246,Somerset West and Taunton District Council,YES,2020-12-31T00:01:00
+E07000246,Somerset West and Taunton District Council,YES,2021-01-04T00:01:00
+E08000001,Bolton Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000001,Bolton Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E08000002,Bury Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000002,Bury Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E08000003,Manchester City Council,YES,2020-12-31T00:01:00
+E08000003,Manchester City Council,YES,2021-01-04T00:01:00
+E08000004,Oldham Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000004,Oldham Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E08000005,Rochdale Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000005,Rochdale Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E08000006,Salford City Council,YES,2020-12-31T00:01:00
+E08000006,Salford City Council,YES,2021-01-04T00:01:00
+E08000007,Stockport Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000007,Stockport Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E08000008,Tameside Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000008,Tameside Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E08000009,Trafford Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000009,Trafford Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E08000010,Wigan Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000010,Wigan Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E08000011,Knowsley Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E08000012,Liverpool City Council,YES,2021-01-04T00:01:00
+E08000013,St Helens Council,YES,2021-01-04T00:01:00
+E08000014,Sefton Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E08000015,Wirral Council,YES,2021-01-04T00:01:00
+E08000016,Barnsley Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E08000017,Doncaster Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E08000018,Rotherham Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E08000019,Sheffield City Council,YES,2021-01-04T00:01:00
+E08000021,Newcastle City Council,YES,2020-12-31T00:01:00
+E08000021,Newcastle City Council,YES,2021-01-04T00:01:00
+E08000022,North Tyneside Council,YES,2020-12-31T00:01:00
+E08000022,North Tyneside Council,YES,2021-01-04T00:01:00
+E08000023,South Tyneside Council,YES,2020-12-31T00:01:00
+E08000023,South Tyneside Council,YES,2021-01-04T00:01:00
+E08000024,Sunderland City Council,YES,2020-12-31T00:01:00
+E08000024,Sunderland City Council,YES,2021-01-04T00:01:00
+E08000025,Birmingham City Council,YES,2020-12-31T00:01:00
+E08000025,Birmingham City Council,YES,2021-01-04T00:01:00
+E08000026,Coventry City Council,YES,2020-12-31T00:01:00
+E08000026,Coventry City Council,YES,2021-01-04T00:01:00
+E08000027,Dudley Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000027,Dudley Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E08000028,Sandwell Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000028,Sandwell Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E08000029,Solihull Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000029,Solihull Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E08000030,Walsall Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000030,Walsall Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E08000031,City of Wolverhampton Council,YES,2020-12-31T00:01:00
+E08000031,City of Wolverhampton Council,YES,2021-01-04T00:01:00
+E08000032,City of Bradford Metropolitan District Council,YES,2021-01-04T00:01:00
+E08000033,Calderdale Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E08000034,Kirklees Council,YES,2021-01-04T00:01:00
+E08000035,Leeds City Council,YES,2021-01-04T00:01:00
+E08000036,Wakefield Metropolitan District Council,YES,2021-01-04T00:01:00
+E08000037,Gateshead Metropolitan Borough Council,YES,2020-12-31T00:01:00
+E08000037,Gateshead Metropolitan Borough Council,YES,2021-01-04T00:01:00
+E09000001,City of London Corporation,YES,2020-12-20T00:01:00
+E09000001,City of London Corporation,YES,2021-01-04T00:01:00
+E09000002,London Borough of Barking and Dagenham,YES,2020-12-20T00:01:00
+E09000002,London Borough of Barking and Dagenham,YES,2021-01-04T00:01:00
+E09000003,London Borough of Barnet,YES,2020-12-20T00:01:00
+E09000003,London Borough of Barnet,YES,2021-01-04T00:01:00
+E09000004,London Borough of Bexley,YES,2020-12-20T00:01:00
+E09000004,London Borough of Bexley,YES,2021-01-04T00:01:00
+E09000005,London Borough of Brent,YES,2020-12-20T00:01:00
+E09000005,London Borough of Brent,YES,2021-01-04T00:01:00
+E09000006,London Borough of Bromley,YES,2020-12-20T00:01:00
+E09000006,London Borough of Bromley,YES,2021-01-04T00:01:00
+E09000007,London Borough of Camden,YES,2020-12-20T00:01:00
+E09000007,London Borough of Camden,YES,2021-01-04T00:01:00
+E09000008,London Borough of Croydon,YES,2020-12-20T00:01:00
+E09000008,London Borough of Croydon,YES,2021-01-04T00:01:00
+E09000009,London Borough of Ealing,YES,2020-12-20T00:01:00
+E09000009,London Borough of Ealing,YES,2021-01-04T00:01:00
+E09000010,London Borough of Enfield,YES,2020-12-20T00:01:00
+E09000010,London Borough of Enfield,YES,2021-01-04T00:01:00
+E09000011,Royal Borough of Greenwich,YES,2020-12-20T00:01:00
+E09000011,Royal Borough of Greenwich,YES,2021-01-04T00:01:00
+E09000012,London Borough of Hackney,YES,2020-12-20T00:01:00
+E09000012,London Borough of Hackney,YES,2021-01-04T00:01:00
+E09000013,London Borough of Hammersmith & Fulham,YES,2020-12-20T00:01:00
+E09000013,London Borough of Hammersmith & Fulham,YES,2021-01-04T00:01:00
+E09000014,London Borough of Haringey,YES,2020-12-20T00:01:00
+E09000014,London Borough of Haringey,YES,2021-01-04T00:01:00
+E09000015,London Borough of Harrow,YES,2020-12-20T00:01:00
+E09000015,London Borough of Harrow,YES,2021-01-04T00:01:00
+E09000016,London Borough of Havering,YES,2020-12-20T00:01:00
+E09000016,London Borough of Havering,YES,2021-01-04T00:01:00
+E09000017,London Borough of Hillingdon,YES,2020-12-20T00:01:00
+E09000017,London Borough of Hillingdon,YES,2021-01-04T00:01:00
+E09000018,London Borough of Hounslow,YES,2020-12-20T00:01:00
+E09000018,London Borough of Hounslow,YES,2021-01-04T00:01:00
+E09000019,London Borough of Islington,YES,2020-12-20T00:01:00
+E09000019,London Borough of Islington,YES,2021-01-04T00:01:00
+E09000020,Royal Borough of Kensington and Chelsea,YES,2020-12-20T00:01:00
+E09000020,Royal Borough of Kensington and Chelsea,YES,2021-01-04T00:01:00
+E09000021,Royal Borough of Kingston upon Thames,YES,2020-12-20T00:01:00
+E09000021,Royal Borough of Kingston upon Thames,YES,2021-01-04T00:01:00
+E09000022,London Borough of Lambeth,YES,2020-12-20T00:01:00
+E09000022,London Borough of Lambeth,YES,2021-01-04T00:01:00
+E09000023,London Borough of Lewisham,YES,2020-12-20T00:01:00
+E09000023,London Borough of Lewisham,YES,2021-01-04T00:01:00
+E09000024,London Borough of Merton,YES,2020-12-20T00:01:00
+E09000024,London Borough of Merton,YES,2021-01-04T00:01:00
+E09000025,London Borough of Newham,YES,2020-12-20T00:01:00
+E09000025,London Borough of Newham,YES,2021-01-04T00:01:00
+E09000026,London Borough of Redbridge,YES,2020-12-20T00:01:00
+E09000026,London Borough of Redbridge,YES,2021-01-04T00:01:00
+E09000027,London Borough of Richmond upon Thames,YES,2020-12-20T00:01:00
+E09000027,London Borough of Richmond upon Thames,YES,2021-01-04T00:01:00
+E09000028,London Borough of Southwark,YES,2020-12-20T00:01:00
+E09000028,London Borough of Southwark,YES,2021-01-04T00:01:00
+E09000029,London Borough of Sutton,YES,2020-12-20T00:01:00
+E09000029,London Borough of Sutton,YES,2021-01-04T00:01:00
+E09000030,London Borough of Tower Hamlets,YES,2020-12-20T00:01:00
+E09000030,London Borough of Tower Hamlets,YES,2021-01-04T00:01:00
+E09000031,London Borough of Waltham Forest,YES,2020-12-20T00:01:00
+E09000031,London Borough of Waltham Forest,YES,2021-01-04T00:01:00
+E09000032,London Borough of Wandsworth,YES,2020-12-20T00:01:00
+E09000032,London Borough of Wandsworth,YES,2021-01-04T00:01:00
+E09000033,City of Westminster,YES,2020-12-20T00:01:00
+E09000033,City of Westminster,YES,2021-01-04T00:01:00

--- a/vulnerable_people_form/integrations/ladcode_shielding_advice_lookup.py
+++ b/vulnerable_people_form/integrations/ladcode_shielding_advice_lookup.py
@@ -6,7 +6,7 @@ from vulnerable_people_form.form_pages.shared.logger_utils import create_log_mes
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_NATIONAL_SHIELDING_ADVICE = 'NO'
+DEFAULT_NATIONAL_SHIELDING_ADVICE = False
 FIELDNAMES = [
     'ladcode',
     'ladname',
@@ -29,7 +29,7 @@ class LocalAuthorityShielding:
                                                    key=lambda k: (k['ladcode'], k['start_datetime_utc']),
                                                    reverse=False)
 
-    def get_shielding_advice_by_ladcode(self, ladcode: str):
+    def is_la_shielding(self, ladcode: str):
         """
         fetches the shielding advice status for supplied LAD Code
         """
@@ -44,7 +44,7 @@ class LocalAuthorityShielding:
         logger.info(create_log_message(
             log_event_names["SHIELDING_ADVICE_FOR_LADCODE_SUCCESS"],
             f"{ladcode} has Shielding Advice {shielding_advice}"))
-        return shielding_advice
+        return shielding_advice == 'YES'
 
     def get_all_records_for_ladcode(self, ladcode):
         """

--- a/vulnerable_people_form/integrations/location_eligibility.py
+++ b/vulnerable_people_form/integrations/location_eligibility.py
@@ -103,7 +103,7 @@ def get_ladcode_from_postcode(postcode):
 def get_ladcode_from_uprn(uprn):
     records = execute_sql(
             "CALL cv_ref.uprn_to_ladcode(:uprn)",
-            (generate_string_parameter("uprn", uprn),),)["records"]
+            (generate_int_parameter("uprn", uprn),),)["records"]
 
     if not records:
         logger.info(create_log_message(


### PR DESCRIPTION

Add shielding advice CSV

This can be generated from GOV.UK's data[1] using the following one-liner.

```
{ echo "ladcode,ladname,shielding_advice,start_datetime_utc";  yq -r '.  | to_entries | .[] | {"key": .key, "name": .value.name, "restrictions": .value.restrictions[]} | select(.restrictions.alert_level == 4) | [.key, .name, "YES", .restrictions.start_date + "T" + .restrictions.start_time + ":00"] | @csv' local_restrictions.yml | csvformat
```

This assumes:

- people in an LA should shield if and only if they're in tier 4
- local time is currently the same as UTC

[1] https://github.com/alphagov/collections/blob/master/config/local_restrictions.yml