### PR TITLE
Add .github/dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: pip
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: "03:00"
+  open-pull-requests-limit: 10
+  allow:
+  - dependency-type: production


### PR DESCRIPTION
Copied and amended from digital-marketplace-frontend:
https://github.com/alphagov/digitalmarketplace-admin-frontend/blob/master/.github/dependabot.yml

I *think* this will look for dependencies in requirements.txt but
maybe not in requirements-dev.txt.  Not sure if/how we can enable
that.