### PR TITLE
Log the page source/browser status after failure

### DIFF
--- a/behave/features/steps/general.py
+++ b/behave/features/steps/general.py
@@ -32,12 +32,15 @@ def get_url_match(url_pattern):
 
 def log_page_response(func):
     def wrapper(context, *args, **kwargs):
-        logging.info(f"URL:         {context.browser.current_url}")
-        logging.info(f"Title:       {context.browser.title}")
-        logging.info(f"""Browser Log: {context.browser.get_log("browser")}""")
-        logging.info("Source:")
-        logging.info(context.browser.page_source)
-        func(context, *args, **kwargs)
+        try:
+            func(context, *args, **kwargs)
+        except Exception as exc:
+            logging.info(f"URL:         {context.browser.current_url}")
+            logging.info(f"Title:       {context.browser.title}")
+            logging.info(f"""Browser Log: {context.browser.get_log("browser")}""")
+            logging.info("Source:")
+            logging.info(context.browser.page_source)
+            raise exc
 
     return wrapper
 


### PR DESCRIPTION
Before we were logging the content before the test failure. Now we're
logging after. I'm hoping this will catch any error messages that may
have been returned as a result of flakey `input` interactions and
successful form submissions.