### PR TITLE
Moving to a session based backlink

### DIFF
--- a/tests/form_pages/shared/test_routing.py
+++ b/tests/form_pages/shared/test_routing.py
@@ -8,7 +8,7 @@ from vulnerable_people_form.form_pages.shared.answers_enums import ApplyingOnOwn
 from vulnerable_people_form.form_pages.shared.constants import SESSION_KEY_LOCATION_TIER, \
     SESSION_KEY_SHIELDING_ADVICE, PostcodeTier, PostcodeTierStatus, ShieldingAdvice, \
     ShieldingAdviceStatus
-from vulnerable_people_form.form_pages.shared.routing import route_to_next_form_page, get_back_url_for_contact_details,\
+from vulnerable_people_form.form_pages.shared.routing import route_to_next_form_page, \
     get_redirect_for_returning_user_based_on_tier
 
 _ROUTING_FORM_ANSWERS_FUNCTION_FULLY_QUALIFIED_NAME = \
@@ -200,38 +200,6 @@ def test_route_to_next_form_page_raises_a_value_error_invalid_postcode_tier_pres
         with pytest.raises(ValueError) as err_info:
             route_to_next_form_page()
         assert str(err_info.value) == f"Unexpected location tier value encountered: {get_postcode_tier_return_value}"  # noqa
