### PR TITLE
Feature/improved address formatting

### DIFF
--- a/tests/integrations/test_postcode_lookup_helper.py
+++ b/tests/integrations/test_postcode_lookup_helper.py
@@ -1,13 +1,14 @@
-import pytest
-import requests
 import json
 from unittest import mock
+
+import pytest
+import requests
 from flask import Flask
 
 from vulnerable_people_form.integrations.postcode_lookup_helper import \
-        entry_is_a_postal_address, \
-        get_addresses_from_postcode, \
-        PostcodeNotFound, ErrorFindingAddress
+    entry_is_a_postal_address, \
+    get_addresses_from_postcode, \
+    PostcodeNotFound, ErrorFindingAddress, town_city_builder, address_builder
 
 _current_app = Flask(__name__)
 
@@ -73,6 +74,177 @@ def test_get_addresses_from_postcode_handles_500_status_code(mock_get, faker):
             get_addresses_from_postcode(postcode)
 
 
+def test_address_builder_given_house_name_address_returns_address():
+    # GIVEN
+    lpi_info = {
+        'PAO_TEXT': 'The Vicarage',
+        'STREET_DESCRIPTION': 'Church Lane'
+    }
+
+    # WHEN
+    address = address_builder(lpi_info)
+
+    # THEN
+    assert address['building_and_street_line_1'] == 'The Vicarage'
+    assert address['building_and_street_line_2'] == 'Church Lane'
+
+
+def test_address_builder_given_house_number_style_address_returns_address():
+    # GIVEN
+    lpi_info = {
+        'PAO_START_NUMBER': 12,
+        'STREET_DESCRIPTION': 'Church Lane'
+    }
+
+    # WHEN
+    address = address_builder(lpi_info)
+
+    # THEN
+    assert address['building_and_street_line_1'] == '12 Church Lane'
+    assert address['building_and_street_line_2'] == ''
+
+
+def test_address_builder_given_flat_number_style_address_returns_address():
+    # GIVEN
+    lpi_info = {
+        'PAO_START_NUMBER': 12,
+        'PAO_START_SUFFIX': 'B',
+        'STREET_DESCRIPTION': 'Church Lane'
+    }
+
+    # WHEN
+    address = address_builder(lpi_info)
+
+    # THEN
+    assert address['building_and_street_line_1'] == '12B Church Lane'
+    assert address['building_and_street_line_2'] == ''
+
+
+def test_address_builder_given_house_range_number_style_address_returns_address():
+    # GIVEN
+    lpi_info = {
+        'PAO_START_NUMBER': 12,
+        'PAO_END_NUMBER': 14,
+        'STREET_DESCRIPTION': 'Church Lane'
+    }
+
+    # WHEN
+    address = address_builder(lpi_info)
+
+    # THEN
+    assert address['building_and_street_line_1'] == '12-14 Church Lane'
+    assert address['building_and_street_line_2'] == ''
+
+
+def test_address_builder_given_secondary_style_address_returns_address():
+    # GIVEN
+    lpi_info = {
+        'SAO_START_NUMBER': 12,
+        'PAO_TEXT': 'Sussex Court',
+        'STREET_DESCRIPTION': 'Church Lane'
+    }
+
+    # WHEN
+    address = address_builder(lpi_info)
+
+    # THEN
+    assert address['building_and_street_line_1'] == '12, Sussex Court'
+    assert address['building_and_street_line_2'] == 'Church Lane'
+
+
+def test_address_builder_given_one_line_address_and_org_returns_org_as_line_1():
+    # GIVEN
+    lpi_info = {
+        'ORGANISATION': 'Sunset Care',
+        'PAO_START_NUMBER': 1,
+        'STREET_DESCRIPTION': 'Church Lane',
+    }
+
+    # WHEN
+    address = address_builder(lpi_info)
+
+    # THEN
+    assert address['building_and_street_line_1'] == 'Sunset Care'
+    assert address['building_and_street_line_2'] == '1 Church Lane'
+
+
+def test_address_builder_given_org_name_is_short_optimises_line_length():
+    # GIVEN
+    lpi_info = {
+        'ORGANISATION': 'Gds',
+        'PAO_TEXT': 'Aviation House',
+        'STREET_DESCRIPTION': 'Holborn',
+    }
+
+    # WHEN
+    address = address_builder(lpi_info)
+
+    # THEN
+    assert address['building_and_street_line_1'] == 'Gds, Aviation House'
+    assert address['building_and_street_line_2'] == 'Holborn'
+
+
+def test_address_builder_given_org_name_is_long_optimises_line_length():
+    # GIVEN
+    lpi_info = {
+        'ORGANISATION': 'Government Digital Service',
+        'PAO_TEXT': 'Aviation House',
+        'STREET_DESCRIPTION': 'Holborn',
+    }
+
+    # WHEN
+    address = address_builder(lpi_info)
+
+    # THEN
+    assert address['building_and_street_line_1'] == 'Government Digital Service'
+    assert address['building_and_street_line_2'] == 'Aviation House, Holborn'
+
+
+def test_town_city_builder_removes_duplicates():
+    # GIVEN
+    lpi_info = {
+        'LOCALITY_NAME': 'Barnet',
+        'TOWN_NAME': 'London',
+        'ADMINISTRATIVE_AREA': 'London'
+    }
+
+    # WHEN
+    town_city_line = town_city_builder(lpi_info)
+
+    # THEN
+    assert town_city_line == 'Barnet, London'
+
+
+def test_town_city_builder_removes_nulls():
+    # GIVEN
+    lpi_info = {
+        'LOCALITY_NAME': 'Barnet',
+        'TOWN_NAME': '',
+        'ADMINISTRATIVE_AREA': 'London'
+    }
+
+    # WHEN
+    town_city_line = town_city_builder(lpi_info)
+
+    # THEN
+    assert town_city_line == 'Barnet, London'
+
+
+def test_town_city_builder_ignores_missing_keys():
+    # GIVEN
+    # input doesn't include a town name
+    lpi_info = {
+        'LOCALITY_NAME': 'Barnet',
+        'ADMINISTRATIVE_AREA': 'London'
+    }
+
+    # WHEN
+    town_city_line = town_city_builder(lpi_info)
+
+    # THEN
+    assert town_city_line == 'Barnet, London'
+
+
 def api_response_and_function_result_should_match(expected_entries, addresses):
     assert len(expected_entries) == len(addresses)
     for i in range(0, len(expected_entries)):
