### PR TITLE
Add e2e test for churn report

### DIFF
--- a/behave/features/e2e_test_features/01.simple_web_submission_entry.feature
+++ b/behave/features/e2e_test_features/01.simple_web_submission_entry.feature
@@ -70,7 +70,8 @@ Feature: COVID-19 Shielded vulnerable people service - basic e2e user journey - 
 
     Scenario: Should be redirected to contact details when no answered to basic care needs help
         Given I am on the "basic-care-needs" page
-        When I click the ".govuk-radios__item input[value='0']" element
+        # This change of answer means that submission should appear on churn report
+        When I answer the care needs question differently to last submission for nhs_number "9999999999" in hub "london-borough-of-tower-hamlets"
         And I submit the form
         Then I am redirected to the "contact-details" page
 

--- a/behave/features/e2e_test_features/09.s3_outputs_check.feature
+++ b/behave/features/e2e_test_features/09.s3_outputs_check.feature
@@ -5,3 +5,4 @@ Feature: COVID-19 Shielded vulnerable people service - validate data from previo
         When the pipeline has completed successfully
         Then nhs_number "9999999999" is available in LA feed for "london-borough-of-tower-hamlets" with yesterday date in field "submission_datetime"
         AND nhs_number "9999999999" is available in supermarket feed with yesterday date in field "FirstName"
+        AND nhs_number "9999999999" is in churn report for "london-borough-of-tower-hamlets" with "Yes" in field "changed_preferences"

--- a/behave/features/e2e_test_features/pipeline_validation_steps/pipeline_validation_steps.py
+++ b/behave/features/e2e_test_features/pipeline_validation_steps/pipeline_validation_steps.py
@@ -56,6 +56,17 @@ def assert_nhs_number_is_available_in_supermarket(context, nhs_number, check_fie
     assert len(results) == 1
 
 
+@then('nhs_number "{nhs_number}" is in churn report for "{hub}" with "{check_value}" in field "{check_field}"')
+def assert_nhs_number_is_available_in_hub_churn_report(context, nhs_number, hub, check_field, check_value):
+    bucket = 'gds-ons-covid-19-query-results-{}'.format(env)
+    prefix = 'web-app-{}-data/local_authority/{}/'.format(env, hub)
+    filename_prefix = 'GDS-to-LA-ChurnReport'
+    id_field = 'nhs_number'
+
+    results = get_result_for_user(bucket, prefix, filename_prefix, id_field, nhs_number, check_field, check_value)
+    assert len(results) == 1
+
+
 def get_result_for_user(bucket, prefix, filename_prefix, id_field, id_value, check_field, check_value):
     latest_file_content = get_latest_file_contents(bucket, prefix, filename_prefix)
     print("Using {}: {}".format(id_field, id_value))

--- a/behave/features/steps/general.py
+++ b/behave/features/steps/general.py
@@ -1,6 +1,7 @@
 import os
 import json
 
+from datetime import datetime
 from behave import then, when, given
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions
@@ -108,3 +109,11 @@ def set_postcode_value_for_shielding(context, tier):
     html_element = context.browser.find_element_by_css_selector("#postcode")
     html_element.clear()
     html_element.send_keys(postcode)
+
+
+@when('I answer the care needs question differently to last submission for nhs_number "{nhs_number}" in hub "{hub}"')
+def click_basic_care_needs_element(context, nhs_number, hub):
+    # change the care needs response each day
+    new_care_answer = '0' if datetime.now().toordinal() % 2 else '1'
+    html_element = context.browser.find_element_by_css_selector(f".govuk-radios__item input[value='{new_care_answer}']")
+    html_element.click()


### PR DESCRIPTION
Modify e2e test so that population of churn report can be tested
by changing basic-care-needs answer with each test submission.
Changing basic-care-needs each run should result in the entry always appearing in the churn report, due to changed preferences.
Took the straightforward approach of alternating the answer with simply:`new_care_answer = '0' if datetime.now().toordinal() % 2 else '1'` (rather than inspecting the previous submission).
If deemed valueable, further work could be done to test the other types of population of the churn report (e.g. change of address), this can be discussed.
