### PR TITLE
Adds basic nhs config to sample config

### DIFF
--- a/instance/config.py.sample.dev
+++ b/instance/config.py.sample.dev
@@ -15,11 +15,10 @@ POSTCODE_TIER_OVERRIDE = """{"TE22RR" : {"tier": 2, "shielding": 0},
 # NHS OIDC config
 NHS_OIDC_AUTHORITY_URL = "https://auth.sandpit.signin.nhs.uk"
 NHS_OIDC_CLIENT_ID = "temp"
-NHS_OIDC_REGISTRATION_CALLBACK_URL = "http://localhost:5000/nhs-registration-callback"
-NHS_OIDC_LOGIN_CALLBACK_URL = "http://localhost:5000/nhs-login-callback"
+NHS_OIDC_REGISTRATION_CALLBACK_URL = "http://webform:5000/nhs-registration-callback"
+NHS_OIDC_LOGIN_CALLBACK_URL = "http://webform:5000/nhs-login-callback"
 NHS_OIDC_LOGIN_PRIVATE_KEY_PATH = "instance/private_key.pem"
 NHS_OIDC_LOGIN_PRIVATE_KEY = ""
-
 
 # AWS CONFIG
 AWS_RDS_DATABASE_NAME = "coronavirus"


### PR DESCRIPTION
So that there is less to add to get things up and running.

This sample config is copied to config.py during the setup of the local development environment.