### PR TITLE
concourse: fix CRONITOR_ENDPOINT escaping

### DIFF
--- a/concourse/tasks/cronitor.yml
+++ b/concourse/tasks/cronitor.yml
@@ -11,6 +11,6 @@ run:
     - -c
     - |
       set -ue
-      echo 'Curling cronitor ${CRONITOR_ENDPOINT}...'
+      echo "Curling cronitor ${CRONITOR_ENDPOINT}..."
       curl --fail "${CRONITOR_URL}${CRONITOR_ENDPOINT}"
       echo 'Curled cronitor successfully.'


### PR DESCRIPTION
We need double quotes to print the actual endpoint value.