@@ -80,7 +252,7 @@ def api_response_and_function_result_should_match(expected_entries, addresses):
         assert addresses[i]['text'] == api_response_entry_json['LPI']['ADDRESS']
         values = json.loads(addresses[i]['value'])
         assert values['uprn'] == expected_entries[i].uprn
-        assert values['town_city'] == f"{expected_entries[i].city.title()}, {expected_entries[i].city.title()}"
+        assert values['town_city'] == f"{expected_entries[i].city.title()}"
         assert values['postcode'] == expected_entries[i].postcode
         assert values['building_and_street_line_1'] == '{door_number} {street}'.format(
             door_number=expected_entries[i].door_number,

--- a/tests/integrations/test_postcode_lookup_helper.py
+++ b/tests/integrations/test_postcode_lookup_helper.py
@@ -89,159 +89,142 @@ def test_address_builder_given_house_name_address_returns_address():
     assert address['building_and_street_line_2'] == 'Church Lane'
 
 
+def test_address_builder_given_house_name_and_number_address_returns_address():
+    lpi_info = {
+        'PAO_START_NUMBER': '12',
+        'PAO_TEXT': 'The Vicarage',
+        'STREET_DESCRIPTION': 'Church Lane'
+    }
+
+    address = address_builder(lpi_info)
+
+    assert address['building_and_street_line_1'] == 'The Vicarage, 12'
+    assert address['building_and_street_line_2'] == 'Church Lane'
+
+
 def test_address_builder_given_house_number_style_address_returns_address():
-    # GIVEN
     lpi_info = {
         'PAO_START_NUMBER': 12,
         'STREET_DESCRIPTION': 'Church Lane'
     }
 
-    # WHEN
     address = address_builder(lpi_info)
 
-    # THEN
     assert address['building_and_street_line_1'] == '12 Church Lane'
     assert address['building_and_street_line_2'] == ''
 
 
 def test_address_builder_given_flat_number_style_address_returns_address():
-    # GIVEN
     lpi_info = {
         'PAO_START_NUMBER': 12,
         'PAO_START_SUFFIX': 'B',
         'STREET_DESCRIPTION': 'Church Lane'
     }
 
-    # WHEN
     address = address_builder(lpi_info)
 
-    # THEN
     assert address['building_and_street_line_1'] == '12B Church Lane'
     assert address['building_and_street_line_2'] == ''
 
 
 def test_address_builder_given_house_range_number_style_address_returns_address():
-    # GIVEN
     lpi_info = {
         'PAO_START_NUMBER': 12,
         'PAO_END_NUMBER': 14,
         'STREET_DESCRIPTION': 'Church Lane'
     }
 
-    # WHEN
     address = address_builder(lpi_info)
 
-    # THEN
     assert address['building_and_street_line_1'] == '12-14 Church Lane'
     assert address['building_and_street_line_2'] == ''
 
 
 def test_address_builder_given_secondary_style_address_returns_address():
-    # GIVEN
     lpi_info = {
         'SAO_START_NUMBER': 12,
         'PAO_TEXT': 'Sussex Court',
         'STREET_DESCRIPTION': 'Church Lane'
     }
 
-    # WHEN
     address = address_builder(lpi_info)
 
-    # THEN
     assert address['building_and_street_line_1'] == '12, Sussex Court'
     assert address['building_and_street_line_2'] == 'Church Lane'
 
 
 def test_address_builder_given_one_line_address_and_org_returns_org_as_line_1():
-    # GIVEN
     lpi_info = {
         'ORGANISATION': 'Sunset Care',
         'PAO_START_NUMBER': 1,
         'STREET_DESCRIPTION': 'Church Lane',
     }
 
-    # WHEN
     address = address_builder(lpi_info)
 
-    # THEN
     assert address['building_and_street_line_1'] == 'Sunset Care'
     assert address['building_and_street_line_2'] == '1 Church Lane'
 
 
 def test_address_builder_given_org_name_is_short_optimises_line_length():
-    # GIVEN
     lpi_info = {
         'ORGANISATION': 'Gds',
         'PAO_TEXT': 'Aviation House',
         'STREET_DESCRIPTION': 'Holborn',
     }
 
-    # WHEN
     address = address_builder(lpi_info)
 
-    # THEN
     assert address['building_and_street_line_1'] == 'Gds, Aviation House'
     assert address['building_and_street_line_2'] == 'Holborn'
 
 
 def test_address_builder_given_org_name_is_long_optimises_line_length():
-    # GIVEN
     lpi_info = {
         'ORGANISATION': 'Government Digital Service',
         'PAO_TEXT': 'Aviation House',
         'STREET_DESCRIPTION': 'Holborn',
     }
 
-    # WHEN
     address = address_builder(lpi_info)
 
-    # THEN
     assert address['building_and_street_line_1'] == 'Government Digital Service'
     assert address['building_and_street_line_2'] == 'Aviation House, Holborn'
 
 
 def test_town_city_builder_removes_duplicates():
-    # GIVEN
     lpi_info = {
         'LOCALITY_NAME': 'Barnet',
         'TOWN_NAME': 'London',
         'ADMINISTRATIVE_AREA': 'London'
     }
 
-    # WHEN
     town_city_line = town_city_builder(lpi_info)
 
-    # THEN
     assert town_city_line == 'Barnet, London'
 
 
 def test_town_city_builder_removes_nulls():
-    # GIVEN
     lpi_info = {
         'LOCALITY_NAME': 'Barnet',
         'TOWN_NAME': '',
         'ADMINISTRATIVE_AREA': 'London'
     }
 
-    # WHEN
     town_city_line = town_city_builder(lpi_info)
 
-    # THEN
     assert town_city_line == 'Barnet, London'
 
 
 def test_town_city_builder_ignores_missing_keys():
-    # GIVEN
     # input doesn't include a town name
     lpi_info = {
         'LOCALITY_NAME': 'Barnet',
         'ADMINISTRATIVE_AREA': 'London'
     }
 
-    # WHEN
     town_city_line = town_city_builder(lpi_info)
 
-    # THEN
     assert town_city_line == 'Barnet, London'
 
 

--- a/vulnerable_people_form/integrations/postcode_lookup_helper.py
+++ b/vulnerable_people_form/integrations/postcode_lookup_helper.py
@@ -25,10 +25,6 @@ class ErrorFindingAddress(RuntimeError):
     pass
 
 
-def address_line_builder(lpi_info, slice):
-    return ", ".join({k: v for k, v in lpi_info.items() if k in slice}.values())
-
-
 def address_builder(lpi_info):
     primary_property_identifier = property_identifier(start_number=lpi_info.get('PAO_START_NUMBER'),
                                                       start_suffix=lpi_info.get('PAO_START_SUFFIX'),
@@ -88,7 +84,8 @@ def property_identifier(start_number, start_suffix, end_number, end_suffix, text
         return f'{a}{b}' if b else f'{a}'
 
     if text_value:
-        return text_value
+        number_identifier = property_identifier(start_number, start_suffix, end_number, end_suffix, None)
+        return f'{text_value}, {number_identifier}' if number_identifier else text_value
     elif end_number:
         return f'{number_suffix(start_number, start_suffix)}-{number_suffix(end_number, end_suffix)}'
     elif start_number:
@@ -165,11 +162,11 @@ def get_addresses_from_postcode(postcode):
     elif response.status_code == HTTPStatus.UNAUTHORIZED.value:
         logger.error(_create_postcode_lookup_failure_log_message(
             "Unauthorised request submitted to API - Invalid ORDNANCE_SURVEY_PLACES_API_KEY", postcode,
-            response.text))  # noqa
+            response.text))
         raise ErrorFindingAddress()
     elif response.status_code == HTTPStatus.BAD_REQUEST.value:
         logger.warning(_create_postcode_lookup_failure_log_message("Invalid request submitted to API", postcode,
-                                                                   response.text))  # noqa
+                                                                   response.text))
         raise PostcodeNotFound()
     else:
         logger.error(_create_postcode_lookup_failure_log_message("Error finding address", postcode, response.text))