-
-
-def test_get_back_url_for_contact_details_should_raise_value_error_when_invalid_postcode_tier():  # noqa
-    with _current_app.app_context(), \
-         _current_app.test_request_context() as test_request_ctx:
-        test_request_ctx.session[SESSION_KEY_LOCATION_TIER] = PostcodeTier.HIGH.value
-        with pytest.raises(ValueError) as err_info:
-            get_back_url_for_contact_details()
-        assert f"Unexpected location tier value encountered: {PostcodeTier.HIGH.value}" == str(err_info.value)
-
-def test_get_back_url_for_contact_details_should_return_basic_care_needs_when_very_high_plus_shielding_tier():  # noqa
-    with _current_app.app_context(), \
-         _current_app.test_request_context() as test_request_ctx:
-        test_request_ctx.session[SESSION_KEY_LOCATION_TIER] = PostcodeTier.VERY_HIGH_PLUS_SHIELDING.value
-        test_request_ctx.session[SESSION_KEY_SHIELDING_ADVICE] = ShieldingAdvice.ADVISED_TO_SHIELD.value
-        back_url = get_back_url_for_contact_details()
-        assert back_url == "/basic-care-needs"
-
-
-@pytest.mark.parametrize("shopping_question_answer, expected_back_url",
-                         [(ShoppingAssistanceAnswers.NO.value, "/priority-supermarket-deliveries"),
-                          (ShoppingAssistanceAnswers.YES.value, "/do-you-have-someone-to-go-shopping-for-you")])
-def test_get_back_url_for_contact_details_should_return_correct_url_when_very_high_tier(
-        shopping_question_answer, expected_back_url):
-    with _current_app.app_context(),\
-         _current_app.test_request_context() as test_request_ctx, \
-         patch(_ROUTING_FORM_ANSWERS_FUNCTION_FULLY_QUALIFIED_NAME,
-               return_value={"do_you_have_someone_to_go_shopping_for_you": shopping_question_answer}):
-        test_request_ctx.session[SESSION_KEY_LOCATION_TIER] = PostcodeTier.VERY_HIGH.value
-        test_request_ctx.session[SESSION_KEY_SHIELDING_ADVICE] = ShieldingAdvice.NOT_ADVISED_TO_SHIELD.value
-        back_url = get_back_url_for_contact_details()
-        assert back_url == expected_back_url
 
 
 @pytest.mark.parametrize("""original_postcode_tier, get_latest_location_tier_return_value,

--- a/vulnerable_people_form/form_pages/accessibility_statement.py
+++ b/vulnerable_people_form/form_pages/accessibility_statement.py
@@ -1,8 +1,7 @@
 from .default import app_default
 from .shared.render import render_template_with_title
-from .shared.routing import dynamic_back_url
 
 
 @app_default.route("/accessibility-statement", methods=["GET"])
 def get_accessibility_statement():
-    return render_template_with_title("accessibility.html", previous_path=dynamic_back_url())
+    return render_template_with_title("accessibility.html")

--- a/vulnerable_people_form/form_pages/address_lookup.py
+++ b/vulnerable_people_form/form_pages/address_lookup.py
@@ -5,7 +5,6 @@ from flask import redirect, session, current_app
 from ..integrations import postcode_lookup_helper, location_eligibility
 from .blueprint import form
 from .shared.constants import SESSION_KEY_ADDRESS_SELECTED
-from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
 from .shared.session import get_errors_from_session, request_form, form_answers
@@ -51,11 +50,9 @@ def get_address_lookup():
             return redirect("/support-address")
 
     addresses = add_initial_dropdown_option(addresses)
-    prev_path = append_querystring_params("/postcode-eligibility")
 
     return render_template_with_title(
         "address-lookup.html",
-        previous_path=prev_path,
         postcode=postcode,
         addresses=addresses,
         **get_errors_from_session("postcode"),

--- a/vulnerable_people_form/form_pages/applying_on_own_behalf.py
+++ b/vulnerable_people_form/form_pages/applying_on_own_behalf.py
@@ -5,7 +5,6 @@ from .shared.answers_enums import (
     ApplyingOnOwnBehalfAnswers,
     get_radio_options_from_enum,
 )
-from .shared.constants import GOVUK_JOURNEY_START_PAGE_URL
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
 from .shared.session import (
@@ -23,7 +22,6 @@ def get_apply_on_own_behalf():
         radio_items=get_radio_options_from_enum(
             ApplyingOnOwnBehalfAnswers, form_answers().get("applying_on_own_behalf")
         ),
-        previous_path=GOVUK_JOURNEY_START_PAGE_URL,
         **get_errors_from_session("applying_on_own_behalf"),
     )
 

--- a/vulnerable_people_form/form_pages/basic_care_needs.py
+++ b/vulnerable_people_form/form_pages/basic_care_needs.py
@@ -2,7 +2,6 @@ from flask import redirect
 
 from .blueprint import form
 from .shared.answers_enums import get_radio_options_from_enum, BasicCareNeedsAnswers
-from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
 from .shared.session import (
@@ -15,13 +14,8 @@ from .shared.validation import validate_basic_care_needs
 
 @form.route("/basic-care-needs", methods=["GET"])
 def get_basic_care_needs():
-    prev_path = "/priority-supermarket-deliveries" \
-        if form_answers().get("priority_supermarket_deliveries") is not None \
-        else "/do-you-have-someone-to-go-shopping-for-you"
-    prev_path = append_querystring_params(prev_path)
     return render_template_with_title(
         "basic-care-needs.html",
-        previous_path=prev_path,
         radio_items=get_radio_options_from_enum(BasicCareNeedsAnswers, form_answers().get("basic_care_needs")),
         **get_errors_from_session("basic_care_needs"),
     )

--- a/vulnerable_people_form/form_pages/blueprint.py
+++ b/vulnerable_people_form/form_pages/blueprint.py
@@ -3,12 +3,13 @@ from http import HTTPStatus
 from flask import (
     Blueprint,
     redirect,
-    render_template
+    render_template,
+    request
 )
 from flask_wtf.csrf import CSRFError
 
 from vulnerable_people_form.form_pages.shared.querystring_utils import append_querystring_params
-from vulnerable_people_form.form_pages.shared.session import has_started_form
+from vulnerable_people_form.form_pages.shared.session import has_started_form, record_current_path
 
 form = Blueprint("form", __name__)
 
@@ -28,6 +29,12 @@ def add_caching_headers(response):
     response.headers["Cache-Control"] = "no-store"
     response.headers["Pragma"] = "no-cache"
     return response
+
+
+@form.before_request
+def record_page_to_session():
+    if request.method == "GET" :
+        record_current_path(request.path)
 
 
 @form.errorhandler(CSRFError)

--- a/vulnerable_people_form/form_pages/check_your_answers.py
+++ b/vulnerable_people_form/form_pages/check_your_answers.py
@@ -4,7 +4,7 @@ from .blueprint import form
 from .shared.constants import ShieldingAdvice
 from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
-from .shared.routing import route_to_next_form_page, dynamic_back_url
+from .shared.routing import route_to_next_form_page
 from .shared.session import persist_answers_from_session, get_summary_rows_from_form_answers, \
      is_shielding_without_basic_care_needs_answer, get_shielding_advice
 from ..integrations import notifications
@@ -22,7 +22,6 @@ def get_check_your_answers():
 
     return render_template_with_title(
         "check-your-answers.html",
-        previous_path=dynamic_back_url(),
         summary_rows=get_summary_rows_from_form_answers(exclude_answers)
     )
 

--- a/vulnerable_people_form/form_pages/contact_details.py
+++ b/vulnerable_people_form/form_pages/contact_details.py
@@ -6,7 +6,7 @@ from flask import redirect, session
 from .blueprint import form
 from .shared.logger_utils import init_logger
 from .shared.render import render_template_with_title
-from .shared.routing import route_to_next_form_page, get_back_url_for_contact_details
+from .shared.routing import route_to_next_form_page
 from .shared.session import form_answers, get_errors_from_session, request_form
 from .shared.validation import validate_contact_details
 
@@ -29,7 +29,6 @@ def format_phone_number_if_valid(phone_number):
 def get_contact_details():
     return render_template_with_title(
         "contact-details.html",
-        previous_path=get_back_url_for_contact_details(),
         values=form_answers().get("contact_details", {}),
         **get_errors_from_session("contact_details"),
     )

--- a/vulnerable_people_form/form_pages/cookies.py
+++ b/vulnerable_people_form/form_pages/cookies.py
@@ -1,8 +1,7 @@
 from .default import app_default
 from .shared.render import render_template_with_title
-from .shared.routing import dynamic_back_url
 
 
 @app_default.route("/cookies", methods=["GET"])
 def get_cookies():
-    return render_template_with_title("cookies.html", previous_path=dynamic_back_url())
+    return render_template_with_title("cookies.html")

--- a/vulnerable_people_form/form_pages/date_of_birth.py
+++ b/vulnerable_people_form/form_pages/date_of_birth.py
@@ -2,7 +2,6 @@ from flask import redirect, session
 
 from .blueprint import form
 from .shared.form_utils import sanitise_date
-from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
 from .shared.session import form_answers, get_errors_from_session, request_form
@@ -13,7 +12,6 @@ from .shared.validation import validate_date_of_birth
 def get_date_of_birth():
     return render_template_with_title(
         "date-of-birth.html",
-        previous_path=append_querystring_params("/name"),
         values=form_answers().get("date_of_birth", {}),
         **get_errors_from_session("date_of_birth"),
     )

--- a/vulnerable_people_form/form_pages/do_you_have_someone_to_go_shopping_for_you.py
+++ b/vulnerable_people_form/form_pages/do_you_have_someone_to_go_shopping_for_you.py
@@ -3,7 +3,7 @@ from flask import redirect
 from .shared.answers_enums import get_radio_options_from_enum, ShoppingAssistanceAnswers
 from .blueprint import form
 from .shared.render import render_template_with_title
-from .shared.routing import route_to_next_form_page, get_back_url_for_shopping_assistance
+from .shared.routing import route_to_next_form_page
 from .shared.session import (
     form_answers,
     get_errors_from_session,
@@ -14,14 +14,12 @@ from .shared.validation import validate_do_you_have_someone_to_go_shopping_for_y
 
 @form.route("/do-you-have-someone-to-go-shopping-for-you", methods=["GET"])
 def get_do_you_have_someone_to_go_shopping_for_you():
-    back_url = get_back_url_for_shopping_assistance()
     return render_template_with_title(
         "do-you-have-someone-to-go-shopping-for-you.html",
         radio_items=get_radio_options_from_enum(
             ShoppingAssistanceAnswers,
             form_answers().get("do_you_have_someone_to_go_shopping_for_you"),
         ),
-        previous_path=back_url,
         **get_errors_from_session("do_you_have_someone_to_go_shopping_for_you"),
     )
 

--- a/vulnerable_people_form/form_pages/medical_conditions.py
+++ b/vulnerable_people_form/form_pages/medical_conditions.py
@@ -2,7 +2,6 @@ from flask import redirect
 
 from .shared.answers_enums import MedicalConditionsAnswers, get_radio_options_from_enum
 from .blueprint import form
-from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
 from .shared.session import (
@@ -26,6 +25,5 @@ def get_medical_conditions():
     return render_template_with_title(
         "medical-conditions.html",
         radio_items=get_radio_options_from_enum(MedicalConditionsAnswers, form_answers().get("medical_conditions")),
-        previous_path=append_querystring_params("/nhs-letter"),
         **get_errors_from_session("medical_conditions"),
     )

--- a/vulnerable_people_form/form_pages/name.py
+++ b/vulnerable_people_form/form_pages/name.py
@@ -2,7 +2,6 @@ from flask import redirect, session
 
 from .blueprint import form
 from .shared.form_utils import sanitise_name
-from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
 from .shared.session import form_answers, get_errors_from_session, request_form
@@ -14,7 +13,6 @@ def get_name():
     return render_template_with_title(
         "name.html",
         values=form_answers().get("name", {}),
-        previous_path=append_querystring_params("/nhs-number"),
         **get_errors_from_session("name"),
     )
 

--- a/vulnerable_people_form/form_pages/nhs_letter.py
+++ b/vulnerable_people_form/form_pages/nhs_letter.py
@@ -2,7 +2,6 @@ from flask import redirect
 
 from .blueprint import form
 from .shared.answers_enums import NHSLetterAnswers, get_radio_options_from_enum
-from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
 from .shared.session import (
@@ -18,7 +17,6 @@ def get_nhs_letter():
     return render_template_with_title(
         "nhs-letter.html",
         radio_items=get_radio_options_from_enum(NHSLetterAnswers, form_answers().get("nhs_letter")),
-        previous_path=append_querystring_params("/address-lookup"),
         **get_errors_from_session("nhs_letter"),
     )
 

--- a/vulnerable_people_form/form_pages/nhs_login.py
+++ b/vulnerable_people_form/form_pages/nhs_login.py
@@ -2,7 +2,6 @@ from flask import redirect
 
 from .blueprint import form
 from .shared.answers_enums import YesNoAnswers, get_radio_options_from_enum
-from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
 from .shared.session import (
@@ -18,7 +17,6 @@ def get_nhs_login():
     return render_template_with_title(
         "nhs-login.html",
         radio_items=get_radio_options_from_enum(YesNoAnswers, form_answers().get("nhs_login")),
-        previous_path=append_querystring_params("/applying-on-own-behalf"),
         **get_errors_from_session("nhs_login"),
     )
 

--- a/vulnerable_people_form/form_pages/nhs_login_link.py
+++ b/vulnerable_people_form/form_pages/nhs_login_link.py
@@ -1,7 +1,6 @@
 from flask import current_app
 
 from vulnerable_people_form.form_pages.shared.render import render_template_with_title
-from vulnerable_people_form.form_pages.shared.routing import dynamic_back_url
 from .blueprint import form
 
 
@@ -9,7 +8,6 @@ from .blueprint import form
 def get_nhs_login_link():
     return render_template_with_title(
         "nhs-login-link.html",
-        previous_path=dynamic_back_url(),
         nhs_login_href=current_app.nhs_oidc_client.get_authorization_url(),
         continue_url="/postcode-eligibility"
     )

--- a/vulnerable_people_form/form_pages/nhs_number.py
+++ b/vulnerable_people_form/form_pages/nhs_number.py
@@ -2,28 +2,21 @@ from flask import redirect, session
 
 from .blueprint import form
 from .shared.form_utils import clean_nhs_number
-from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
 from .shared.session import (
     form_answers,
     get_errors_from_session,
-    request_form,
-    get_answer_from_form,
+    request_form
 )
 from .shared.validation import validate_nhs_number
 
 
 @form.route("/nhs-number", methods=["GET"])
 def get_nhs_number():
-    previous_path = "/nhs-letter"
-    if get_answer_from_form(("medical_conditions",)) is not None:
-        previous_path = "/medical-conditions"
 
-    previous_path = append_querystring_params(previous_path)
     return render_template_with_title(
         "nhs-number.html",
-        previous_path=previous_path,
         values={
             "nhs_number": form_answers().get("nhs_number", ""),
             "applying_on_own_behalf": form_answers().get("applying_on_own_behalf")

--- a/vulnerable_people_form/form_pages/nhs_registration_link.py
+++ b/vulnerable_people_form/form_pages/nhs_registration_link.py
@@ -3,7 +3,6 @@ from flask import current_app
 from vulnerable_people_form.form_pages.shared.constants import JourneyProgress
 from vulnerable_people_form.form_pages.shared.querystring_utils import append_querystring_params
 from vulnerable_people_form.form_pages.shared.render import render_template_with_title
-from vulnerable_people_form.form_pages.shared.routing import dynamic_back_url
 from .blueprint import form
 
 
@@ -11,7 +10,6 @@ from .blueprint import form
 def get_nhs_registration_link():
     return render_template_with_title(
         "nhs-registration-link.html",
-        previous_path=dynamic_back_url(),
         nhs_registration_href=current_app.nhs_oidc_client.get_registration_url(JourneyProgress.NHS_NUMBER),
         continue_url=append_querystring_params("/applying-on-own-behalf")
     )

--- a/vulnerable_people_form/form_pages/not_eligible_medical.py
+++ b/vulnerable_people_form/form_pages/not_eligible_medical.py
@@ -1,8 +1,7 @@
 from .blueprint import form
 from .shared.render import render_template_with_title
-from .shared.routing import dynamic_back_url
 
 
 @form.route("/not-eligible-medical", methods=["GET"])
 def get_not_eligible_medical():
-    return render_template_with_title("not-eligible-medical.html", previous_path=dynamic_back_url())
+    return render_template_with_title("not-eligible-medical.html")

--- a/vulnerable_people_form/form_pages/not_eligible_postcode.py
+++ b/vulnerable_people_form/form_pages/not_eligible_postcode.py
@@ -2,13 +2,12 @@ from vulnerable_people_form.form_pages.shared.location_tier import is_tier_less_
 from vulnerable_people_form.form_pages.shared.session import get_location_tier, get_is_postcode_in_england
 from .blueprint import form
 from .shared.render import render_template_with_title
-from .shared.routing import dynamic_back_url
 
 
 @form.route("/not-eligible-postcode", methods=["GET"])
 def get_not_eligible_postcode():
     template_name = _get_template_name()
-    return render_template_with_title(template_name, previous_path=dynamic_back_url())
+    return render_template_with_title(template_name)
 
 
 @form.route("/not-eligible-postcode-returning-user", methods=["GET"])

--- a/vulnerable_people_form/form_pages/postcode_eligibility.py
+++ b/vulnerable_people_form/form_pages/postcode_eligibility.py
@@ -1,33 +1,18 @@
 from flask import redirect, session, current_app
 
 from .blueprint import form
-from .shared.answers_enums import ApplyingOnOwnBehalfAnswers
 from .shared.form_utils import format_postcode
-from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
-from .shared.session import get_errors_from_session, request_form, get_answer_from_form, is_nhs_login_user
+from .shared.session import get_errors_from_session, request_form
 from .shared.location_tier import update_is_postcode_in_england
 from .shared.validation import validate_postcode
 
 
 @form.route("/postcode-eligibility", methods=["GET"])
 def get_postcode_eligibility():
-    applying_on_own_behalf_answer = get_answer_from_form(["applying_on_own_behalf"])
-    if applying_on_own_behalf_answer == ApplyingOnOwnBehalfAnswers.YES.value:
-        if is_nhs_login_user():
-            prev_path = "/nhs-login-link"
-        else:
-            prev_path = "/nhs-login"
-
-    elif applying_on_own_behalf_answer == ApplyingOnOwnBehalfAnswers.NO.value:
-        prev_path = "/applying-on-own-behalf"
-    else:
-        raise ValueError("Unexpected ApplyingOnOwnBehalfAnswers value encountered: " + applying_on_own_behalf_answer)
-    prev_path = append_querystring_params(prev_path)
     return render_template_with_title(
         "postcode-eligibility.html",
-        previous_path=prev_path,
         values={"postcode": session.get("postcode", "")},
         **get_errors_from_session("postcode"),
     )

--- a/vulnerable_people_form/form_pages/postcode_lookup.py
+++ b/vulnerable_people_form/form_pages/postcode_lookup.py
@@ -3,7 +3,6 @@ from flask import redirect, session, current_app
 from .blueprint import form
 from .shared.form_utils import format_postcode
 from .shared.location_tier import update_location_status_by_postcode
-from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
 from .shared.session import (
@@ -36,7 +35,6 @@ def post_postcode_lookup():
 def get_postcode_lookup():
     return render_template_with_title(
         "postcode-lookup.html",
-        previous_path=append_querystring_params("/address-lookup"),
         values={"postcode": session.get("postcode", "")},
         **get_errors_from_session("postcode"),
     )

--- a/vulnerable_people_form/form_pages/priority_supermarket_deliveries.py
+++ b/vulnerable_people_form/form_pages/priority_supermarket_deliveries.py
@@ -5,7 +5,6 @@ from .shared.answers_enums import (
     PrioritySuperMarketDeliveriesAnswers,
     get_radio_options_from_enum,
 )
-from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
 from .shared.session import (
@@ -24,7 +23,6 @@ def get_priority_supermarket_deliveries():
             PrioritySuperMarketDeliveriesAnswers,
             form_answers().get("priority_supermarket_deliveries"),
         ),
-        previous_path=append_querystring_params("/do-you-have-someone-to-go-shopping-for-you"),
         **get_errors_from_session("priority_supermarket_deliveries"),
     )
 

--- a/vulnerable_people_form/form_pages/privacy.py
+++ b/vulnerable_people_form/form_pages/privacy.py
@@ -1,8 +1,7 @@
 from .default import app_default
 from .shared.render import render_template_with_title
-from .shared.routing import dynamic_back_url
 
 
 @app_default.route("/privacy", methods=["GET"])
 def get_privacy():
-    return render_template_with_title("privacy.html", previous_path=dynamic_back_url())
+    return render_template_with_title("privacy.html")

--- a/vulnerable_people_form/form_pages/shared/render.py
+++ b/vulnerable_people_form/form_pages/shared/render.py
@@ -1,7 +1,7 @@
 from flask import render_template, current_app, request
 
 from .constants import PAGE_TITLES
-from .session import accessing_saved_answers, is_nhs_login_user
+from .session import accessing_saved_answers, is_nhs_login_user, get_previous_path
 
 
 def render_template_with_title(template_name, *args, **kwargs):
@@ -23,6 +23,7 @@ def render_template_with_title(template_name, *args, **kwargs):
         form_base_template="base.html" if is_changing_form_answer else "base-with-back-link.html",
         **{
             "nhs_user": is_nhs_login_user(),
+            "previous_path": get_previous_path(),
             "button_text": "Save and continue" if accessing_saved_answers() else "Continue",
             **kwargs,
         },

--- a/vulnerable_people_form/form_pages/support_address.py
+++ b/vulnerable_people_form/form_pages/support_address.py
@@ -4,7 +4,6 @@ from .blueprint import form
 from .shared.constants import SESSION_KEY_ADDRESS_SELECTED
 from .shared.form_utils import sanitise_support_address, format_postcode
 from .shared.location_tier import update_location_status_by_postcode,  update_is_postcode_in_england
-from .shared.querystring_utils import append_querystring_params
 from .shared.render import render_template_with_title
 from .shared.routing import route_to_next_form_page
 from .shared.session import form_answers, get_errors_from_session, request_form
@@ -39,7 +38,6 @@ def get_support_address():
     _order_support_address_errors()
     return render_template_with_title(
         "support-address.html",
-        previous_path=append_querystring_params("/address-lookup"),
         values=form_answers().get("support_address", {}),
         **get_errors_from_session("support_address"),
     )


### PR DESCRIPTION
The previous_path is now retrieved in the render page from the session and defaults
to the main govuk start page when it is not set.

It is kept up to date in the blueprint