### PR TITLE
Update the file for the e2e-test-with-pipeline-validation-in-staging

### DIFF
--- a/behave/features/e2e_test_features/09.s3_outputs_check.feature
+++ b/behave/features/e2e_test_features/09.s3_outputs_check.feature
@@ -3,5 +3,5 @@ Feature: COVID-19 Shielded vulnerable people service - validate data from previo
     Scenario: Pipeline should be executed and data validated for previous day run
         Given there was a new web submission yesterday
         When the pipeline has completed successfully
-        Then nhs_number "9999999999" is available in LA feed for "unknown" with yesterday date in field "submission_datetime"
+        Then nhs_number "9999999999" is available in LA feed for "london-borough-of-tower-hamlets" with yesterday date in field "submission_datetime"
         AND nhs_number "9999999999" is available in supermarket feed with yesterday date in field "FirstName"


### PR DESCRIPTION
Update the file for the e2e-test-with-pipeline-validation-in-staging to london-borough-of-tower-hamlets.

The smoke test submissions is ending up there due to the latest_user_address
view functionality which falls back to using the nhs address when the
submission hub doesn't match