### PR TITLE
Fix start page redirect url

### DIFF
--- a/behave/features/5.root_redirection.feature
+++ b/behave/features/5.root_redirection.feature
@@ -2,4 +2,4 @@
 Feature: COVID-19 Shielded vulnerable people service - gov.uk journey start page redirection
   Scenario: Should be redirected to gov.uk journey start page
       When I navigate to "/"
-      Then I am redirected to the external page with URL "https://coronavirus-shielding-support.service.gov.uk/closed.html"
+      Then I am redirected to the external page with URL "https://www.gov.uk/coronavirus-shielding-support"


### PR DESCRIPTION
We briefly had a page at coronovirus-shielding-support.service.gov.uk that gov.uk
redirected to from

https://www.gov.uk/coronavirus-shielding-support

With information about what to do when the service was closed. 

Now gov.uk have updated their pages to include that information so they no
longer have the redirect in place and navigating to /start goes back to
their page again.