### PR TITLE
Fix prepopulate data for new postcodes

### DIFF
--- a/scripts/prepopulate.sql
+++ b/scripts/prepopulate.sql
@@ -4,12 +4,13 @@ truncate table cv_ref.ref_ONSUD_uprn_to_lad_code_mapping;
 
 insert into cv_ref.ref_NSPL_postcode_to_lad_code_mapping (pcd, laua, ctry, provisioned_datetime) values 
 ("BB11TA","E06000008","E92000001" , NOW()), 
-("LE674AY", "E07000134","E92000001" , NOW()), 
+("BD37DB", "E07000134","E92000001" , NOW()), 
 ("L244AD","E06000006" ,"E92000001" , NOW()),
-("LU11AA","E06000032" ,"E92000001" , NOW());
+("LU11AA","E06000032" ,"E92000001" , NOW()),
+("LS287TQ","E06000008","E92000001" , NOW());
 
 insert into cv_base.clean_local_area_restrictions (lad_code, lad_name, alert_level, start_datetime) values
-("E06000008", "Blackburn", "4", NOW()),
+("E06000008", "Blackburn", "3", NOW()),
 ("E06000032", "Luton", "4", NOW()),
 ("E07000134", "Leighton", "3", NOW()),
 ("E06000006", "Lowestoft", "2", NOW());
@@ -19,4 +20,5 @@ insert into cv_ref.ref_ONSUD_uprn_to_lad_code_mapping (uprn, lad19cd, ctry, prov
 (2000, "E06000006", "E92000001", NOW() ),
 (3000, "E09000134", "M83000003", NOW() ),
 (10000000, "E06000008", "E92000001", NOW() ),
+(1000000, "E06000008", "E92000001", NOW() ),
 (10000001, "E06000032", "E92000001", NOW() );

--- a/tests/ons-mock/server.py
+++ b/tests/ons-mock/server.py
@@ -4,7 +4,8 @@ import json
 import re
 from fake_os_places_api_entry import FakeOSPlacesAPIEntry
 
-_postcode_to_uprn = {"BB11TA": 10000000,
+_postcode_to_uprn = {"LS287TQ": 10000000,
+                     "BB11TA": 1000000,
                      "LE674AY": 1000,
                      "L244AD":  2000,
                      "LU11AA":  10000001,


### PR DESCRIPTION
This makes the data put into the local dev environment match the smoke
and e2e tests. It also makes the mock server know the new postcodes so
it can work return uprns that are different.