### PR TITLE
Fix pipeline definition for smoke test sandbox

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -145,7 +145,7 @@ jobs:
         trigger: true
         passed: [deploy-to-sandbox]
       - task: smoke-test
-        file: git-master/concourse/tasks/smoke-test-sandbox.yml
+        file: git-sandbox/concourse/tasks/smoke-test-sandbox.yml
         params:
           WEB_APP_BASE_URL: "https://gds-shielded-vulnerable-people-service-sandbox.london.cloudapps.digital"
           MESSAGE: "Checks that the application deployed to sandbox is not serving HTTP error codes"


### PR DESCRIPTION
It should refer to the sandbox branch rather than master
so that alternate smoke tests can be tested.