### PR TITLE
pipeline: fix slack alerts

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -464,30 +464,29 @@ jobs:
         passed: [e2e-test-staging]
       - get: trigger-at-6am
         trigger: true
-      - task: webform-entry
-        file: git-master/concourse/tasks/e2e-test-with-pipeline-validation-webform-entry.yml
-        attempts: 1
-        params:
-          CF_SPACE: "staging"
-          ENVIRONMENT: "staging"
-          WEB_APP_BASE_URL: "https://gds-shielded-vulnerable-people-service-staging.london.cloudapps.digital"
-          MESSAGE: "Checks that the application deployed to staging is not serving HTTP error codes"
-          POSTCODE_TIER_OVERRIDE: ((svp-form/postcode-tier-override))
-        on_failure: *slack_alert_on_failure
-        on_success: *slack_alert_on_fixed
-      - task: get-aws-credentials
-        file: git-master/concourse/tasks/get-gatling-tester-aws-creds.yml
-        params:
-          ACCOUNT_ID: 375282846305
-          ENVIRONMENT: staging
-          REGION: eu-west-2
-          DURATION: 21600
-      - task: s3-validation
-        file: git-master/concourse/tasks/e2e-test-with-pipeline-validation-s3-check.yml
-        params:
-          ENVIRONMENT: "staging"
-          REGION: "eu-west-2"
-          SALT: "1rjoBuOtDYaid83fYRJBFU5ouUi0nSueev2BhyoEhnw"
-          POSTCODE_TIER_OVERRIDE: ((svp-form/postcode-tier-override))
+      - do:
+        - task: webform-entry
+          file: git-master/concourse/tasks/e2e-test-with-pipeline-validation-webform-entry.yml
+          attempts: 1
+          params:
+            CF_SPACE: "staging"
+            ENVIRONMENT: "staging"
+            WEB_APP_BASE_URL: "https://gds-shielded-vulnerable-people-service-staging.london.cloudapps.digital"
+            MESSAGE: "Checks that the application deployed to staging is not serving HTTP error codes"
+            POSTCODE_TIER_OVERRIDE: ((svp-form/postcode-tier-override))
+        - task: get-aws-credentials
+          file: git-master/concourse/tasks/get-gatling-tester-aws-creds.yml
+          params:
+            ACCOUNT_ID: 375282846305
+            ENVIRONMENT: staging
+            REGION: eu-west-2
+            DURATION: 21600
+        - task: s3-validation
+          file: git-master/concourse/tasks/e2e-test-with-pipeline-validation-s3-check.yml
+          params:
+            ENVIRONMENT: "staging"
+            REGION: "eu-west-2"
+            SALT: "1rjoBuOtDYaid83fYRJBFU5ouUi0nSueev2BhyoEhnw"
+            POSTCODE_TIER_OVERRIDE: ((svp-form/postcode-tier-override))
         on_failure: *slack_alert_on_failure
         on_success: *slack_alert_on_fixed


### PR DESCRIPTION
Currently, when the pipeline fails, we often get *two* slack alerts,
one for "failed" and one for "fixed".  This is because we have
`on_failure` and `on_success` blocks on two different tasks in the
same job.  The `webform-entry` task succeeds, so it emits a "fixed"
notification, then the `s3-validation` task fails, so it emits a
"failed" notification.

The fix is to run all tasks in a single `do` step, and attach the
`on_failure` and `on_success` modifiers to the whole `do` sequence,
not to the individual tasks.