--- a/vulnerable_people_form/integrations/postcode_lookup_helper.py
+++ b/vulnerable_people_form/integrations/postcode_lookup_helper.py
@@ -55,7 +55,7 @@ def address_builder(lpi_info):
                                                                                            organisation)
 
     return {
-        "uprn": int(lpi_info.get("UPRN")),
+        "uprn": int(lpi_info.get("UPRN")) if lpi_info.get("UPRN") else None,
         "town_city": town_city_builder(lpi_info).title(),
         "postcode": lpi_info.get("POSTCODE_LOCATOR"),
         "building_and_street_line_1": building_and_street_line_1.title(),

--- a/vulnerable_people_form/integrations/postcode_lookup_helper.py
+++ b/vulnerable_people_form/integrations/postcode_lookup_helper.py
@@ -56,11 +56,31 @@ def address_builder(lpi_info):
 
     return {
         "uprn": int(lpi_info.get("UPRN")),
-        "town_city": address_line_builder(lpi_info, ["LOCALITY_NAME", "TOWN_NAME", "ADMINISTRATIVE_AREA"]).title(),
+        "town_city": town_city_builder(lpi_info).title(),
         "postcode": lpi_info.get("POSTCODE_LOCATOR"),
         "building_and_street_line_1": building_and_street_line_1.title(),
         "building_and_street_line_2": building_and_street_line_2.title(),
     }
+
+
+def town_city_builder(lpi_info):
+    locality = lpi_info.get('LOCALITY_NAME')
+    town = lpi_info.get('TOWN_NAME')
+    administrative_area = lpi_info.get('ADMINISTRATIVE_AREA')
+
+    non_null_sections = [item for item in [locality, town, administrative_area] if item]
+
+    unique_sections = unique_values_preserving_order(non_null_sections)
+
+    return ', '.join(unique_sections)
+
+
+def unique_values_preserving_order(sections):
+    unique_sections = []
+    for section in sections:
+        if section not in unique_sections:
+            unique_sections.append(section)
+    return unique_sections
 
 
 def property_identifier(start_number, start_suffix, end_number, end_suffix, text_value):
@@ -79,7 +99,7 @@ def property_identifier(start_number, start_suffix, end_number, end_suffix, text
 
 def build_building_and_street_lines(primary_property_identifier, primary_property_identifier_is_a_building,
                                     secondary_property_identifier, street):
-    if secondary_property_identifier != "":
+    if secondary_property_identifier:
         building_and_street_line_1 = secondary_property_identifier + ', ' + primary_property_identifier
         building_and_street_line_2 = street
     elif primary_property_identifier_is_a_building:


### PR DESCRIPTION
Updates to formatting of addresses on the check your details screen. 
Correctly display addresses based on 
- house numbers (i.e. 12 Church Road), 
- sub-house numbers (i.e. 12A Church Road) 
- house ranges (i.e. 12-14 Church Road)
- house names (i.e. The Vicarage, Church Road)
- flat and building numbers (i.e. 39, 7 Church Road)
- organisation addresses