### PR TITLE
disable git monitoring in concourse ci pipeline

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -17,6 +17,7 @@ resource_types:
 resources:
   - name: git-master
     type: git
+    check_every: never # this line added for decommissioning, prevents this trigger from firing
     icon: github-circle
     source:
       uri: https://github.com/alphagov/govuk-shielded-vulnerable-people-service
@@ -24,6 +25,7 @@ resources:
 
   - name: git-sandbox
     type: git
+    check_every: never # this line added for decommissioning, prevents this trigger from firing
     icon: github-circle
     source:
       uri: https://github.com/alphagov/govuk-shielded-vulnerable-people-service


### PR DESCRIPTION
Change git resource checking for git-sandbox and git-master to
check_every=never. This change needed to prevent deployment of
new changes to paas, in preparation for decommissioning the web form.