### PR TITLE
Make all callback pages not be recorded for back button purposes

### DIFF
--- a/vulnerable_people_form/form_pages/blueprint.py
+++ b/vulnerable_people_form/form_pages/blueprint.py
@@ -33,9 +33,13 @@ def add_caching_headers(response):
     return response
 
 
+def _is_callback_path(path):
+    return re.match("/nhs-.*-callback.*", path)
+
+
 @form.before_request
 def record_page_to_session():
-    if request.method == "GET" and not re.match("/nhs-login-callback.*", request.path):
+    if request.method == "GET" and not _is_callback_path(request.path) :
         record_current_path(request.path)
 
 


### PR DESCRIPTION
There was another path for back links that doesn't make sense to
record.

The nhs registration flow is different from the nhs-login flow and hits
the nhs-registration-callback.

This change matches all nhs-.*-callback so both cases are covered and
not saved.