### PR TITLE
Remove journey progress check when tiering enabled

### DIFF
--- a/vulnerable_people_form/form_pages/nhs_registration_callback.py
+++ b/vulnerable_people_form/form_pages/nhs_registration_callback.py
@@ -76,7 +76,7 @@ def get_nhs_registration_callback():
     session["form_answers"]["nhs_number"] = nhs_user_info["nhs_number"]
 
     if load_answers_into_session_if_available():
-        if current_app.is_tiering_logic_enabled and journey_progress is JourneyProgress.NHS_NUMBER:
+        if current_app.is_tiering_logic_enabled:
             return get_redirect_for_returning_user_based_on_tier()
         return get_redirect_to_terminal_page()
 


### PR DESCRIPTION
When tiering is enabled and an existing nhs login registration exists it should always go down the new route so that it can check the tier status and direct the user accordingly in the UI