### PR TITLE
Block access to PaaS app whilst service is closed

### DIFF
--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -95,3 +95,4 @@ run:
 
       cf bind-service govuk-coronavirus-shielded-vulnerable-people-form prometheus
       cf bind-route-service london.cloudapps.digital "support-service-ip-safelist-route-service-$CF_SPACE" --hostname "$HOSTNAME" --path metrics
+      cf bind-route-service london.cloudapps.digital "support-service-ip-safelist-route-service-$CF_SPACE" --hostname "$HOSTNAME"


### PR DESCRIPTION
This will use the IP safelist app that's deployed by the Support
Service[1]. This is a bit confusing. There is probably some work that
could be done to extract and rename this app so that it's clearer that
it's something shared by multiple apps.

[1] https://github.com/alphagov/covid-engineering/blob/273aa5f811ce8e3cf8cc635a0ba61d2e4a23df40/concourse/support-tool/deploy-ip-safelist.yml#L31-L34