### PR TITLE
Use google-chrome-stable instead of headless-chromium

### DIFF
--- a/behave/features/environment.py
+++ b/behave/features/environment.py
@@ -7,7 +7,7 @@ from selenium.webdriver.chrome.options import Options
 
 def before_all(context):
     chrome_options = Options()
-    chrome_options.binary = "bin/headless-chromium"
+    chrome_options.binary = "/usr/bin/google-chrome-stable"
     chrome_options.headless = True
 
     chrome_options.add_argument("--no-sandbox")  # Bypass OS security model


### PR DESCRIPTION
Our latest chromedriver does not have chromium installed so
use google-chrome-stable instead.

It may or may not help with smoke test stability too.