### PR TITLE
Try a more recent version `chromedriver`

### DIFF
--- a/concourse/tasks/e2e-test-sandbox.yml
+++ b/concourse/tasks/e2e-test-sandbox.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: gdscyber/concourse-chrome-driver
+    repository: vulnerablepeopleservice/chrome-driver
     tag: latest
     username: ((docker_hub_username))
     password: ((docker_hub_password))

--- a/concourse/tasks/e2e-test-with-pipeline-validation-webform-entry.yml
+++ b/concourse/tasks/e2e-test-with-pipeline-validation-webform-entry.yml
@@ -2,7 +2,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: gdscyber/concourse-chrome-driver
+    repository: vulnerablepeopleservice/chrome-driver
     tag: latest
 params:
   CGO_ENABLE: "0"

--- a/concourse/tasks/e2e-test.yml
+++ b/concourse/tasks/e2e-test.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: gdscyber/concourse-chrome-driver
+    repository: vulnerablepeopleservice/chrome-driver
     tag: latest
     username: ((docker_hub_username))
     password: ((docker_hub_password))

--- a/concourse/tasks/smoke-test-sandbox.yml
+++ b/concourse/tasks/smoke-test-sandbox.yml
@@ -2,8 +2,8 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: gdscyber/concourse-chrome-driver
-    tag: 1.1
+    repository: vulnerablepeopleservice/chrome-driver
+    tag: latest
     username: ((docker_hub_username))
     password: ((docker_hub_password))
 params:

--- a/concourse/tasks/smoke-test.yml
+++ b/concourse/tasks/smoke-test.yml
@@ -2,8 +2,8 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: gdscyber/concourse-chrome-driver
-    tag: 1.1
+    repository: vulnerablepeopleservice/chrome-driver
+    tag: latest
     username: ((docker_hub_username))
     password: ((docker_hub_password))
 params:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   chrome-driver:
-    image: gdscyber/concourse-chrome-driver:1.1
+    image: vulnerablepeopleservice/chrome-driver:latest
     volumes:
       - ./behave:/usr/src/app
     command: bash


### PR DESCRIPTION
```
$ docker run -t gdscyber/concourse-chrome-driver /bin/bash -c 'chromedriver --version'
ChromeDriver 70.0.3538.16 (16ed95b41bb05e565b11fb66ac33c660b721f778)
$ docker run -t vulnerablepeopleservice/chrome-driver /bin/bash -c 'chromedriver --version'
ChromeDriver 86.0.4240.22 (398b0743353ff36fb1b82468f63a3a93b4e2e89e-refs/branch-heads/4240@{#378}
```