### PR TITLE
Fix problems with sign in with nhs login

### DIFF
--- a/vulnerable_people_form/templates/nhs-login-link.html
+++ b/vulnerable_people_form/templates/nhs-login-link.html
@@ -5,8 +5,8 @@
 {% block content %}
     <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-6">{{ title_text }}</h1>
     <div class="govuk-!-width-one-third govuk-!-padding-bottom-3">
-        <a href="{{nhs_login_href}}" style = "display: inline-block;">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 323.33 59" role="presentation">
+        <a href="{{nhs_login_href}}" style = "display: inline-block;" role="button">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 323.33 59" role="presentation" disabled>
         <title>Sign in with NHS Login</title>
         <g id="Layer_2" data-name="Layer 2">
           <g id="Layer_1-2" data-name="Layer 1">


### PR DESCRIPTION
This PR has two parts

The first part was to make the svg unfocusable. Some resarch found that
setting it as disabled worked. This was tested using virtual box and the
virtualbox vm, here https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/

The second change sets the role of the anchor element to button. This should fix
the confusion of the dragon users

How this now behaves in nvda, I am unsure.