### PR TITLE
Added shielding advice page for returning user

### DIFF
--- a/tests/form_pages/shared/test_routing.py
+++ b/tests/form_pages/shared/test_routing.py
@@ -249,7 +249,7 @@ def test_get_back_url_for_contact_details_should_return_correct_url_when_very_hi
                                "latest_shielding_advice": ShieldingAdvice.ADVISED_TO_SHIELD.value,
                                "change_status": ShieldingAdviceStatus.INCREASED.value
                            },
-                          "/basic-care-needs?ca=1"),
+                          "/shielding-advice?ca=1"),
                           (PostcodeTier.VERY_HIGH,
                            {
                                "latest_location_tier": PostcodeTier.VERY_HIGH.value,

--- a/vulnerable_people_form/form_pages/__init__.py
+++ b/vulnerable_people_form/form_pages/__init__.py
@@ -32,7 +32,8 @@ from . import (
     support_address,
     view_answers,
     nhs_login_landing,
-    nhs_login_no_consent
+    nhs_login_no_consent,
+    nhs_login_shielding_advice
 )
 
 __all__ = ["blueprint"]

--- a/vulnerable_people_form/form_pages/nhs_login_shielding_advice.py
+++ b/vulnerable_people_form/form_pages/nhs_login_shielding_advice.py
@@ -1,0 +1,11 @@
+from vulnerable_people_form.form_pages.shared.render import render_template_with_title
+from vulnerable_people_form.form_pages.shared.querystring_utils import append_querystring_params
+from .blueprint import form
+
+
+@form.route("/shielding-advice", methods=["GET"])
+def get_nhs_login_shielding_advice():
+    return render_template_with_title(
+        "nhs-login-shielding-advice.html",
+        continue_url=append_querystring_params("/basic-care-needs")
+    )

--- a/vulnerable_people_form/form_pages/shared/constants.py
+++ b/vulnerable_people_form/form_pages/shared/constants.py
@@ -52,6 +52,7 @@ PAGE_TITLES = {
     "view-answers": "Your saved details",
     "nhs-login-landing": "You have successfully signed out",
     "nhs-login-no-consent": "You have decided not to share your NHS login information",
+    "nhs-login-shielding-advice": "Shielding advice has changed"
 }
 
 NHS_USER_INFO_TO_FORM_ANSWERS = {

--- a/vulnerable_people_form/form_pages/shared/routing.py
+++ b/vulnerable_people_form/form_pages/shared/routing.py
@@ -262,7 +262,7 @@ def get_redirect_for_returning_user_based_on_tier():
     shielding_advice_change_status = ShieldingAdviceStatus(latest_shielding_advice_info["change_status"])
     if (shielding_advice_change_status == ShieldingAdviceStatus.INCREASED
        and latest_shielding_advice == ShieldingAdvice.ADVISED_TO_SHIELD):
-        return redirect("/basic-care-needs?ca=1")
+        return redirect("/shielding-advice?ca=1")
     else:
         if not is_tier_very_high_or_above(latest_location_tier):
             return redirect("/not-eligible-postcode-returning-user")

--- a/vulnerable_people_form/templates/nhs-login-shielding-advice.html
+++ b/vulnerable_people_form/templates/nhs-login-shielding-advice.html
@@ -1,0 +1,13 @@
+{%- from 'govuk_frontend_jinja/components/button/macro.html' import govukButton -%}
+
+{% extends "base.html" %}
+
+{% block content %}
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-6">{{ title_text }}</h1>
+    <p class="govuk-body">You are now advised to follow shielding advice since you last registered.</p>
+    <p class="govuk-body">This means we will need to ask you an additional question..</p>
+    {{ govukButton({
+        "text": "Continue",
+        "href": continue_url
+    }) }}
+{% endblock %}


### PR DESCRIPTION
Following the latest round of testing sessions (round 8), we have agreed that we want to add an interstitial page in the returning NHS login user journey. This page will explain to the user that their shielding advice has now changed and will therefore be asked a new question. 
