### PR TITLE
Add a waiter on the submit button being clickable

### DIFF
--- a/behave/features/steps/general.py
+++ b/behave/features/steps/general.py
@@ -145,7 +145,9 @@ def set_nhs_password_value(context, css_selector):
 @when('I submit the form')
 @log_page_response
 def submit_the_form(context):
-    click_element(context, "button[type='Submit']")
+    element = WebDriverWait(context.browser, _DEFAULT_TIMEOUT).until(
+            expected_conditions.element_to_be_clickable((By.CSS_SELECTOR, "button[type='Submit']")))
+    element.click()
 
 
 @when('I enter the value "{value}" in the field with name "{field_name}"')


### PR DESCRIPTION
We now have logs in Concourse for failed smoke test runs. There didn't
appear to be anything that would suggest the HTML responses from the
server are weird. What we seem to see is the submit button is clicked
but nothing happens[1].

I'm having a wild guess that for some reason I don't understand the
button isn't clickable yet.

[1] https://cd.gds-reliability.engineering/teams/covid19/pipelines/svp-form/jobs/continuous-smoke-test-prod/builds/111865