### PR TITLE
Remove padding and add formatting

### DIFF
--- a/vulnerable_people_form/templates/nhs-login-link.html
+++ b/vulnerable_people_form/templates/nhs-login-link.html
@@ -5,8 +5,8 @@
 {% block content %}
     <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-6">{{ title_text }}</h1>
     <div class="govuk-!-width-one-third govuk-!-padding-bottom-3">
-        <a href="{{nhs_login_href}}" class="govuk-!-padding-bottom-3">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 323.33 59">
+        <a href="{{nhs_login_href}}" style = "display: inline-block;">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 323.33 59" role="presentation">
         <title>Sign in with NHS Login</title>
         <g id="Layer_2" data-name="Layer 2">
           <g id="Layer_1-2" data-name="Layer 1">


### PR DESCRIPTION
The padding for the anchor link was putting it in a weird place.

Added presentation role to help with screen readers according to

https://codepen.io/haltersweb/pen/eByVMK

And made the anchor an in-line block to make it conform to the size of
the svg for the tab location.

I tried button elements but they messed with the query parameters.