### PR TITLE
Log any errors from the browser when fetching pages

### DIFF
--- a/behave/behave.ini
+++ b/behave/behave.ini
@@ -1,4 +1,3 @@
 [behave]
 stderr_capture=False
 stdout_capture=False
-log_capture=False

--- a/behave/features/steps/general.py
+++ b/behave/features/steps/general.py
@@ -1,5 +1,6 @@
 import os
 import json
+import logging
 
 from datetime import datetime
 from behave import then, when, given
@@ -35,6 +36,7 @@ def wait_until_element_present(context, timeout_seconds, element_css_selector):
 @when('I navigate to "{path}"')
 def user_path_step(context, path):
     context.browser.get(_BASE_URL + path)
+    logging.error(context.browser.get_log("browser"))
 
 
 @then('the content of element with selector "{element_css_selector}" equals "{expected_element_content}"')


### PR DESCRIPTION
I have a hypothesis that the IP allow list route service is causing the smoke
test failures. The failures only started to appear in staging once it was
added. I'd like to try and capture the content/status of the page to verify
this.

It doesn't appear to be possible to get the status code from Selenium[1].

It seems as though we can get something close to what we need by logging
`browser.get_log("browser")`. Which produces the following output if we we try
to access the service from an IP that is not on the allow list.

```
Captured logging:
ERROR:root:[{'level': 'SEVERE', 'message': 'https://gds-shielded-vulnerable-people-service-staging.london.cloudapps.digital/start - Failed to load resource: the server responded with a status of 403 ()', 'source': 'network', 'timestamp': 1618236533937}]
```

[1] https://github.com/seleniumhq/selenium-google-code-issue-archive/issues/141