### PR TITLE
Run tests daily

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -37,16 +37,21 @@ resources:
       username: ((readonly_team_name))
       password: ((readonly_local_user_password))
 
-  - name: trigger-at-6pm-sunday
+  - name: every-2m
+    type: time
+    source:
+      interval: 2m
+
+  - name: trigger-at-1am
     type: cron-resource
     source:
-      expression: "0 18 * * 0"
+      expression: "0 1 * * *"
       location: "Local"
 
-  - name: trigger-at-9pm-sunday
+  - name: trigger-at-6am
     type: cron-resource
     source:
-      expression: "0 21 * * 0"
+      expression: "0 6 * * *"
       location: "Local"
 
 # Anchors for later
@@ -288,7 +293,7 @@ jobs:
 
   - name: continuous-smoke-test-staging
     plan:
-      - get:  trigger-at-6pm-sunday
+      - get: every-2m
         trigger: true
       - get: git-master
         passed: [e2e-test-staging]
@@ -309,7 +314,7 @@ jobs:
 
   - name: continuous-smoke-test-prod
     plan:
-      - get:  trigger-at-6pm-sunday
+      - get: every-2m
         trigger: true
       - get: git-master
         passed: [deploy-to-prod]
@@ -339,7 +344,7 @@ jobs:
     plan:
       - get: git-master
         passed: [e2e-test-staging]
-      - get: trigger-at-6pm-sunday
+      - get: trigger-at-1am
         trigger: true
       - task: gatling
         file: git-master/concourse/tasks/gatling-workflow-load-test.yml
@@ -405,7 +410,7 @@ jobs:
     plan:
       - get: git-master
         passed: [e2e-test-staging]
-      - get: trigger-at-6pm-sunday
+      - get: trigger-at-1am
         trigger: true
       - task: get-aws-credentials
         file: git-master/concourse/tasks/get-gatling-tester-aws-creds.yml
@@ -457,7 +462,7 @@ jobs:
     plan:
       - get: git-master
         passed: [e2e-test-staging]
-      - get: trigger-at-9pm-sunday
+      - get: trigger-at-6am
         trigger: true
       - do:
         - task: webform-entry

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -37,11 +37,6 @@ resources:
       username: ((readonly_team_name))
       password: ((readonly_local_user_password))
 
-  - name: every-2m
-    type: time
-    source:
-      interval: 2m
-
   - name: trigger-at-1am
     type: cron-resource
     source:
@@ -293,7 +288,7 @@ jobs:
 
   - name: continuous-smoke-test-staging
     plan:
-      - get: every-2m
+      - get: trigger-at-6am
         trigger: true
       - get: git-master
         passed: [e2e-test-staging]
@@ -314,7 +309,7 @@ jobs:
 
   - name: continuous-smoke-test-prod
     plan:
-      - get: every-2m
+      - get: trigger-at-6am
         trigger: true
       - get: git-master
         passed: [deploy-to-prod]


### PR DESCRIPTION
This reverts c7d3e0d (which moved lots of things to run weekly) and instead moves to run daily.

The driver is the e2e test with pipeline validation, which implicitly assumes that it runs at least daily, to spot changes that happened the previous day and have been through the pipeline.