### PR TITLE
Stop sleeping when checking the page we're on

### DIFF
--- a/behave/features/steps/general.py
+++ b/behave/features/steps/general.py
@@ -112,14 +112,12 @@ def assert_element_content_matches(context, element_css_selector, expected_eleme
 
 @given('I am on the "{expected_page}" page')
 @log_page_response
-@sleep
 def assert_on_specified_page(context, expected_page):
     assert context.browser.current_url == f"{_BASE_URL}/{expected_page}"
 
 
 @given('I am on the "{expected_page}" nhs page')
 @log_page_response
-@sleep
 def assert_on_specified_nhs_page(context, expected_page):
     assert context.browser.current_url == f"{_NHS_BASE_URL}/{expected_page}"
 


### PR DESCRIPTION
In scenarios where we redirect quickly this fails. For example, the
scenario `Should be redirected to view-answers when waiting on the
authcode` will fail without this change.