### PR TITLE
unschedule 1am + 6am smoke, e2e & load tests in concourse

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -39,12 +39,14 @@ resources:
 
   - name: trigger-at-1am
     type: cron-resource
+    check_every: never # this line added for decommissioning, prevents this trigger from firing
     source:
       expression: "0 1 * * *"
       location: "Local"
 
   - name: trigger-at-6am
     type: cron-resource
+    check_every: never # this line added for decommissioning, prevents this trigger from firing
     source:
       expression: "0 6 * * *"
       location: "Local"


### PR DESCRIPTION
commit 32514ba1db023600a62f0c61cdf15cf6c79b4331 (HEAD -> feature/unschedule-tests, origin/feature/unschedule-tests)
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Wed Sep 22 11:27:36 2021 +0100

    unschedule 1am + 6am smoke, e2e & load tests in concourse

    Change 1am and 6am trigger resources to check_every=never in
    pipeline.yml.
    This will prevent live service tests (smoke, e2e and load) from
    scheduled runs against webform.
    This change needed to prepare web form for decommission and handover.